### PR TITLE
🛡️ Sentinel: Fix Zip Slip vulnerability in behavior files

### DIFF
--- a/backend/src/api/behavior_export.py
+++ b/backend/src/api/behavior_export.py
@@ -140,7 +140,16 @@ async def export_behavior_pack(
         with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
             # Add behavior files
             for file in behavior_files:
-                zip_file.writestr(file.file_path, file.content)
+                # Sanitize file path to prevent Zip Slip
+                # Split by / or \, filter out '..', and rejoin with /
+                parts = file.file_path.replace("\\", "/").split("/")
+                safe_parts = [p for p in parts if p and p != ".."]
+                safe_path = "/".join(safe_parts)
+
+                if not safe_path:
+                    continue
+
+                zip_file.writestr(safe_path, file.content)
             
             # Add export metadata
             zip_file.writestr("export_metadata.json", json.dumps(export_data["metadata"], indent=2))

--- a/backend/src/db/crud.py
+++ b/backend/src/db/crud.py
@@ -622,6 +622,10 @@ async def create_behavior_file(
     except ValueError:
         raise ValueError("Invalid conversion_id format")
 
+    # Prevent path traversal attacks
+    if ".." in file_path or file_path.startswith("/") or file_path.startswith("\\"):
+        raise ValueError("Invalid file path: path traversal detected or absolute path used")
+
     behavior_file = models.BehaviorFile(
         conversion_id=conversion_uuid,
         file_path=file_path,

--- a/backend/src/tests/conftest.py
+++ b/backend/src/tests/conftest.py
@@ -55,8 +55,7 @@ def pytest_sessionstart(session):
 
             async def init_test_db():
                 from db.declarative_base import Base
-                # from db import models
-                # from db import models as db_models  # Ensure this imports models.py
+                from db import models
                 from sqlalchemy import text
                 async with test_engine.begin() as conn:
                     # Only add extensions for PostgreSQL
@@ -88,7 +87,9 @@ def project_root():
     project_root = backend_dir.parent    # project root
     return project_root
 
-@pytest.fixture(scope="function")
+import pytest_asyncio
+
+@pytest_asyncio.fixture(scope="function")
 async def db_session():
     """Create a database session for each test with transaction rollback."""
     async with test_engine.begin() as connection:

--- a/backend/src/tests/unit/test_behavior_files_crud.py
+++ b/backend/src/tests/unit/test_behavior_files_crud.py
@@ -3,44 +3,30 @@ import pytest_asyncio
 import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 from db import crud
-from db.base import AsyncSessionLocal
 
 
 @pytest_asyncio.fixture
-async def async_session():
-    """Create an async database session for testing."""
-    async with AsyncSessionLocal() as session:
-        yield session
-
-
-@pytest_asyncio.fixture
-async def sample_conversion_job(async_session: AsyncSession):
+async def sample_conversion_job(db_session: AsyncSession):
     """Create a sample conversion job for testing."""
     job = await crud.create_job(
-        async_session,
+        db_session,
         file_id=str(uuid.uuid4()),
         original_filename="test_mod.jar",
         target_version="1.20.0",
         options={}
     )
     yield job
-
-    # Cleanup - delete the job (cascade will handle behavior files)
-    try:
-        await async_session.delete(job)
-        await async_session.commit()
-    except Exception:
-        pass  # Job might already be deleted
+    # Cleanup handled by fixture rollback
 
 
 @pytest.mark.asyncio
 class TestBehaviorFilesCRUD:
     """Test behavior files CRUD operations."""
 
-    async def test_create_behavior_file(self, async_session: AsyncSession, sample_conversion_job):
+    async def test_create_behavior_file(self, db_session: AsyncSession, sample_conversion_job):
         """Test creating a behavior file."""
         behavior_file = await crud.create_behavior_file(
-            async_session,
+            db_session,
             conversion_id=str(sample_conversion_job.id),
             file_path="behaviors/entities/test_entity.json",
             file_type="entity_behavior",
@@ -55,11 +41,11 @@ class TestBehaviorFilesCRUD:
         assert behavior_file.created_at is not None
         assert behavior_file.updated_at is not None
 
-    async def test_get_behavior_file(self, async_session: AsyncSession, sample_conversion_job):
+    async def test_get_behavior_file(self, db_session: AsyncSession, sample_conversion_job):
         """Test retrieving a behavior file by ID."""
         # Create a behavior file
         created_file = await crud.create_behavior_file(
-            async_session,
+            db_session,
             conversion_id=str(sample_conversion_job.id),
             file_path="behaviors/blocks/test_block.json",
             file_type="block_behavior",
@@ -67,7 +53,7 @@ class TestBehaviorFilesCRUD:
         )
 
         # Retrieve it
-        retrieved_file = await crud.get_behavior_file(async_session, str(created_file.id))
+        retrieved_file = await crud.get_behavior_file(db_session, str(created_file.id))
 
         assert retrieved_file is not None
         assert retrieved_file.id == created_file.id
@@ -75,7 +61,7 @@ class TestBehaviorFilesCRUD:
         assert retrieved_file.file_type == "block_behavior"
         assert "test:block" in retrieved_file.content
 
-    async def test_get_behavior_files_by_conversion(self, async_session: AsyncSession, sample_conversion_job):
+    async def test_get_behavior_files_by_conversion(self, db_session: AsyncSession, sample_conversion_job):
         """Test retrieving all behavior files for a conversion."""
         # Create multiple behavior files
         files_data = [
@@ -99,7 +85,7 @@ class TestBehaviorFilesCRUD:
         created_files = []
         for file_data in files_data:
             behavior_file = await crud.create_behavior_file(
-                async_session,
+                db_session,
                 conversion_id=str(sample_conversion_job.id),
                 **file_data
             )
@@ -107,7 +93,7 @@ class TestBehaviorFilesCRUD:
 
         # Retrieve all files
         retrieved_files = await crud.get_behavior_files_by_conversion(
-            async_session, str(sample_conversion_job.id)
+            db_session, str(sample_conversion_job.id)
         )
 
         assert len(retrieved_files) == 3
@@ -122,11 +108,11 @@ class TestBehaviorFilesCRUD:
         assert file_types["behaviors/blocks/stone.json"] == "block_behavior"
         assert file_types["scripts/main.js"] == "script"
 
-    async def test_update_behavior_file_content(self, async_session: AsyncSession, sample_conversion_job):
+    async def test_update_behavior_file_content(self, db_session: AsyncSession, sample_conversion_job):
         """Test updating behavior file content."""
         # Create a behavior file
         behavior_file = await crud.create_behavior_file(
-            async_session,
+            db_session,
             conversion_id=str(sample_conversion_job.id),
             file_path="recipes/test_recipe.json",
             file_type="recipe",
@@ -138,7 +124,7 @@ class TestBehaviorFilesCRUD:
         # Update the content
         new_content = '{"minecraft:recipe_shaped": {"description": {"identifier": "test:recipe_new"}}}'
         updated_file = await crud.update_behavior_file_content(
-            async_session, str(behavior_file.id), new_content
+            db_session, str(behavior_file.id), new_content
         )
 
         assert updated_file is not None
@@ -146,7 +132,7 @@ class TestBehaviorFilesCRUD:
         assert "test:recipe_new" in updated_file.content
         assert updated_file.updated_at > original_updated_at
 
-    async def test_get_behavior_files_by_type(self, async_session: AsyncSession, sample_conversion_job):
+    async def test_get_behavior_files_by_type(self, db_session: AsyncSession, sample_conversion_job):
         """Test retrieving behavior files by type."""
         # Create files of different types
         entity_files = [
@@ -166,7 +152,7 @@ class TestBehaviorFilesCRUD:
 
         for file_path, file_type, identifier in all_files:
             await crud.create_behavior_file(
-                async_session,
+                db_session,
                 conversion_id=str(sample_conversion_job.id),
                 file_path=file_path,
                 file_type=file_type,
@@ -175,30 +161,30 @@ class TestBehaviorFilesCRUD:
 
         # Test getting entity behaviors
         entity_behaviors = await crud.get_behavior_files_by_type(
-            async_session, str(sample_conversion_job.id), "entity_behavior"
+            db_session, str(sample_conversion_job.id), "entity_behavior"
         )
         assert len(entity_behaviors) == 2
         assert all(f.file_type == "entity_behavior" for f in entity_behaviors)
 
         # Test getting block behaviors
         block_behaviors = await crud.get_behavior_files_by_type(
-            async_session, str(sample_conversion_job.id), "block_behavior"
+            db_session, str(sample_conversion_job.id), "block_behavior"
         )
         assert len(block_behaviors) == 1
         assert block_behaviors[0].file_type == "block_behavior"
 
         # Test getting scripts
         scripts = await crud.get_behavior_files_by_type(
-            async_session, str(sample_conversion_job.id), "script"
+            db_session, str(sample_conversion_job.id), "script"
         )
         assert len(scripts) == 1
         assert scripts[0].file_type == "script"
 
-    async def test_delete_behavior_file(self, async_session: AsyncSession, sample_conversion_job):
+    async def test_delete_behavior_file(self, db_session: AsyncSession, sample_conversion_job):
         """Test deleting a behavior file."""
         # Create a behavior file
         behavior_file = await crud.create_behavior_file(
-            async_session,
+            db_session,
             conversion_id=str(sample_conversion_job.id),
             file_path="temp/test_file.json",
             file_type="script",
@@ -208,43 +194,43 @@ class TestBehaviorFilesCRUD:
         file_id = str(behavior_file.id)
 
         # Verify it exists
-        retrieved_file = await crud.get_behavior_file(async_session, file_id)
+        retrieved_file = await crud.get_behavior_file(db_session, file_id)
         assert retrieved_file is not None
 
         # Delete it
-        success = await crud.delete_behavior_file(async_session, file_id)
+        success = await crud.delete_behavior_file(db_session, file_id)
         assert success is True
 
         # Verify it's gone
-        deleted_file = await crud.get_behavior_file(async_session, file_id)
+        deleted_file = await crud.get_behavior_file(db_session, file_id)
         assert deleted_file is None
 
-    async def test_invalid_conversion_id(self, async_session: AsyncSession):
+    async def test_invalid_conversion_id(self, db_session: AsyncSession):
         """Test behavior with invalid conversion ID."""
         invalid_id = str(uuid.uuid4())
 
         # This should not raise an error, but return empty list
-        files = await crud.get_behavior_files_by_conversion(async_session, invalid_id)
+        files = await crud.get_behavior_files_by_conversion(db_session, invalid_id)
         assert files == []
 
         # Creating with invalid conversion_id should raise an error due to foreign key constraint
         with pytest.raises(Exception):  # Could be IntegrityError or similar
             await crud.create_behavior_file(
-                async_session,
+                db_session,
                 conversion_id=invalid_id,
                 file_path="invalid/test.json",
                 file_type="test",
                 content="test"
             )
 
-    async def test_invalid_file_id_format(self, async_session: AsyncSession):
+    async def test_invalid_file_id_format(self, db_session: AsyncSession):
         """Test behavior with invalid file ID format."""
         # Test with non-UUID string
-        result = await crud.get_behavior_file(async_session, "not-a-uuid")
+        result = await crud.get_behavior_file(db_session, "not-a-uuid")
         assert result is None
 
-        result = await crud.update_behavior_file_content(async_session, "not-a-uuid", "content")
+        result = await crud.update_behavior_file_content(db_session, "not-a-uuid", "content")
         assert result is None
 
-        success = await crud.delete_behavior_file(async_session, "not-a-uuid")
+        success = await crud.delete_behavior_file(db_session, "not-a-uuid")
         assert success is False

--- a/backend/src/tests/unit/test_behavior_files_security.py
+++ b/backend/src/tests/unit/test_behavior_files_security.py
@@ -1,0 +1,110 @@
+import pytest
+import pytest_asyncio
+import uuid
+import zipfile
+import io
+import json
+from datetime import datetime
+from sqlalchemy.ext.asyncio import AsyncSession
+from db import crud
+from api.behavior_export import export_behavior_pack, ExportRequest
+
+@pytest_asyncio.fixture
+async def sample_conversion_job(db_session: AsyncSession):
+    """Create a sample conversion job for testing."""
+    job = await crud.create_job(
+        db_session,
+        file_id=str(uuid.uuid4()),
+        original_filename="test_mod.jar",
+        target_version="1.20.0",
+        options={}
+    )
+    yield job
+    # Cleanup is handled by transaction rollback in db_session fixture
+
+@pytest.mark.asyncio
+class TestBehaviorFilesSecurity:
+    """Test security aspects of behavior files."""
+
+    async def test_create_behavior_file_path_traversal(self, db_session: AsyncSession, sample_conversion_job):
+        """Test that creating a behavior file with path traversal fails."""
+        malicious_paths = [
+            "../evil.json",
+            "../../etc/passwd",
+            "folder/../evil.json",
+            "/absolute/path.json",
+            "\\absolute\\windows\\path.json"
+        ]
+
+        for path in malicious_paths:
+            with pytest.raises(ValueError, match="Invalid file path"):
+                await crud.create_behavior_file(
+                    db_session,
+                    conversion_id=str(sample_conversion_job.id),
+                    file_path=path,
+                    file_type="script",
+                    content="{}"
+                )
+
+    async def test_create_behavior_file_valid_paths(self, db_session: AsyncSession, sample_conversion_job):
+        """Test that creating a behavior file with valid paths succeeds."""
+        valid_paths = [
+            "valid.json",
+            "folder/valid.json",
+            "folder/subfolder/valid.json",
+            "file-with-dashes.json",
+            "file_with_underscores.json"
+        ]
+
+        for path in valid_paths:
+            file = await crud.create_behavior_file(
+                db_session,
+                conversion_id=str(sample_conversion_job.id),
+                file_path=path,
+                file_type="script",
+                content="{}"
+            )
+            assert file.file_path == path
+
+    async def test_export_zip_sanitization(self, db_session: AsyncSession, sample_conversion_job, mocker):
+        """Test that zip export sanitizes paths."""
+
+        # Mock behavior file object
+        MockBehaviorFile = type('BehaviorFile', (), {})
+        malicious_file = MockBehaviorFile()
+        malicious_file.file_path = "../../evil.sh"
+        malicious_file.content = "echo pwned"
+        malicious_file.file_type = "script"
+        malicious_file.created_at = datetime.now()
+        malicious_file.updated_at = datetime.now()
+
+        # Mock dependencies using AsyncMock because these functions are awaited
+        from unittest.mock import AsyncMock
+
+        mocker.patch('db.crud.get_behavior_files_by_conversion', side_effect=AsyncMock(return_value=[malicious_file]))
+        mocker.patch('db.crud.get_job', side_effect=AsyncMock(return_value=sample_conversion_job))
+        mocker.patch('db.crud.get_addon_details', side_effect=AsyncMock(return_value=None), create=True)
+
+        # Mock CacheService.set_export_data
+        mock_set = mocker.patch('services.cache.CacheService.set_export_data', side_effect=AsyncMock(return_value=True))
+
+        # Execute export
+        request = ExportRequest(
+            conversion_id=str(sample_conversion_job.id),
+            export_format="zip",
+            include_templates=False
+        )
+
+        await export_behavior_pack(request, db_session)
+
+        # Verify zip content passed to cache
+        assert mock_set.called
+        zip_content = mock_set.call_args[0][1]
+
+        # Verify zip content
+        with zipfile.ZipFile(io.BytesIO(zip_content), 'r') as zf:
+            names = zf.namelist()
+            # The path "../../evil.sh" should be sanitized to "evil.sh"
+            assert "evil.sh" in names
+            assert "../../evil.sh" not in names
+            print(f"Sanitized paths in zip: {names}")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Zip Slip / Path Traversal
The `create_behavior_file` endpoint allowed path traversal characters (`..`) in `file_path`.
The `export_behavior_pack` endpoint used `file_path` directly when creating ZIP archives, allowing malicious files to be written outside the extraction directory.

🎯 Impact:
A malicious user could upload a behavior file with a path like `../../evil.sh`. When an admin or another user exports and extracts the behavior pack, the file would be written outside the intended directory, potentially leading to RCE or system compromise.

🔧 Fix:
1.  **Input Validation**: Updated `backend/src/db/crud.py` to reject file paths containing `..` or starting with `/` in `create_behavior_file`.
2.  **Output Sanitization**: Updated `backend/src/api/behavior_export.py` to sanitize paths before writing to ZIP files (Defense in Depth).
3.  **Test Infrastructure**: Fixed `backend/src/tests/conftest.py` to properly initialize test database tables.

✅ Verification:
Added `backend/src/tests/unit/test_behavior_files_security.py` which:
- Verifies `create_behavior_file` raises `ValueError` for malicious paths.
- Verifies `export_behavior_pack` sanitizes paths in ZIP output.
- All tests passed.

---
*PR created automatically by Jules for task [17133426742091449968](https://jules.google.com/task/17133426742091449968) started by @anchapin*