### PR TITLE
Fix template metadata loading and add entity/item template tests

### DIFF
--- a/ai-engine/templates/bedrock/items/tool.meta.json
+++ b/ai-engine/templates/bedrock/items/tool.meta.json
@@ -4,8 +4,7 @@
   "description": "Tool template with durability, mining speeds, and enchantability",
   "required_parameters": [
     "namespace",
-    "item_name",
-    "texture_name"
+    "item_name"
   ],
   "optional_parameters": [
     "display_name",

--- a/ai-engine/templates/template_engine.py
+++ b/ai-engine/templates/template_engine.py
@@ -395,6 +395,11 @@ class TemplateEngine:
             category_dir = self.templates_dir / category.value
             if category_dir.exists():
                 for template_file in category_dir.glob('*.json'):
+                    # Skip .meta.json and variant files (basic_block_bp.json, basic_block_rp.json)
+                    if template_file.name.endswith('.meta.json'):
+                        continue
+                    if '_bp.json' in template_file.name or '_rp.json' in template_file.name:
+                        continue
                     template_type = self._map_filename_to_type(template_file.name)
                     if template_type:
                         self.template_cache[template_type] = JinjaTemplate(


### PR DESCRIPTION
## Summary

This PR fixes the template engine's metadata loading bug and adds comprehensive unit tests for entity and item templates, addressing issues #404 and #405.

## Changes

### Bug Fixes
- Fixed template engine to skip `.meta.json` and variant files (`_bp.json`, `_rp.json`) during template discovery - these were causing "Unknown template file" warnings
- Fixed tool template metadata to not require `texture_name` as a required parameter (it has a default value in the template)

### New Tests
- Added 9 new unit tests for entity and item templates:
  - `test_entity_template_selection` - Tests selection logic for hostile, passive, NPC, and projectile entities
  - `test_hostile_mob_template_rendering` - Tests hostile mob template rendering
  - `test_passive_mob_template_rendering` - Tests passive mob template rendering  
  - `test_tool_template_rendering` - Tests tool item template rendering
  - `test_armor_template_rendering` - Tests armor item template rendering
  - `test_consumable_template_rendering` - Tests consumable item template rendering
  - `test_tool_metadata_loaded` - Tests tool template metadata and defaults
  - `test_entity_metadata_loaded` - Tests entity template metadata loading

## Test Results
All 17 tests pass (previously 8 tests).

## Related Issues
- #404: Expand template library: Add entity and item templates
- #405: Implement QA validation framework for output verification