### PR TITLE
⚡ Bolt: Optimize JavaAnalyzerAgent parsing efficiency

### DIFF
--- a/ai-engine/tests/test_java_analyzer_ast.py
+++ b/ai-engine/tests/test_java_analyzer_ast.py
@@ -209,7 +209,8 @@ public class TestBlock {
         with zipfile.ZipFile(jar_with_java_sources, 'r') as jar:
             java_sources = ['src/main/java/com/example/testmod/block/TestBlock.java', 
                            'src/main/java/com/example/testmod/item/TestItem.java']
-            features = analyzer._analyze_features_from_sources(jar, java_sources)
+            batch_result = analyzer._analyze_sources_batch(jar, java_sources)
+            features = batch_result['features']
             
             assert len(features["blocks"]) > 0
             assert len(features["items"]) > 0


### PR DESCRIPTION
💡 What: Optimized `JavaAnalyzerAgent` in `ai-engine` to read and parse Java source files only once per analysis session, instead of multiple times for different extraction tasks. Added a keyword heuristic to skip parsing irrelevant files.

🎯 Why: The previous implementation iterated over the same files multiple times (for features, dependencies, and metadata), invoking `javalang.parse` each time. `javalang` parsing is CPU-intensive and slow for large files. This redundant work significantly slowed down the analysis phase.

📊 Impact: Reduces File I/O and CPU usage during JAR analysis. For the first 10 files (the limit), it reduces parsing calls by up to 66%. Keyword pre-check further avoids parsing for files without relevant content.

🔬 Measurement: `pytest ai-engine/tests/test_java_analyzer_ast.py` verifies the correctness of the new `_analyze_sources_batch` method. The logic guarantees single-pass execution.

---
*PR created automatically by Jules for task [13290977473657641891](https://jules.google.com/task/13290977473657641891) started by @anchapin*