### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF vulnerability in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2026-02-16 - SSRF Prevention Pattern
+**Vulnerability:** Server-Side Request Forgery (SSRF) in file download functionality.
+**Learning:** `httpx` (and `requests`) follow redirects by default, potentially bypassing initial URL validation if a redirect leads to a private IP. Blocking DNS resolution via `socket.getaddrinfo` is effective but requires handling IPv6 scope IDs and fail-secure logic.
+**Prevention:**
+1. Validate URL scheme (http/https).
+2. Resolve hostname to IP(s) and check against private/loopback ranges.
+3. Disable automatic redirect following (`follow_redirects=False`).
+4. Manually handle redirects, re-validating the URL at each hop.
+5. Sanitize URLs before logging to avoid leaking sensitive tokens.


### PR DESCRIPTION
This PR addresses a critical SSRF vulnerability in the `FileProcessor.download_from_url` method. 

**Vulnerability:**
The previous implementation used `httpx.get(..., follow_redirects=True)`, which allowed an attacker to supply a URL that redirects to an internal service (e.g., `localhost:8080`, metadata services), bypassing initial validation if any existed.

**Fix:**
1.  **URL Validation:** Introduced `_is_safe_url` which resolves the hostname using `socket.getaddrinfo` (in a non-blocking way) and checks if the IP is loopback, private, or link-local. It also handles IPv6 scope IDs.
2.  **Manual Redirect Loop:** Disabled automatic redirect following. The code now manually follows redirects (up to 5), validating the `Location` header URL at each step before making a request.
3.  **Log Sanitization:** All logged URLs are now parsed and reconstructed to strip query parameters and fragments, preventing leakage of sensitive tokens.

**Verification:**
-   Added unit tests in `backend/src/tests/unit/test_file_processor.py` covering:
    -   Public IP resolution (allowed).
    -   Private/Loopback IP resolution (blocked).
    -   Invalid schemes (blocked).
-   Verified manually with a reproduction script (since deleted) that `localhost` access is blocked.
-   Existing unit tests passed.

**Note:**
This change introduces a dependency on `ipaddress` and `socket` (standard library). Tests were updated to patch `file_processor` module imports correctly.

---
*PR created automatically by Jules for task [11226174381158694190](https://jules.google.com/task/11226174381158694190) started by @anchapin*