### PR TITLE
Fix E2E test imports - Issue #434

### DIFF
--- a/tests/test_mvp_conversion.py
+++ b/tests/test_mvp_conversion.py
@@ -89,7 +89,7 @@ from agents.bedrock_builder import BedrockBuilderAgent
 from agents.packaging_agent import PackagingAgent
 
 # Import test fixtures from ai-engine fixtures
-from fixtures.test_jar_generator import JarGenerator, create_test_mod_suite
+from fixtures.test_jar_generator import TestJarGenerator as JarGenerator, create_test_mod_suite
 
 
 class TestMVPEndToEndConversion:


### PR DESCRIPTION
## Summary
Fixed import error in test_mvp_conversion.py that was preventing E2E tests from running.

## Changes
- Changed import from `from fixtures.test_jar_generator import JarGenerator` 
- To: `from fixtures.test_jar_generator import TestJarGenerator as JarGenerator`

The test file was importing a class that doesn't exist - it was renamed to TestJarGenerator.

## Testing
All 11 E2E integration tests now pass:
- test_simple_block_conversion ✓
- test_missing_texture_fallback ✓
- test_malformed_jar_error_handling ✓
- test_multiple_block_types ✓
- test_converted_addon_loads_in_bedrock ✓
- test_performance_benchmarks ✓
- test_conversion_pipeline_coverage ✓
- test_nonexistent_file ✓
- test_corrupted_zip_file ✓
- test_jar_with_no_metadata ✓
- test_special_characters_in_registry_name ✓

## Related
- Issue #434: [P1] Implement E2E Integration Tests for MVP Block Conversion