### PR TITLE
feat(frontend): Add URL parsing for CurseForge/Modrinth imports

### DIFF
--- a/frontend/src/components/ConversionUpload/ConversionUpload.tsx
+++ b/frontend/src/components/ConversionUpload/ConversionUpload.tsx
@@ -13,6 +13,7 @@ import {
   ConversionStatusEnum
 } from '../../types/api';
 import ConversionProgress from '../ConversionProgress/ConversionProgress';
+import { parseModUrl, getPlatformInfo } from '../../utils/urlParser';
 import './ConversionUpload.css';
 
 // Configuration constants
@@ -405,6 +406,29 @@ export const ConversionUpload: React.FC<ConversionUploadProps> = ({
               className="url-input"
               disabled={!!selectedFile || isProcessing || isCompleted}
             />
+            {modUrl && (
+              <div className="url-platform-indicator" style={{
+                marginTop: '8px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                padding: '8px 12px',
+                borderRadius: '6px',
+                backgroundColor: getPlatformInfo(parseModUrl(modUrl).platform).bgColor,
+                color: getPlatformInfo(parseModUrl(modUrl).platform).color,
+                fontSize: '14px',
+                fontWeight: 500
+              }}>
+                {parseModUrl(modUrl).isValid ? (
+                  <>
+                    <span>{getPlatformInfo(parseModUrl(modUrl).name} detected</span>
+                    <span style={{ opacity: 0.7 }}>• {parseModUrl(modUrl).slug}</span>
+                  </>
+                ) : (
+                  <span style={{ color: '#ef4444' }}>Invalid URL - Supported: CurseForge, Modrinth</span>
+                )}
+              </div>
+            )}
             <div className="supported-sites">
               <span>Supported: CurseForge • Modrinth</span>
             </div>

--- a/frontend/src/utils/urlParser.ts
+++ b/frontend/src/utils/urlParser.ts
@@ -1,0 +1,164 @@
+/**
+ * URL Parser utility for CurseForge and Modrinth URLs
+ */
+
+export interface ParsedModURL {
+  platform: 'curseforge' | 'modrinth' | 'unknown';
+  slug: string;
+  url: string;
+  isValid: boolean;
+  error?: string;
+}
+
+/**
+ * Parse a CurseForge or Modrinth URL to extract mod information
+ * 
+ * Supports URLs like:
+ * - https://www.curseforge.com/minecraft/mods/mod-name
+ * - https://curseforge.com/minecraft/mods/mod-name
+ * - https://modrinth.com/mod/mod-name
+ * - https://modrinth.com/resourcepack/resourcepack-name
+ * - https://modrinth.com/plugin/plugin-name
+ */
+export function parseModUrl(url: string): ParsedModURL {
+  if (!url || typeof url !== 'string') {
+    return {
+      platform: 'unknown',
+      slug: '',
+      url: url || '',
+      isValid: false,
+      error: 'URL is required',
+    };
+  }
+
+  // Try CurseForge patterns
+  const curseforgePatterns = [
+    /(?:https?:\/\/)?(?:www\.)?curseforge\.com\/minecraft\/mods\/([^\/?]+)/i,
+    /(?:https?:\/\/)?(?:www\.)?curseforge\.com\/minecraft\/modpacks\/([^\/?]+)/i,  // Modpacks
+  ];
+
+  for (const pattern of curseforgePatterns) {
+    const match = url.match(pattern);
+    if (match) {
+      const slug = match[1];
+      return {
+        platform: 'curseforge',
+        slug,
+        url: `https://www.curseforge.com/minecraft/mods/${slug}`,
+        isValid: true,
+      };
+    }
+  }
+
+  // Try Modrinth patterns
+  const modrinthPatterns = [
+    /(?:https?:\/\/)?(?:www\.)?modrinth\.com\/(mod|resourcepack|plugin|pack)\/([^\/?]+)/i,
+    /(?:https?:\/\/)?modrinth\.com\/([^\/?]+)/i,  // Short URL
+  ];
+
+  for (const pattern of modrinthPatterns) {
+    const match = url.match(pattern);
+    if (match) {
+      if (match.length >= 3) {
+        // Type and slug
+        const projectType = match[1];
+        const slug = match[2];
+        return {
+          platform: 'modrinth',
+          slug,
+          url: `https://modrinth.com/${projectType}/${slug}`,
+          isValid: true,
+        };
+      } else {
+        // Short URL - assume mod
+        const slug = match[1];
+        return {
+          platform: 'modrinth',
+          slug,
+          url: `https://modrinth.com/mod/${slug}`,
+          isValid: true,
+        };
+      }
+    }
+  }
+
+  return {
+    platform: 'unknown',
+    slug: '',
+    url,
+    isValid: false,
+    error: 'Unable to parse URL. Supported platforms: CurseForge, Modrinth',
+  };
+}
+
+/**
+ * Get platform display name
+ */
+export function getPlatformDisplayName(platform: 'curseforge' | 'modrinth' | 'unknown'): string {
+  switch (platform) {
+    case 'curseforge':
+      return 'CurseForge';
+    case 'modrinth':
+      return 'Modrinth';
+    default:
+      return 'Unknown';
+  }
+}
+
+/**
+ * Get platform icon/color
+ */
+export function getPlatformInfo(platform: 'curseforge' | 'modrinth' | 'unknown'): {
+  name: string;
+  color: string;
+  bgColor: string;
+} {
+  switch (platform) {
+    case 'curseforge':
+      return {
+        name: 'CurseForge',
+        color: '#f16436',
+        bgColor: 'rgba(241, 100, 54, 0.1)',
+      };
+    case 'modrinth':
+      return {
+        name: 'Modrinth',
+        color: '#00b5a0',
+        bgColor: 'rgba(0, 181, 160, 0.1)',
+      };
+    default:
+      return {
+        name: 'Unknown',
+        color: '#6b7280',
+        bgColor: 'rgba(107, 114, 128, 0.1)',
+      };
+  }
+}
+
+/**
+ * Format download count
+ */
+export function formatDownloadCount(count?: number): string {
+  if (!count || count === 0) return '0';
+  
+  if (count >= 1000000) {
+    return `${(count / 1000000).toFixed(1)}M`;
+  }
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1)}K`;
+  }
+  return count.toString();
+}
+
+/**
+ * Format file size
+ */
+export function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}


### PR DESCRIPTION
## Summary

Implements frontend URL parsing and UI for importing mods directly from CurseForge or Modrinth URLs.

## Changes

### URL Parser Utility (frontend/src/utils/urlParser.ts)
- Parse CurseForge and Modrinth URLs to extract mod information
- Support for various URL formats (www, non-www, short URLs)
- Platform detection with colors and display names
- Helper functions for formatting download counts and file sizes

### API Service Updates (frontend/src/services/api.ts)
Added modImportsAPI with methods:
- parseURL - Parse a CurseForge or Modrinth URL
- searchMods - Search mods on both platforms
- getModInfo - Get detailed mod information
- getModFiles - Get available versions/files
- importMod - Import mod from URL (downloads file)
- getCategories - Get platform categories
- getLoaders - Get Modrinth loaders

### ConversionUpload Component Updates
- Import and use the URL parser utility
- Show platform detection when user enters a URL
- Display platform name (CurseForge/Modrinth) and mod slug inline
- Visual indicator with platform-specific colors

## Related Issues

- Closes #518: feat(frontend): Add URL parsing for CurseForge/Modrinth imports
- Related to #483: Integrate CurseForge/Modrinth API for Direct Import
- Related to #516: Backend CurseForge API integration
- Related to #517: Backend Modrinth API integration
