### PR TITLE
🎨 Palette: Add accessibility attributes to Settings navigation link

### DIFF
--- a/frontend/src/components/TopNavigation/TopNavigation.tsx
+++ b/frontend/src/components/TopNavigation/TopNavigation.tsx
@@ -24,7 +24,7 @@ export const TopNavigation: React.FC<TopNavigationProps> = ({ className = '' }) 
     { to: '/experiments', label: 'Experiments' },
     { to: '/experiment-results', label: 'Results' },
     { to: '/docs', label: 'Documentation' },
-    { to: '/settings', label: '⚙️' }
+    { to: '/settings', label: '⚙️', ariaLabel: 'Settings', title: 'Settings' }
   ];
 
   return (
@@ -35,11 +35,13 @@ export const TopNavigation: React.FC<TopNavigationProps> = ({ className = '' }) 
         </Link>
         
         <div className="top-navigation__links">
-          {navigationLinks.map(({ to, label }) => (
+          {navigationLinks.map(({ to, label, ariaLabel, title }) => (
             <Link 
               key={to}
               to={to} 
               className={`top-navigation__link ${isActive(to) ? 'top-navigation__link--active' : ''}`}
+              aria-label={ariaLabel}
+              title={title}
             >
               {label}
             </Link>


### PR DESCRIPTION
This PR improves the accessibility and usability of the TopNavigation component by adding an `aria-label` and `title` to the icon-only Settings link (⚙️). 

* 💡 **What:** Added `ariaLabel` and `title` properties to the `/settings` navigation link.
* 🎯 **Why:** Icon-only links lack descriptive text for screen readers (which might otherwise read the raw emoji or be silent) and lack visual context for mouse users on hover.
* ♿ **Accessibility:** This ensures the settings link has an accessible name, satisfying WCAG criteria for non-text content and meaningful links.

---
*PR created automatically by Jules for task [18308072197604231388](https://jules.google.com/task/18308072197604231388) started by @anchapin*