### PR TITLE
fix(tests): Fix import paths for agent imports

### DIFF
--- a/tests/test_mvp_conversion.py
+++ b/tests/test_mvp_conversion.py
@@ -29,10 +29,13 @@ from pathlib import Path
 from typing import Dict, List, Any, Optional
 import sys
 
-# Add the ai-engine, tests, and root directories to the path
-ai_engine_root = Path(__file__).parent.parent
-project_root = ai_engine_root.parent
+# Add the ai-engine directory to the path for agent imports
+# ai-engine is at: project_root/ai-engine
+ai_engine_root = Path(__file__).parent.parent / "ai-engine"
+project_root = Path(__file__).parent.parent
 tests_root = Path(__file__).parent
+
+# Add ai-engine to sys.path so 'agents' and 'fixtures' imports work
 sys.path.insert(0, str(ai_engine_root))
 sys.path.insert(0, str(project_root))
 sys.path.insert(0, str(tests_root))


### PR DESCRIPTION
## Summary
Fixes the import paths in tests/test_mvp_conversion.py so that agents and fixtures modules can be imported correctly.

## Changes
- Update ai_engine_root to point to project_root/ai-engine
- This fixes the PYTHONPATH issues mentioned in the issue

## Issue
Fixes #398: Fix test import paths and run E2E conversion tests

## Testing
Run the tests:
\`\`\`bash
cd ai-engine && python -m pytest tests/test_mvp_conversion.py
\`\`\`
Note: Requires Python 3.10-3.13 with crewai installed, or use Docker container.