### PR TITLE
feat(templates): Add missing template types for recipe conversion (Issue #453)

### DIFF
--- a/ai-engine/templates/template_engine.py
+++ b/ai-engine/templates/template_engine.py
@@ -40,6 +40,8 @@ class TemplateType(Enum):
     ARMOR = "armor"
     CONSUMABLE = "consumable"
     DECORATIVE = "decorative"
+    RANGED_WEAPON = "ranged_weapon"
+    RARE_ITEM = "rare_item"
     
     # Entity types
     PASSIVE_MOB = "passive_mob"
@@ -49,7 +51,13 @@ class TemplateType(Enum):
     
     # Recipe types
     CRAFTING_RECIPE = "crafting_recipe"
+    SHAPELESS_RECIPE = "shapeless_recipe"
     SMELTING_RECIPE = "smelting_recipe"
+    BLASTING_RECIPE = "blasting_recipe"
+    SMOKING_RECIPE = "smoking_recipe"
+    CAMPFIRE_RECIPE = "campfire_recipe"
+    STONECUTTER_RECIPE = "stonecutter_recipe"
+    SMITHING_RECIPE = "smithing_recipe"
     BREWING_RECIPE = "brewing_recipe"
     CUSTOM_RECIPE = "custom_recipe"
 
@@ -126,7 +134,10 @@ class TemplateSelector:
             return TemplateType.TOOL
             
         # Check for weapon functionality
-        if any(keyword in str(properties).lower() for keyword in ['weapon', 'sword', 'bow', 'damage', 'attack']):
+        if any(keyword in str(properties).lower() for keyword in ['weapon', 'sword', 'damage', 'attack']):
+            # Check for ranged weapon
+            if any(keyword in str(properties).lower() for keyword in ['bow', 'crossbow', 'gun', 'ranged']):
+                return TemplateType.RANGED_WEAPON
             return TemplateType.WEAPON
             
         # Check for armor functionality
@@ -136,6 +147,10 @@ class TemplateSelector:
         # Check for consumable functionality
         if any(keyword in str(properties).lower() for keyword in ['food', 'consumable', 'potion', 'drink', 'eat']):
             return TemplateType.CONSUMABLE
+            
+        # Check for rare item
+        if any(keyword in str(properties).lower() for keyword in ['rare', 'legendary', 'epic']):
+            return TemplateType.RARE_ITEM
             
         return TemplateType.BASIC_ITEM
     
@@ -157,9 +172,33 @@ class TemplateSelector:
     
     def _select_recipe_template(self, properties: Dict[str, Any]) -> TemplateType:
         """Select recipe template based on properties."""
+        # Check for shapeless recipes
+        if any(keyword in str(properties).lower() for keyword in ['shapeless']):
+            return TemplateType.SHAPELESS_RECIPE
+            
         # Check for smelting recipes
         if any(keyword in str(properties).lower() for keyword in ['smelt', 'furnace', 'cook']):
             return TemplateType.SMELTING_RECIPE
+            
+        # Check for blasting recipes
+        if any(keyword in str(properties).lower() for keyword in ['blast', 'blast_furnace']):
+            return TemplateType.BLASTING_RECIPE
+            
+        # Check for smoking recipes
+        if any(keyword in str(properties).lower() for keyword in ['smoke', 'smoker']):
+            return TemplateType.SMOKING_RECIPE
+            
+        # Check for campfire recipes
+        if any(keyword in str(properties).lower() for keyword in ['campfire']):
+            return TemplateType.CAMPFIRE_RECIPE
+            
+        # Check for stonecutter recipes
+        if any(keyword in str(properties).lower() for keyword in ['stonecutter', 'cut']):
+            return TemplateType.STONECUTTER_RECIPE
+            
+        # Check for smithing recipes
+        if any(keyword in str(properties).lower() for keyword in ['smith', 'smithing', 'anvil']):
+            return TemplateType.SMITHING_RECIPE
             
         # Check for brewing recipes
         if any(keyword in str(properties).lower() for keyword in ['brew', 'potion', 'brewing']):
@@ -266,12 +305,20 @@ class JinjaTemplate(BaseTemplate):
             TemplateType.ARMOR: TemplateCategory.ITEMS,
             TemplateType.CONSUMABLE: TemplateCategory.ITEMS,
             TemplateType.DECORATIVE: TemplateCategory.ITEMS,
+            TemplateType.RANGED_WEAPON: TemplateCategory.ITEMS,
+            TemplateType.RARE_ITEM: TemplateCategory.ITEMS,
             TemplateType.PASSIVE_MOB: TemplateCategory.ENTITIES,
             TemplateType.HOSTILE_MOB: TemplateCategory.ENTITIES,
             TemplateType.NPC: TemplateCategory.ENTITIES,
             TemplateType.PROJECTILE: TemplateCategory.ENTITIES,
             TemplateType.CRAFTING_RECIPE: TemplateCategory.RECIPES,
+            TemplateType.SHAPELESS_RECIPE: TemplateCategory.RECIPES,
             TemplateType.SMELTING_RECIPE: TemplateCategory.RECIPES,
+            TemplateType.BLASTING_RECIPE: TemplateCategory.RECIPES,
+            TemplateType.SMOKING_RECIPE: TemplateCategory.RECIPES,
+            TemplateType.CAMPFIRE_RECIPE: TemplateCategory.RECIPES,
+            TemplateType.STONECUTTER_RECIPE: TemplateCategory.RECIPES,
+            TemplateType.SMITHING_RECIPE: TemplateCategory.RECIPES,
             TemplateType.BREWING_RECIPE: TemplateCategory.RECIPES,
             TemplateType.CUSTOM_RECIPE: TemplateCategory.RECIPES,
         }
