### PR TITLE
feat(ai-engine): Add robots.txt compliance to BedrockDocsScraper

### DIFF
--- a/ai-engine/requirements.txt
+++ b/ai-engine/requirements.txt
@@ -32,6 +32,7 @@ httpx==0.28.1
 beautifulsoup4>=4.12.0 # For web scraping (BedrockDocsScraper)
 aiofiles>=23.0.0     # For async file operations (potentially in scraper or other utils)
 validators>=0.22.0   # For URL validation (BedrockDocsScraper)
+robotexclusionparser>=1.7  # For robots.txt compliance (BedrockDocsScraper)
 
 # Web Search
 ddgs>=5.3.0              # For actual web search functionality (replaces duckduckgo-search)


### PR DESCRIPTION
## Summary

Implements robots.txt compliance checking for the Bedrock documentation scraper, addressing Issue #245.

## Changes

- Added `robotexclusionparser` library for parsing robots.txt files
- Implemented `_check_robots_txt()` method to verify URLs are allowed before fetching
- Implemented `_fetch_robots_txt()` method to fetch and parse robots.txt for each domain
- Implemented `_apply_crawl_delay()` method to respect crawl-delay directives
- Added `respect_robots_txt` parameter to toggle compliance (default: True)
- Added `robots_blocked_requests` to statistics tracking
- Updated User-Agent string to v2.1.0

## Features

1. **Robots.txt Compliance**: Before fetching any URL, the scraper now checks if the URL is allowed by the site's robots.txt rules
2. **Crawl-Delay Support**: Automatically extracts and respects crawl-delay directives from robots.txt
3. **Per-Domain Rate Limiting**: Uses crawl-delay to pace requests per domain
4. **Graceful Fallback**: If robots.txt parsing fails, defaults to allowing the request
5. **Statistics Tracking**: Tracks blocked requests in scraping statistics

## Testing

The scraper can be tested with:
```python
scraper = BedrockDocsScraper(rate_limit_seconds=0.5, respect_robots_txt=True)
documents = await scraper.scrape_documentation()
```

## Related Issues

- Closes #245: Implement comprehensive Bedrock documentation scraper