### PR TITLE
🎨 Palette: Improve focus management after file removal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-18 - Accessibility for Expandable Content
 **Learning:** Adding `aria-expanded` and `aria-controls` to toggle buttons is crucial for screen readers to understand the relationship between the button and the content it reveals.
 **Action:** When implementing show/hide functionality, always verify that the trigger element has these attributes.
+
+## 2026-02-24 - Focus Management on DOM Removal
+**Learning:** When an interactive element (like a "Remove" button) is removed from the DOM, focus is lost to the `body`, disorienting keyboard users.
+**Action:** Implement focus restoration logic using `useEffect` and `useRef` to move focus to a logical fallback element (e.g., the "Upload" button) immediately after the element is unmounted.

--- a/.factory/tasks.md
+++ b/.factory/tasks.md
@@ -7,7 +7,8 @@
 - None
 
 ## Completed
-- None
+- ✅ Implement focus management for file removal in ConversionUploadEnhanced component
+- ✅ Verify focus management with tests
 
 ---
-*Last updated: 2025-11-10*
+*Last updated: 2026-02-24*

--- a/frontend/src/components/ConversionUpload/ConversionUploadEnhanced.test.tsx
+++ b/frontend/src/components/ConversionUpload/ConversionUploadEnhanced.test.tsx
@@ -142,4 +142,33 @@ describe('ConversionUploadEnhanced Accessibility', () => {
         expect(spinner).toHaveAttribute('aria-hidden', 'true');
     });
   });
+
+  test('Focus moves to Browse Files button after removing a file', async () => {
+    const user = userEvent.setup();
+    render(<ConversionUploadEnhanced />);
+
+    // Upload a file
+    const file = new File(['dummy content'], 'test-mod.jar', { type: 'application/java-archive' });
+    const fileInput = screen.getByLabelText(/file upload/i);
+    await user.upload(fileInput, file);
+
+    // Wait for the file preview to appear
+    await waitFor(() => {
+      expect(screen.getByText('test-mod.jar')).toBeInTheDocument();
+    });
+
+    // Find the remove button
+    const removeButton = screen.getByText('✕').closest('button');
+
+    // Click remove
+    fireEvent.click(removeButton!);
+
+    // Wait for browse button
+    const browseButton = await screen.findByText('Browse Files');
+
+    // Check focus
+    await waitFor(() => {
+      expect(document.activeElement).toBe(browseButton.closest('button'));
+    });
+  });
 });

--- a/frontend/src/components/ConversionUpload/ConversionUploadEnhanced.tsx
+++ b/frontend/src/components/ConversionUpload/ConversionUploadEnhanced.tsx
@@ -67,6 +67,19 @@ export const ConversionUploadEnhanced: React.FC<ConversionUploadProps> = ({
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isMountedRef = useRef(true);
 
+  // Focus management refs
+  const browseButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFileRef = useRef<File | null>(null);
+
+  // Focus management effect
+  useEffect(() => {
+    // If a file was previously selected and now it's null (removed), focus the browse button
+    if (previousFileRef.current && !selectedFile) {
+      browseButtonRef.current?.focus();
+    }
+    previousFileRef.current = selectedFile;
+  }, [selectedFile]);
+
   // File validation
   const validateFile = useCallback((file: File): { isValid: boolean; error?: string } => {
     if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
@@ -466,6 +479,7 @@ export const ConversionUploadEnhanced: React.FC<ConversionUploadProps> = ({
               <div className="upload-icon-large">☁️</div>
               <h3>Drag & drop your modpack here</h3>
               <button
+                ref={browseButtonRef}
                 type="button"
                 className="browse-button"
                 onClick={(e) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,7 +148,7 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       storybook:
-        specifier: ^10.2.9
+        specifier: ^10.2.10
         version: 10.2.10(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ^5.9.3


### PR DESCRIPTION
💡 What: Added focus restoration to the "Browse Files" button when a file is removed in `ConversionUploadEnhanced`.
🎯 Why: To prevent focus loss to the document body, which disorients keyboard users.
♿ Accessibility: Ensures logical focus flow for keyboard navigation.
Related: Task "Implement focus management for file removal in ConversionUploadEnhanced component".

---
*PR created automatically by Jules for task [2123200920263583739](https://jules.google.com/task/2123200920263583739) started by @anchapin*