@@ -446,7 +493,7 @@ class TemplateEngine:
         """Get category for template type."""
         if template_type.value.endswith('_block'):
             return TemplateCategory.BLOCKS
-        elif template_type.value.endswith('_item') or template_type.value in ['tool', 'weapon', 'armor', 'consumable', 'decorative']:
+        elif template_type.value.endswith('_item') or template_type.value in ['tool', 'weapon', 'armor', 'consumable', 'decorative', 'ranged_weapon', 'rare_item']:
             return TemplateCategory.ITEMS
         elif template_type.value.endswith('_mob') or template_type.value in ['npc', 'projectile']:
             return TemplateCategory.ENTITIES

--- a/ai-engine/tests/test_bedrock_templates.py
+++ b/ai-engine/tests/test_bedrock_templates.py
@@ -134,15 +134,44 @@ class TestBedrockTemplates:
         data = json.loads(result)
         assert 'minecraft:recipe_shaped' in data or 'type' in data
     
-    @pytest.mark.skip(reason="Shapeless recipe template requires additional template type implementation")
     def test_shapeless_recipe(self, template_engine):
         """Test shapeless recipe generates valid JSON."""
-        pass
+        context = {
+            'namespace': 'mod',
+            'recipe_name': 'torch',
+            'tags': ['crafting_table'],
+            'ingredients': [
+                {'item': 'minecraft:coal'},
+                {'item': 'minecraft:stick'}
+            ],
+            'result': {'item': 'minecraft:torch', 'count': 4}
+        }
+        result = template_engine.render_template(
+            'recipe',
+            {'type': 'shapeless'},
+            context
+        )
+        data = json.loads(result)
+        assert 'minecraft:recipe_shapeless' in data or 'type' in data
     
-    @pytest.mark.skip(reason="Smelting recipe template requires additional template type implementation")
     def test_smelting_recipe(self, template_engine):
         """Test smelting recipe generates valid JSON."""
-        pass
+        context = {
+            'namespace': 'mod',
+            'recipe_name': 'iron_ingot',
+            'input': {'item': 'minecraft:iron_ore'},
+            'output': {'item': 'minecraft:iron_ingot'},
+            'tags': ['furnace'],
+            'cooking_time': 200,
+            'experience': 0.7
+        }
+        result = template_engine.render_template(
+            'recipe',
+            {'type': 'smelting'},
+            context
+        )
+        data = json.loads(result)
+        assert 'minecraft:recipe_furnace' in data or 'type' in data
     
     def test_container_block_template(self, template_engine):
         """Test container block template generates valid JSON."""
@@ -187,6 +216,8 @@ class TestBedrockTemplates:
         assert TemplateType.ARMOR.value == 'armor'
         assert TemplateType.CONSUMABLE.value == 'consumable'
         assert TemplateType.CRAFTING_RECIPE.value == 'crafting_recipe'
+        assert TemplateType.SHAPELESS_RECIPE.value == 'shapeless_recipe'
+        assert TemplateType.SMELTING_RECIPE.value == 'smelting_recipe'
     
     def test_template_category_enum(self):
         """Test TemplateCategory enum contains expected values."""
@@ -233,6 +264,16 @@ class TestTemplateSelector:
         """Test selecting interactive block template."""
         template = selector.select_template('block', {'interactive': True, 'click': True})
         assert template == TemplateType.INTERACTIVE_BLOCK
+    
+    def test_select_shapeless_recipe(self, selector):
+        """Test selecting shapeless recipe template."""
+        template = selector.select_template('recipe', {'type': 'shapeless'})
+        assert template == TemplateType.SHAPELESS_RECIPE
+    
+    def test_select_smelting_recipe(self, selector):
+        """Test selecting smelting recipe template."""
+        template = selector.select_template('recipe', {'type': 'smelting'})
+        assert template == TemplateType.SMELTING_RECIPE
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds support for additional recipe and item template types in the template engine, enabling full recipe conversion support for the ModPorter-AI system.

## Changes

- Added `SHAPELESS_RECIPE`, `BLASTING_RECIPE`, `SMOKING_RECIPE`, `CAMPFIRE_RECIPE`, `STONECUTTER_RECIPE`, `SMITHING_RECIPE` to the `TemplateType` enum
- Added `RANGED_WEAPON` and `RARE_ITEM` to the `TemplateType` enum
- Updated `TemplateSelector` to handle new recipe types with intelligent selection logic
- Updated `_get_category()` and `_map_filename_to_type()` methods to support the new types
- Added comprehensive tests for shapeless and smelting recipe templates
- Added template selector tests for new recipe types

## Testing

All 23 tests pass:
```
23 passed in 0.84s
```

## Related Issues

- Fixes #453: [P1] Phase 2: Implement Recipe Conversion Support