### PR TITLE
🛡️ Sentinel: Fix TOCTOU DNS Rebinding in FileProcessor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,12 @@
 1. Never modify shared service state in middleware.
 2. Pass request-specific configuration as arguments to service methods (e.g. `override_config`).
 3. Use immutable configuration objects where possible or deep copy if modification is needed locally.
+
+## 2026-02-17 - TOCTOU DNS Rebinding Prevention
+**Vulnerability:** Time-of-Check Time-of-Use (TOCTOU) vulnerability in URL validation allowing DNS Rebinding attacks. Validating a URL's IP and then requesting it allows an attacker to change the DNS record between the check and the request.
+**Learning:** Checking `_is_safe_url(url)` is insufficient because `httpx.get(url)` performs a new DNS resolution. Pinning the connection to the validated IP is required for HTTP. For HTTPS, strict pinning is complex due to SNI/Cert validation, but TLS validation generally mitigates rebinding to non-TLS internal services.
+**Prevention:**
+1. Resolve the hostname to a safe IP first (`_resolve_safe_ip`).
+2. For HTTP: Rewrite the URL to use the safe IP (`http://<safe_ip>/path`) and set the `Host` header to the original hostname.
+3. For HTTPS: Use the original hostname but rely on strict certificate verification (hostname matching) to prevent connection to internal services lacking the attacker's certificate.
+4. Ensure mocking in tests simulates this behavior by returning the IP string, not just a boolean.

--- a/backend/src/file_processor.py
+++ b/backend/src/file_processor.py
@@ -86,28 +86,32 @@ class FileProcessor:
             return "default_sanitized_filename"
         return sanitized
 
-    async def _is_safe_url(self, url: str) -> bool:
+    async def _resolve_safe_ip(self, url: str) -> Optional[str]:
         """
         Validates URL to prevent SSRF by resolving hostname and checking for private/loopback IPs.
+        Returns the safe IP address if valid, None otherwise.
         """
         try:
             parsed = urllib.parse.urlparse(url)
-            if parsed.scheme not in ('http', 'https'):
+            if parsed.scheme not in ("http", "https"):
                 logger.warning(f"Unsafe scheme in URL for hostname: {parsed.hostname}")
-                return False
+                return None
             hostname = parsed.hostname
             if not hostname:
-                return False
+                return None
 
             # Run blocking DNS resolution in executor
             loop = asyncio.get_running_loop()
             # Use getaddrinfo to support both IPv4 and IPv6
             try:
-                infos = await loop.run_in_executor(None, socket.getaddrinfo, hostname, None)
+                infos = await loop.run_in_executor(
+                    None, socket.getaddrinfo, hostname, None
+                )
             except socket.gaierror:
                 logger.warning(f"Could not resolve hostname: {hostname}")
-                return False
+                return None
 
+            safe_ip = None
             for info in infos:
                 ip = info[4][0]
                 # Strip IPv6 scope ID if present (e.g. fe80::1%eth0 -> fe80::1)
@@ -117,17 +121,26 @@ class FileProcessor:
                 try:
                     ip_obj = ipaddress.ip_address(ip)
                     if ip_obj.is_loopback or ip_obj.is_private or ip_obj.is_link_local:
-                        logger.warning(f"Blocked attempt to access private IP: {ip} for hostname: {hostname}")
-                        return False
+                        logger.warning(
+                            f"Blocked attempt to access private IP: {ip} for hostname: {hostname}"
+                        )
+                        return None
+                    # Pick the first safe IP found
+                    if safe_ip is None:
+                        safe_ip = ip
                 except ValueError:
                     # Fail securely if IP cannot be parsed
-                    logger.warning(f"Could not parse IP address: {ip} for hostname: {hostname}")
-                    return False
-            return True
+                    logger.warning(
+                        f"Could not parse IP address: {ip} for hostname: {hostname}"
+                    )
+                    return None
+            return safe_ip
         except Exception as e:
             # Don't log full URL in exception either
