### PR TITLE
feat(frontend): Frontend-Backend API Integration (#446)

### DIFF
--- a/frontend/src/components/ConversionReport/ConversionReportContainer.tsx
+++ b/frontend/src/components/ConversionReport/ConversionReportContainer.tsx
@@ -32,9 +32,14 @@ export const ConversionReportContainer: React.FC<ConversionReportContainerProps>
       setLoading(true);
       setError(null);
 
-      // Fetch the conversion report from the backend
-      const response = await fetch(`${API_BASE_URL}/jobs/${jobId}/report`);
+      // Try new conversions endpoint first, fall back to legacy jobs endpoint
+      let response = await fetch(`${API_BASE_URL}/conversions/${jobId}/report`);
       
+      if (response.status === 404) {
+        // Fallback to legacy endpoint
+        response = await fetch(`${API_BASE_URL}/jobs/${jobId}/report`);
+      }
+
       if (!response.ok) {
         if (response.status === 404) {
           throw new Error('Conversion report not found. Please ensure the conversion completed successfully.');

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -23,7 +23,10 @@ export class ConversionWebSocket {
 
   constructor(private jobId: string) {
     // Determine WebSocket URL based on environment
-    const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
+    // Use VITE_API_BASE_URL if set, otherwise derive from API_BASE_URL or default
+    const apiBase = import.meta.env.VITE_API_BASE_URL 
+      || (import.meta.env.VITE_API_URL ? import.meta.env.VITE_API_URL.replace(/\/api\/v1$/, '') : null)
+      || (process.env.NODE_ENV === 'production' ? '' : 'http://localhost:8000');
     this.url = apiBase.replace(/^http/, 'ws') + `/api/v1/conversions/${this.jobId}/ws`;
   }
 


### PR DESCRIPTION
## Summary
Connect frontend components to the new backend conversions API endpoints for the real conversion workflow.

## Changes

### API Service (\`frontend/src/services/api.ts\`)
- **\`convertMod()\`**: Now uses \`POST /api/v1/conversions\` (multipart form with file + options) as the primary endpoint, with graceful fallback to the legacy \`/upload\` + \`/convert\` two-step flow
- **\`getConversionStatus()\`**: Uses \`GET /api/v1/conversions/{id}\` with fallback to \`/convert/{id}/status\`
- **\`downloadResult()\`**: Uses \`GET /api/v1/conversions/{id}/download\` with fallback to legacy endpoint
- **\`cancelJob()\`**: Uses \`DELETE /api/v1/conversions/{id}\` with fallback to legacy endpoint

### WebSocket (\`frontend/src/services/websocket.ts\`)
- Fixed WebSocket URL derivation to use \`VITE_API_BASE_URL\` or \`VITE_API_URL\` instead of hardcoded port 8080
- Ensures WebSocket connects to the same backend as REST API calls

### ConversionReport (\`ConversionReportContainer.tsx\`)
- Updated to try \`/conversions/{id}/report\` before falling back to \`/jobs/{id}/report\`

## Backward Compatibility
All changes include fallback to legacy endpoints, ensuring the frontend works with both old and new backend versions during the transition period.

## API Endpoints Connected
| Frontend Action | New Endpoint | Legacy Fallback |
|---|---|---|
| Start conversion | \`POST /api/v1/conversions\` | \`POST /upload\` + \`POST /convert\` |
| Get status | \`GET /api/v1/conversions/{id}\` | \`GET /convert/{id}/status\` |
| Download result | \`GET /api/v1/conversions/{id}/download\` | \`GET /convert/{id}/download\` |
| Cancel job | \`DELETE /api/v1/conversions/{id}\` | \`DELETE /convert/{id}\` |
| WebSocket progress | \`WS /api/v1/conversions/{id}/ws\` | (same) |
| Get report | \`GET /conversions/{id}/report\` | \`GET /jobs/{id}/report\` |

Closes #446

## Summary by Sourcery

Integrate the frontend conversion workflow with the new conversions API while preserving compatibility with legacy endpoints.

New Features:
- Add support for starting conversions via the new unified /conversions endpoint with options passed as multipart form data.
- Add support for retrieving conversion status, downloading results, cancelling jobs, and fetching reports through the new conversions-based endpoints.

Bug Fixes:
- Align WebSocket connection URL with configurable API base URL so realtime updates target the same backend as REST calls.

Enhancements:
- Introduce graceful fallback from new conversions endpoints to existing legacy endpoints to maintain backward compatibility during backend migration.