### PR TITLE
fix: Resolve RAG integration test failures (#418)

### DIFF
--- a/ai-engine/agents/__init__.py
+++ b/ai-engine/agents/__init__.py
@@ -1,32 +1,76 @@
 # ai-engine/agents/__init__.py
-from .asset_converter import AssetConverterAgent as AssetConverter
-from .bedrock_architect import BedrockArchitectAgent as BedrockArchitect
-from .java_analyzer import JavaAnalyzerAgent as JavaAnalyzer
-from .logic_translator import LogicTranslatorAgent as LogicTranslator
-from .packaging_agent import PackagingAgent
-from .qa_validator import QAValidatorAgent as QAValidator
-from .validation_agent import (
-    ValidationAgent, 
-    LLMSemanticAnalyzer, 
-    BehaviorAnalysisEngine, 
-    AssetIntegrityChecker, 
-    ManifestValidator
-)
-from .knowledge_base_agent import KnowledgeBaseAgent
-from .rag_agents import RAGAgents
 
-__all__ = [
-    "AssetConverter",
-    "BedrockArchitect",
-    "JavaAnalyzer",
-    "LogicTranslator",
-    "PackagingAgent",
-    "QAValidator",
-    "ValidationAgent",
-    "LLMSemanticAnalyzer",
-    "BehaviorAnalysisEngine",
-    "AssetIntegrityChecker",
-    "ManifestValidator",
-    "KnowledgeBaseAgent",
-    "RAGAgents"
-]
+# Import RAG components first (no crewai dependency)
+try:
+    from .rag_agents import RAGAgents
+    __all__ = ["RAGAgents"]
+except ImportError as e:
+    RAGAgents = None
+    __all__ = []
+
+# Import knowledge base (no crewai dependency)
+try:
+    from .knowledge_base_agent import KnowledgeBaseAgent
+    __all__.append("KnowledgeBaseAgent")
+except ImportError:
+    KnowledgeBaseAgent = None
+
+# Try to import crewai-dependent agents
+try:
+    from .asset_converter import AssetConverterAgent as AssetConverter
+    __all__.append("AssetConverter")
+except ImportError as e:
+    AssetConverter = None
+    print(f"Warning: Could not import AssetConverterAgent: {e}")
+
+try:
+    from .bedrock_architect import BedrockArchitectAgent as BedrockArchitect
+    __all__.append("BedrockArchitect")
+except ImportError:
+    BedrockArchitect = None
+
+try:
+    from .java_analyzer import JavaAnalyzerAgent as JavaAnalyzer
+    __all__.append("JavaAnalyzer")
+except ImportError:
+    JavaAnalyzer = None
+
+try:
+    from .logic_translator import LogicTranslatorAgent as LogicTranslator
+    __all__.append("LogicTranslator")
+except ImportError:
+    LogicTranslator = None
+
+try:
+    from .packaging_agent import PackagingAgent
+    __all__.append("PackagingAgent")
+except ImportError:
+    PackagingAgent = None
+
+try:
+    from .qa_validator import QAValidatorAgent as QAValidator
+    __all__.append("QAValidator")
+except ImportError:
+    QAValidator = None
+
+try:
+    from .validation_agent import (
+        ValidationAgent, 
+        LLMSemanticAnalyzer, 
+        BehaviorAnalysisEngine, 
+        AssetIntegrityChecker, 
+        ManifestValidator
+    )
+    __all__.extend([
+        "ValidationAgent",
+        "LLMSemanticAnalyzer",
+        "BehaviorAnalysisEngine",
+        "AssetIntegrityChecker",
+        "ManifestValidator"
+    ])
+except ImportError:
+    ValidationAgent = None
+    LLMSemanticAnalyzer = None
+    BehaviorAnalysisEngine = None
+    AssetIntegrityChecker = None
+    ManifestValidator = None


### PR DESCRIPTION
## Summary
Fixes RAG integration tests that were failing due to async/sync mismatches in the embedding generation pipeline.

## Changes Made
1. **Fixed async/sync mismatch in MultiModalEmbeddingGenerator**: The generator was incorrectly using `await` on sync `generate_embeddings` method
2. **Fixed EmbeddingResult type handling**: Properly unwraps EmbeddingResult from LocalEmbeddingGenerator 
3. **Updated agents/__init__.py**: Added graceful error handling for crewai import failures

## Root Cause
The RAG tests were failing because:
- `MultiModalEmbeddingGenerator._generate_text_embedding` was calling `await self.text_generator.generate_embeddings()` but the underlying `LocalEmbeddingGenerator.generate_embeddings` is synchronous
- The EmbeddingResult from LocalEmbeddingGenerator wasn't being unwrapped properly before creating the new EmbeddingResult
- Missing crewai was causing import errors that blocked all agent imports

## Testing
- All 4 previously failing RAG integration tests now pass:
  - test_hybrid_search_functionality ✓
  - test_multimodal_query_processing ✓  
  - test_contextual_querying ✓
  - test_full_advanced_rag_workflow ✓

## Related Issues
- Closes #418