-            logger.error(f"Error validating URL for hostname {parsed.hostname if 'parsed' in locals() else 'unknown'}: {e}")
-            return False
+            logger.error(
+                f"Error validating URL for hostname {parsed.hostname if 'parsed' in locals() else 'unknown'}: {e}"
+            )
+            return None
 
     def validate_upload(self, file: UploadFile) -> ValidationResult:
         """
@@ -615,15 +628,59 @@ class FileProcessor:
 
                 # Manual redirect handling with SSRF protection
                 for _ in range(5):  # Max 5 redirects
-                    if not await self._is_safe_url(current_url):
+                    safe_ip = await self._resolve_safe_ip(current_url)
+                    if not safe_ip:
                         # Sanitize URL for logging (strip query params/fragments)
                         parsed_unsafe = urllib.parse.urlparse(current_url)
                         sanitized_unsafe = f"{parsed_unsafe.scheme}://{parsed_unsafe.hostname}{parsed_unsafe.path}"
                         msg = f"Unsafe URL detected: {sanitized_unsafe}"
                         logger.warning(msg)
-                        return DownloadResult(success=False, message="Unsafe URL detected")
+                        return DownloadResult(
+                            success=False, message="Unsafe URL detected"
+                        )
 
-                    response = await client.get(current_url, follow_redirects=False, timeout=30.0)
+                    parsed_url = urllib.parse.urlparse(current_url)
+                    request_url = current_url
+                    headers = {}
+
+                    # For HTTP, use the resolved IP to prevent DNS rebinding attacks (TOCTOU).
+                    # For HTTPS, we must use the hostname to allow TLS SNI and certificate validation.
+                    # Connecting to an IP for HTTPS would cause certificate validation failure unless
+                    # we disable it (insecure) or have complex custom verification logic.
+                    # TLS validation itself protects against rebinding to a malicious internal server
+                    # unless that server also possesses a valid certificate for the attacker's hostname.
+                    if parsed_url.scheme == "http":
+                        # Rewrite URL to use IP
+                        netloc = safe_ip
+                        # Handle IPv6 brackets
+                        if ":" in safe_ip:
+                            netloc = f"[{safe_ip}]"
+
+                        if parsed_url.port:
+                            netloc = f"{netloc}:{parsed_url.port}"
+
+                        # Construct new URL with IP
+                        request_url = urllib.parse.urlunparse(
+                            (
+                                parsed_url.scheme,
+                                netloc,
+                                parsed_url.path,
+                                parsed_url.params,
+                                parsed_url.query,
+                                parsed_url.fragment,
+                            )
+                        )
+                        headers["Host"] = parsed_url.hostname
+                        logger.debug(
+                            f"Using pinned IP {safe_ip} for HTTP request to {parsed_url.hostname}"
+                        )
+
+                    response = await client.get(
+                        request_url,
+                        headers=headers,
+                        follow_redirects=False,
+                        timeout=30.0,
+                    )
 
                     if 300 <= response.status_code < 400:
                         location = response.headers.get("Location")
@@ -633,7 +690,9 @@ class FileProcessor:
                         current_url = urllib.parse.urljoin(current_url, location)
                         parsed_redirect = urllib.parse.urlparse(current_url)
                         # Sanitize redirect URL for logging
-                        logger.info(f"Following redirect to: {parsed_redirect.scheme}://{parsed_redirect.hostname}{parsed_redirect.path}")
+                        logger.info(
+                            f"Following redirect to: {parsed_redirect.scheme}://{parsed_redirect.hostname}{parsed_redirect.path}"
+                        )
                         continue
                     else:
                         break

--- a/backend/src/tests/unit/test_file_processor.py
+++ b/backend/src/tests/unit/test_file_processor.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 def file_processor():
     """Pytest fixture to provide a FileProcessor instance."""
     fp = FileProcessor()
-    # Mock _is_safe_url to always return True by default for existing tests to avoid network calls
-    fp._is_safe_url = mock.AsyncMock(return_value=True)
+    # Mock _resolve_safe_ip to always return a safe IP by default
+    fp._resolve_safe_ip = mock.AsyncMock(return_value="93.184.216.34")
     return fp
 
 
@@ -94,12 +94,14 @@ class TestFileProcessor:
         assert expected_file_path.read_bytes() == b"file content"
 
         # Check call arguments. Note: follow_redirects is now False due to manual handling
-        # But wait, we mocked _is_safe_url, so the loop runs.
+        # But wait, we mocked _resolve_safe_ip, so the loop runs.
         # The loop calls client.get(..., follow_redirects=False).
 
-        # Verify that get was called with follow_redirects=False
+        # Verify that get was called with rewritten URL (using IP) and Host header
+        expected_url = "http://93.184.216.34/download.zip"
+        expected_headers = {"Host": "example.com"}
         MockAsyncClient.return_value.__aenter__.return_value.get.assert_called_with(
-            url, follow_redirects=False, timeout=30.0
+            expected_url, headers=expected_headers, follow_redirects=False, timeout=30.0
         )
 
     @pytest.mark.asyncio
@@ -311,45 +313,107 @@ class TestFileProcessor:
 
     @pytest.mark.asyncio
     @mock.patch("file_processor.socket.getaddrinfo")
-    async def test_is_safe_url_public_ip(self, mock_getaddrinfo, temp_job_dirs):
-        """Test _is_safe_url with a public IP."""
+    async def test_resolve_safe_ip_public_ip(self, mock_getaddrinfo, temp_job_dirs):
+        """Test _resolve_safe_ip with a public IP."""
         fp = FileProcessor() # Use real instance, not mocked fixture
 
         # Mock public IP for example.com
         mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))]
 
-        result = await fp._is_safe_url("http://example.com/file.zip")
-        assert result is True
+        result = await fp._resolve_safe_ip("http://example.com/file.zip")
+        assert result == "93.184.216.34"
 
     @pytest.mark.asyncio
     @mock.patch("file_processor.socket.getaddrinfo")
-    async def test_is_safe_url_private_ip(self, mock_getaddrinfo, temp_job_dirs):
-        """Test _is_safe_url blocks private IP."""
+    async def test_resolve_safe_ip_private_ip(self, mock_getaddrinfo, temp_job_dirs):
+        """Test _resolve_safe_ip blocks private IP."""
         fp = FileProcessor()
 
         # Mock private IP
         mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('192.168.1.1', 80))]
 
-        result = await fp._is_safe_url("http://internal.com/secret.zip")
-        assert result is False
+        result = await fp._resolve_safe_ip("http://internal.com/secret.zip")
+        assert result is None
 
     @pytest.mark.asyncio
     @mock.patch("file_processor.socket.getaddrinfo")
-    async def test_is_safe_url_loopback_ip(self, mock_getaddrinfo, temp_job_dirs):
-        """Test _is_safe_url blocks loopback IP."""
+    async def test_resolve_safe_ip_loopback_ip(self, mock_getaddrinfo, temp_job_dirs):
+        """Test _resolve_safe_ip blocks loopback IP."""
         fp = FileProcessor()
 
         # Mock loopback IP
         mock_getaddrinfo.return_value = [(socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80))]
 
-        result = await fp._is_safe_url("http://localhost/config")
-        assert result is False
+        result = await fp._resolve_safe_ip("http://localhost/config")
+        assert result is None
 
     @pytest.mark.asyncio
-    async def test_is_safe_url_bad_scheme(self, temp_job_dirs):
+    async def test_resolve_safe_ip_bad_scheme(self, temp_job_dirs):
         fp = FileProcessor()
-        result = await fp._is_safe_url("ftp://example.com/file.zip")
-        assert result is False
+        result = await fp._resolve_safe_ip("ftp://example.com/file.zip")
+        assert result is None
+
+    @pytest.mark.asyncio
+    @mock.patch("file_processor.httpx.AsyncClient")
+    async def test_download_http_uses_ip_pinning(
+        self, MockAsyncClient, file_processor, mock_job_id
+    ):
+        """Test that HTTP requests use the pinned IP and Host header."""
+        # Setup mock
+        mock_response = mock.AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/zip"}
+        mock_response.url = httpx.URL("http://example.com/file.zip")
+        # Need a generator for aiter_bytes
+        async def mock_iter():
+            yield b"content"
+        mock_response.aiter_bytes = mock_iter
+
+        MockAsyncClient.return_value.__aenter__.return_value.get.return_value = mock_response
+
+        # Call
+        url = "http://example.com/file.zip"
+        await file_processor.download_from_url(url, mock_job_id)
+
+        # Verify
+        # Expected URL uses the mocked IP "93.184.216.34"
+        expected_url = "http://93.184.216.34/file.zip"
+        expected_headers = {"Host": "example.com"}
+
+        MockAsyncClient.return_value.__aenter__.return_value.get.assert_called_with(
+            expected_url, headers=expected_headers, follow_redirects=False, timeout=30.0
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch("file_processor.httpx.AsyncClient")
+    async def test_download_https_preserves_hostname(
+        self, MockAsyncClient, file_processor, mock_job_id
+    ):
+        """Test that HTTPS requests use the original hostname (no IP pinning)."""
+        # Setup mock
+        mock_response = mock.AsyncMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/zip"}
+        mock_response.url = httpx.URL("https://example.com/file.zip")
+        async def mock_iter():
+            yield b"content"
+        mock_response.aiter_bytes = mock_iter
+
+        MockAsyncClient.return_value.__aenter__.return_value.get.return_value = mock_response
+
+        # Call
+        url = "https://example.com/file.zip"
+        await file_processor.download_from_url(url, mock_job_id)
+
+        # Verify
+        # Expected URL uses original hostname
+        expected_url = "https://example.com/file.zip"
+        # Headers should be empty (default)
+        expected_headers = {}
+
+        MockAsyncClient.return_value.__aenter__.return_value.get.assert_called_with(
+            expected_url, headers=expected_headers, follow_redirects=False, timeout=30.0
+        )
 
 
     # --- Tests for validate_downloaded_file ---


### PR DESCRIPTION
Fixed a Time-of-Check Time-of-Use (TOCTOU) vulnerability in `FileProcessor.download_from_url` that allowed DNS Rebinding attacks.

Changes:
- Refactored `_is_safe_url` to `_resolve_safe_ip`, returning the validated IP address instead of a boolean.
- Updated `download_from_url` to use the resolved safe IP for HTTP requests, effectively pinning the DNS resolution and preventing the race condition.
- For HTTPS requests, the original hostname is preserved to ensure proper TLS SNI and certificate verification, relying on TLS protections against rebinding to internal non-TLS services.
- Updated unit tests to mock `_resolve_safe_ip` and verify that HTTP requests use the pinned IP while HTTPS requests use the hostname.

---
*PR created automatically by Jules for task [16494019161034462748](https://jules.google.com/task/16494019161034462748) started by @anchapin*