### PR TITLE
feat(ai-engine): Implement Direct Gameplay Comparison Agent (Issue #494)

### DIFF
--- a/ai-engine/agents/gameplay_comparison_agent.py
+++ b/ai-engine/agents/gameplay_comparison_agent.py
@@ -38,11 +38,13 @@ class Screenshot:
     game_version: str
     test_name: str
     hash: str
+    edition: Optional[str] = None  # Explicit game edition (e.g. "java", "bedrock")
 
 
 @dataclass
 class GameplayComparisonResult:
     """Results from comparing gameplay between Java and Bedrock."""
+    conversion_id: str
     java_screenshots: List[Screenshot]
     bedrock_screenshots: List[Screenshot]
     visual_diffs: List[Dict]
@@ -202,7 +204,8 @@ class GameplayTestRunner:
                 timestamp=timestamp,
                 game_version=game_version,
                 test_name=test_name,
-                hash=file_hash
+                hash=file_hash,
+                edition=game_edition
             )
             print(f"  📸 Screenshot captured: {filename}")
             return screenshot
@@ -211,10 +214,12 @@ class GameplayTestRunner:
             return None
     
     def get_screenshots(self, game_edition: Optional[str] = None) -> List[Screenshot]:
-        """Get all captured screenshots."""
-        if game_edition:
-            return [s for s in self.screenshots if game_edition in s.path]
-        return self.screenshots
+        """Get all captured screenshots, optionally filtered by game edition."""
+        if game_edition is None:
+            return self.screenshots
+        
+        # Filter on the structured edition field instead of doing substring matches on the path
+        return [s for s in self.screenshots if s.edition == game_edition]
 
 
 class ScreenshotComparator:


### PR DESCRIPTION
## Summary

This PR implements Mode 1 of the AI-Powered Validation & Comparison system - Direct Gameplay Comparison.

### Components Added
- **MinecraftLauncher**: Handles launching Minecraft Java and Bedrock editions
- **GameplayTestRunner**: Runs automated test scripts in Minecraft
- **ScreenshotComparator**: Compares screenshots to detect visual differences
- **GameplayComparisonAgent**: Main agent with full validation pipeline

### Features
- Launch both Minecraft editions locally
- Run automated test scripts (block placement, crafting, entity spawning)
- Capture and compare screenshots
- Generate validation reports with scores (0-100%)
- Identify missing or broken features

### Issue
- Fixes #494: Implement Direct Gameplay Comparison (Phase 4a)

### Usage
\`\`\`python
from ai_engine.agents.gameplay_comparison_agent import GameplayComparisonAgent

agent = GameplayComparisonAgent()
result = agent.run_comparison(
    conversion_id="conv_001",
    java_mod_path="/path/to/java/mod",
    bedrock_addon_path="/path/to/bedrock/addon"
)
print(f"Score: {result.overall_score}/100")
\`\`\`

## Summary by Sourcery

Implement an AI-driven gameplay comparison agent that automates side‑by‑side validation between Minecraft Java mods and Bedrock addons using scripted tests and screenshot analysis.

New Features:
- Add a Minecraft launcher abstraction capable of checking for and starting Java and Bedrock editions locally.
- Introduce a gameplay test runner that executes scripted in‑game commands and captures screenshots per test.
- Provide a screenshot comparison component that evaluates visual similarity between Java and Bedrock gameplay captures.
- Add a GameplayComparisonAgent that orchestrates end‑to‑end test execution, result comparison, scoring, and report export for a given conversion.

Enhancements:
- Define structured dataclasses for game test scripts, screenshots, and gameplay comparison results to standardize data flow through the validation pipeline.