### PR TITLE
🎨 Palette: Enhance dropzone accessibility and fix button-in-label issue

### DIFF
--- a/frontend/src/components/ConversionUpload/ConversionUpload.css
+++ b/frontend/src/components/ConversionUpload/ConversionUpload.css
@@ -73,6 +73,13 @@
   background-color: #e9ecef;
 }
 
+.dropzone:focus-visible {
+  outline: none;
+  border-color: #2563eb;
+  background-color: #f8fafc;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.3);
+}
+
 /* Upload prompt styles */
 .upload-prompt {
   text-align: center;
@@ -263,6 +270,11 @@
 
 .conversion-options .option-group:last-child {
   margin-bottom: 0;
+}
+
+.checkbox-with-info {
+  display: flex;
+  align-items: center;
 }
 
 .checkbox-label {

--- a/frontend/src/components/ConversionUpload/ConversionUploadEnhanced.tsx
+++ b/frontend/src/components/ConversionUpload/ConversionUploadEnhanced.tsx
@@ -513,15 +513,17 @@ export const ConversionUploadEnhanced: React.FC<ConversionUploadProps> = ({
         {!isFinished && (
           <div className={`conversion-options ${isProcessing || isCompleted ? 'disabled-options' : ''}`}>
             <div className="option-group">
-              <label className="checkbox-label">
-                <input
-                  type="checkbox"
-                  checked={smartAssumptions}
-                  onChange={(e) => setSmartAssumptions(e.target.checked)}
-                  disabled={isProcessing || isCompleted}
-                />
-                <span className="checkmark"></span>
-                Enable Smart Assumptions
+              <div className="checkbox-with-info">
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={smartAssumptions}
+                    onChange={(e) => setSmartAssumptions(e.target.checked)}
+                    disabled={isProcessing || isCompleted}
+                  />
+                  <span className="checkmark"></span>
+                  Enable Smart Assumptions
+                </label>
                 <button
                   type="button"
                   className="info-button"
@@ -531,7 +533,7 @@ export const ConversionUploadEnhanced: React.FC<ConversionUploadProps> = ({
                 >
                   ?
                 </button>
-              </label>
+              </div>
 
               {showSmartAssumptionsInfo && (
                 <div className="info-panel">


### PR DESCRIPTION
This PR addresses two accessibility and usability issues in the conversion upload component:

1.  **Dropzone Focus Indicator**: The file dropzone lacked a visible focus state when navigated via keyboard. I added a `:focus-visible` style with a blue border and shadow ring to clearly indicate focus.
2.  **Button-in-Label Fix**: The "Smart Assumptions" info button was nested inside the checkbox label. Clicking the button would trigger the label and toggle the checkbox, which is confusing behavior. I moved the button outside the label and wrapped them in a flex container to maintain the visual layout while fixing the interaction.

These changes improve the experience for keyboard users and prevent unintended interactions.


---
*PR created automatically by Jules for task [690985339977875208](https://jules.google.com/task/690985339977875208) started by @anchapin*