### PR TITLE
feat(frontend): Add behavior object creation button in Properties Panel

### DIFF
--- a/frontend/src/components/Editor/PropertiesPanel/PropertiesPanel.css
+++ b/frontend/src/components/Editor/PropertiesPanel/PropertiesPanel.css
@@ -143,3 +143,27 @@
   padding: 6px 0;
   border-bottom: 1px solid #e0e0e0;
 }
+
+/* Button to create behavior object */
+.create-behavior-button {
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: bold;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.create-behavior-button:hover {
+  background-color: #45a049;
+}
+
+.create-behavior-button:active {
+  background-color: #3d8b40;
+}

--- a/frontend/src/components/Editor/PropertiesPanel/PropertiesPanel.tsx
+++ b/frontend/src/components/Editor/PropertiesPanel/PropertiesPanel.tsx
@@ -42,6 +42,19 @@ export const PropertiesPanel: React.FC = () => {
     }
   };
 
+  const handleCreateBehavior = () => {
+    if (selectedBlockId && selectedBlock) {
+      // Create a default behavior object
+      const defaultBehavior = {
+        id: `${selectedBlock.identifier}_behavior`,
+        description: `Behavior for ${selectedBlock.identifier}`
+      };
+      
+      // Use updateBlockProperty to set the behavior
+      updateBlockProperty(selectedBlockId, "behavior", defaultBehavior);
+    }
+  };
+
   const handleJsonChange = (
     e: React.ChangeEvent<HTMLTextAreaElement>,
     setter: React.Dispatch<React.SetStateAction<string>>
@@ -157,10 +170,13 @@ export const PropertiesPanel: React.FC = () => {
           ) : (
              <div className="property-item">
                 <span className="property-label">Behavior:</span>
-                <span className="property-value">
-                  No behavior defined.
-                  {/* TODO: Add button to create behavior object */}
-                </span>
+                <button 
+                  className="create-behavior-button"
+                  onClick={handleCreateBehavior}
+                  title="Create behavior object"
+                >
+                  + Create Behavior
+                </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

Adds a behavior object creation button to the Properties Panel in the editor, addressing Issue #243.

## Changes

- Added `handleCreateBehavior` function to create a default behavior object with `id` and `description` properties
- Added '+ Create Behavior' button that appears when no behavior is defined for a block
- Added CSS styling for the create behavior button with hover and active states
- Uses the existing `updateBlockProperty` function to set the behavior

## Testing

1. Select a block in the editor that has no behavior defined
2. In the Properties Panel, look for the "No behavior defined" section
3. Click the "+ Create Behavior" button
4. Verify a default behavior object is created with an ID based on the block identifier

## Related Issues

- Closes #243: Add behavior object creation button in Properties Panel