### PR TITLE
feat(frontend): Add Settings page for user preferences (Issue #378)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ const BehavioralTestWrapper = lazy(() => import('./components/BehavioralTest/Beh
 const EditorPage = lazy(() => import('./pages/EditorPage'));
 const ExperimentsPage = lazy(() => import('./pages/ExperimentsPage'));
 const ExperimentResultsPage = lazy(() => import('./pages/ExperimentResultsPage'));
+const Settings = lazy(() => import('./pages/Settings'));
 
 function App() {
   console.log('App component is rendering...');
@@ -80,6 +81,11 @@ function App() {
                     <EditorPage />
                   </Suspense>
                 } /> {/* Added Behavior Editor Route */}
+                <Route path="/settings" element={
+                  <Suspense fallback={<div>Loading Settings...</div>}>
+                    <Settings />
+                  </Suspense>
+                } />
               </Routes>
             </main>
           </div>

--- a/frontend/src/components/TopNavigation/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation/TopNavigation.tsx
@@ -18,11 +18,13 @@ export const TopNavigation: React.FC<TopNavigationProps> = ({ className = '' }) 
 
   const navigationLinks = [
     { to: '/', label: 'Convert' },
+    { to: '/dashboard', label: 'Dashboard' },
     { to: '/comparison', label: 'Comparison' },
     { to: '/behavioral-test', label: 'Behavioral Test' },
     { to: '/experiments', label: 'Experiments' },
     { to: '/experiment-results', label: 'Results' },
-    { to: '/docs', label: 'Documentation' }
+    { to: '/docs', label: 'Documentation' },
+    { to: '/settings', label: '⚙️' }
   ];
 
   return (

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -1,0 +1,120 @@
+/**
+ * Settings Page Styles
+ */
+
+.settings-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.settings-header {
+  margin-bottom: 2rem;
+}
+
+.settings-header h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.settings-header p {
+  color: #666;
+}
+
+.settings-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.settings-section {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.settings-section h2 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  color: #333;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
+}
+
+.form-group {
+  margin-bottom: 1.25rem;
+}
+
+.form-group:last-child {
+  margin-bottom: 0;
+}
+
+.form-group label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+.form-group input[type="text"],
+.form-group input[type="password"],
+.form-group input[type="number"],
+.form-group select {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  outline: none;
+  border-color: #007bff;
+}
+
+.form-group .help-text {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  color: #666;
+}
+
+.checkbox-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.checkbox-group input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+}
+
+.settings-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.save-button {
+  background: #007bff;
+  color: white;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.save-button:hover {
+  background: #0056b3;
+}
+
+.save-button:active {
+  background: #004494;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,129 @@
+/**
+ * Settings Page
+ * Configuration and user preferences
+ */
+
+import React, { useState } from 'react';
+import './Settings.css';
+
+interface SettingsState {
+  apiKey: string;
+  defaultTargetVersion: string;
+  autoDeleteAfterDays: number;
+  enableNotifications: boolean;
+  maxConcurrentConversions: number;
+}
+
+export const Settings: React.FC = () => {
+  const [settings, setSettings] = useState<SettingsState>({
+    apiKey: '',
+    defaultTargetVersion: '1.20.0',
+    autoDeleteAfterDays: 30,
+    enableNotifications: true,
+    maxConcurrentConversions: 3
+  });
+  
+  const [saved, setSaved] = useState(false);
+
+  const handleSave = () => {
+    // Save to localStorage for demo purposes
+    localStorage.setItem('modporter_settings', JSON.stringify(settings));
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  const handleChange = (key: keyof SettingsState, value: string | number | boolean) => {
+    setSettings(prev => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <div className="settings-page">
+      <div className="settings-header">
+        <h1>⚙️ Settings</h1>
+        <p>Configure your ModPorter AI preferences</p>
+      </div>
+
+      <div className="settings-content">
+        <div className="settings-section">
+          <h2>API Configuration</h2>
+          <div className="form-group">
+            <label htmlFor="apiKey">API Key</label>
+            <input
+              type="password"
+              id="apiKey"
+              value={settings.apiKey}
+              onChange={(e) => handleChange('apiKey', e.target.value)}
+              placeholder="Enter your API key"
+            />
+            <span className="help-text">Required for AI-powered conversions</span>
+          </div>
+          
+          <div className="form-group">
+            <label htmlFor="targetVersion">Default Target Version</label>
+            <select
+              id="targetVersion"
+              value={settings.defaultTargetVersion}
+              onChange={(e) => handleChange('defaultTargetVersion', e.target.value)}
+            >
+              <option value="1.20.0">1.20.0 (Wild Update)</option>
+              <option value="1.19.0">1.19.0 (The Wild Update)</option>
+              <option value="1.18.0">1.18.0 (Caves & Cliffs II)</option>
+              <option value="1.17.0">1.17.0 (Caves & Cliffs I)</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="settings-section">
+          <h2>Conversion Settings</h2>
+          <div className="form-group">
+            <label htmlFor="maxConcurrent">Max Concurrent Conversions</label>
+            <input
+              type="number"
+              id="maxConcurrent"
+              min={1}
+              max={10}
+              value={settings.maxConcurrentConversions}
+              onChange={(e) => handleChange('maxConcurrentConversions', parseInt(e.target.value))}
+            />
+            <span className="help-text">Number of conversions to run in parallel (1-10)</span>
+          </div>
+          
+          <div className="form-group">
+            <label htmlFor="autoDelete">Auto-delete old conversions after (days)</label>
+            <input
+              type="number"
+              id="autoDelete"
+              min={1}
+              max={365}
+              value={settings.autoDeleteAfterDays}
+              onChange={(e) => handleChange('autoDeleteAfterDays', parseInt(e.target.value))}
+            />
+          </div>
+        </div>
+
+        <div className="settings-section">
+          <h2>Notifications</h2>
+          <div className="form-group checkbox-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={settings.enableNotifications}
+                onChange={(e) => handleChange('enableNotifications', e.target.checked)}
+              />
+              Enable email notifications
+            </label>
+            <span className="help-text">Get notified when conversions complete or fail</span>
+          </div>
+        </div>
+
+        <div className="settings-actions">
+          <button className="save-button" onClick={handleSave}>
+            {saved ? '✓ Saved!' : 'Save Settings'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
This PR adds a Settings page to the ModPorter AI frontend as part of the Phase 3 Production Readiness work.

## Changes
- Added new Settings page (`frontend/src/pages/Settings.tsx`) with:
  - API configuration (API key, default target version)
  - Conversion settings (max concurrent conversions, auto-delete old conversions)
  - Notification preferences
- Added Settings link to the navigation bar
- Added `/settings` route to App.tsx

## Related Issues
- Part of Issue #378: Complete conversion workflow UI (Phase 3)
- Related to Issue #334: 📋 ROADMAP: Phase 3 - Production Readiness

## Testing
- [ ] Navigate to /settings and verify the page loads
- [ ] Test saving settings (saved to localStorage)
- [ ] Verify navigation link works