### PR TITLE
feat: Issue #447 - Add QAValidatorAgent integration test for E2E verification

### DIFF
--- a/tests/test_mvp_conversion.py
+++ b/tests/test_mvp_conversion.py
@@ -734,7 +734,10 @@ class TestMVPEndToEndConversion:
 
             # Assertions for validation results
             assert validation_result['overall_score'] > 0, "QA validation should return a score"
-            assert validation_result['status'] in ['pass', 'partial', 'fail'], "Status should be valid"
+
+            # Status must reflect an acceptable QA outcome when enforcing the score threshold
+            assert validation_result['status'] in ['pass', 'partial'], \
+                f"Status {validation_result['status']} is not acceptable for a passing QA result"
 
             # Require at least 70% overall score for passing
             assert validation_result['overall_score'] >= 70, \
@@ -749,6 +752,11 @@ class TestMVPEndToEndConversion:
             manifest = validation_result['validations'].get('manifest', {})
             assert manifest.get('status') in ['pass', 'partial'], \
                 f"Manifest validation failed: {manifest.get('errors', [])}"
+
+            # Content validation should pass (as documented in docstring)
+            content = validation_result['validations'].get('content', {})
+            assert content.get('status') in ['pass', 'partial'], \
+                f"Content validation failed: {content.get('errors', [])}"
 
             print("\n✅ TEST PASSED: QA Validator Integration")
 


### PR DESCRIPTION
## Summary

This PR adds QAValidatorAgent integration to the E2E conversion tests, addressing Issue #447's requirement to validate the output .mcaddon file.

## Changes Made

- Added `QAValidatorAgent` import to `tests/test_mvp_conversion.py`
- Added new test case `test_qa_validator_integration()` that:
  - Runs the full conversion pipeline (analyze → build → package)
  - Validates the generated .mcaddon using QAValidatorAgent
  - Verifies overall quality score >= 70%
  - Verifies structural, manifest, and content validation pass

## Issue Reference

- Closes #447: [MVP] Verify End-to-End Conversion (simple_copper_block.jar)

## Test Results

All 12 tests in `test_mvp_conversion.py` pass:

```
tests/test_mvp_conversion.py::TestMVPEndToEndConversion::test_simple_block_conversion PASSED
tests/test_mvp_conversion.py::TestMVPEndToEndConversion::test_qa_validator_integration PASSED
... (12 total tests passed)
```

## Notes

- The conversion pipeline is fully functional and produces valid .mcaddon files
- QAValidatorAgent provides comprehensive validation with quality scoring
- The test fixture `simple_copper_block.jar` is used for validation

## Summary by Sourcery

Tests:
- Introduce an integration test that runs the full conversion pipeline on simple_copper_block.jar and validates the resulting .mcaddon with QAValidatorAgent, enforcing minimum quality score and key validation passes.