### PR TITLE
Palette: Enhance Conversion History UX with confirmations and empty state

### DIFF
--- a/frontend/src/components/ConversionHistory/ConversionHistory.css
+++ b/frontend/src/components/ConversionHistory/ConversionHistory.css
@@ -74,6 +74,48 @@
   align-items: center;
 }
 
+/* Confirmation UI */
+.confirm-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #fff;
+  padding: 0.2rem;
+  border-radius: 6px;
+  animation: slideInLeft 0.2s ease-out;
+}
+
+@keyframes slideInLeft {
+  from { opacity: 0; transform: translateX(10px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.confirm-text {
+  font-size: 0.9rem;
+  color: #c2185b; /* Matches clear-all color */
+  font-weight: 500;
+  margin-right: 0.2rem;
+}
+
+.cancel-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #e0e0e0;
+  background: white;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #666;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.cancel-btn:hover {
+  background: #f5f5f5;
+  color: #333;
+  border-color: #bdbdbd;
+}
+
+/* Action Buttons */
 .delete-selected-btn,
 .clear-all-btn {
   padding: 0.5rem 1rem;
@@ -125,6 +167,10 @@
   text-align: center;
   padding: 3rem 1rem;
   color: #666;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 
 .empty-icon {
@@ -141,6 +187,34 @@
 .empty-subtitle {
   color: #999 !important;
   font-size: 0.9rem !important;
+}
+
+.start-new-btn {
+  margin-top: 1.5rem;
+  padding: 0.8rem 1.5rem;
+  background: #2196f3;
+  color: white;
+  border: none;
+  border-radius: 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  box-shadow: 0 4px 6px rgba(33, 150, 243, 0.2);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.start-new-btn:hover {
+  background: #1976d2;
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(33, 150, 243, 0.3);
+}
+
+.start-new-btn:focus-visible {
+  outline: 3px solid #90caf9;
+  outline-offset: 2px;
 }
 
 /* History List */
@@ -185,6 +259,7 @@
   width: 16px;
   height: 16px;
   cursor: pointer;
+  accent-color: #2196f3;
 }
 
 .item-icon {

--- a/frontend/src/components/ConversionHistory/ConversionHistoryItem.tsx
+++ b/frontend/src/components/ConversionHistory/ConversionHistoryItem.tsx
@@ -82,6 +82,7 @@ export const ConversionHistoryItem = memo(({
             className="download-btn"
             onClick={() => onDownload(item.job_id, item.original_filename)}
             title="Download converted file"
+            aria-label={`Download ${item.original_filename}`}
           >
             ⬇️ Download
           </button>
@@ -91,6 +92,7 @@ export const ConversionHistoryItem = memo(({
           className="delete-btn"
           onClick={() => onDelete(item.job_id)}
           title="Remove from history"
+          aria-label={`Remove ${item.original_filename} from history`}
         >
           🗑️
         </button>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -279,6 +279,7 @@ export const Dashboard: React.FC = () => {
               ref={setHistoryRef}
               className="dashboard-history"
               maxItems={100}
+              onStartNewConversion={() => setActiveTab('convert')}
             />
           </div>
         )}


### PR DESCRIPTION
💡 **What:**
- Added a "Start New Conversion" button to the empty state in `ConversionHistory`.
- Added inline confirmation ("Yes/No") for destructive actions: "Clear All" and "Delete Selected".
- Added comprehensive ARIA labels (`aria-label`, `role="status"`, `role="alertdialog"`) for better accessibility.
- Refactored `localStorage` persistence to use `useEffect` for cleaner state management.
- Moved styling to `ConversionHistory.css` using new classes (`confirm-actions`, `confirm-text`, `cancel-btn`, `start-new-btn`).

🎯 **Why:**
- Users previously had no clear call-to-action when the history was empty.
- Destructive actions were immediate, risking accidental data loss.
- Accessibility was improved for screen reader users.

📸 **Before/After:**
- **Empty State:** Now shows a clear CTA button.
- **Delete/Clear:** Now asks for confirmation before executing.

♿ **Accessibility:**
- Added `aria-label` to icon-only buttons.
- Used `role="alertdialog"` for confirmation areas.

---
*PR created automatically by Jules for task [11930932128958125989](https://jules.google.com/task/11930932128958125989) started by @anchapin*