### PR TITLE
fix: CI Test Timeout Issue #509

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: pgvector/pgvector:pg15
@@ -55,27 +56,42 @@ jobs:
       with:
         node-version: '20.19.0'
 
-    - name: Cache Python dependencies
+    - name: Cache Python dependencies (backend)
       uses: actions/cache@v5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+        key: ${{ runner.os }}-pip-backend-${{ hashFiles('backend/requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-backend-
+
+    - name: Cache Python dependencies (ai-engine)
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-ai-engine-${{ hashFiles('ai-engine/requirements*.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-ai-engine-
 
     - name: Cache Node dependencies
       uses: actions/cache@v5
       with:
         path: ~/.npm
         key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-npm-
 
     - name: Install backend dependencies
       run: |
         cd backend
+        pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
 
     - name: Install AI engine dependencies
+      timeout-minutes: 15
       run: |
         cd ai-engine
+        pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
 


### PR DESCRIPTION
## Description

This PR fixes the CI Test Timeout issue (#509) where the Deploy ModPorter AI test workflow was getting stuck on the "Install AI engine dependencies" step.

## Changes Made

1. **Added job-level timeout**: Added `timeout-minutes: 30` to the test job to prevent indefinite hangs
2. **Added step-level timeout**: Added `timeout-minutes: 15` to the AI engine dependencies installation step
3. **Improved caching**: Split Python dependency cache into separate backend and ai-engine caches for better efficiency
4. **Added restore-keys**: Added restore-keys for better cache hit rates when requirements change
5. **Upgraded pip**: Added `pip install --upgrade pip setuptools wheel` before installing dependencies to ensure faster installations

## Benefits

- **Prevents indefinite hangs**: The workflow now fails gracefully after 30 minutes instead of timing out indefinitely
- **Faster installations**: Upgrading pip first ensures better performance
- **Better caching**: Separate caches and restore-keys improve cache hit rates
- **Clearer feedback**: Explicit timeouts provide better visibility into what's taking too long

## Related Issue

- #509: CI Test Timeout: Deploy ModPorter AI test workflow stuck on AI engine dependencies installation