### PR TITLE
🎨 Palette: Add focus visible styles for keyboard navigation to ConversionHistory

### DIFF
--- a/frontend/src/components/ConversionHistory/ConversionHistory.css
+++ b/frontend/src/components/ConversionHistory/ConversionHistory.css
@@ -115,6 +115,11 @@
   border-color: #bdbdbd;
 }
 
+.cancel-btn:focus-visible {
+  outline: 3px solid #9e9e9e;
+  outline-offset: 2px;
+}
+
 /* Action Buttons */
 .delete-selected-btn,
 .clear-all-btn {
@@ -139,6 +144,11 @@
   transform: translateY(-1px);
 }
 
+.delete-selected-btn:focus-visible {
+  outline: 3px solid #ffcc02;
+  outline-offset: 2px;
+}
+
 .clear-all-btn {
   background: #fce4ec;
   color: #c2185b;
@@ -149,6 +159,11 @@
   background: #c2185b;
   color: white;
   transform: translateY(-1px);
+}
+
+.clear-all-btn:focus-visible {
+  outline: 3px solid #f8bbd9;
+  outline-offset: 2px;
 }
 
 /* Error Message */
@@ -260,6 +275,11 @@
   height: 16px;
   cursor: pointer;
   accent-color: #2196f3;
+}
+
+.item-checkbox input[type="checkbox"]:focus-visible {
+  outline: 2px solid #2196f3;
+  outline-offset: 2px;
 }
 
 .item-icon {
@@ -382,6 +402,11 @@
   box-shadow: 0 2px 4px rgba(76, 175, 80, 0.3);
 }
 
+.download-btn:focus-visible {
+  outline: 3px solid #81c784;
+  outline-offset: 2px;
+}
+
 .delete-btn {
   background: #fce4ec;
   color: #c2185b;
@@ -393,6 +418,11 @@
   color: white;
   transform: translateY(-1px);
   box-shadow: 0 2px 4px rgba(233, 30, 99, 0.3);
+}
+
+.delete-btn:focus-visible {
+  outline: 3px solid #f48fb1;
+  outline-offset: 2px;
 }
 
 /* Responsive Design */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,7 +148,7 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1
       storybook:
-        specifier: ^10.2.9
+        specifier: ^10.2.10
         version: 10.2.10(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ^5.9.3


### PR DESCRIPTION
💡 What: Added `:focus-visible` styles to all interactive elements within the `ConversionHistory` component, including the download, delete, clear all, cancel, and delete selected buttons, as well as the item selection checkboxes.
🎯 Why: Keyboard users previously lacked clear visual indicators of which button or checkbox had focus, making keyboard navigation through the history list very difficult to track.
📸 Before/After: Verified via Playwright screenshot (`focus-download.png`).
♿ Accessibility: Ensures WCAG compliance for focus visibility (2.4.7 Focus Visible) without impacting the visual experience for pointer (mouse) users.

---
*PR created automatically by Jules for task [16626595364072644281](https://jules.google.com/task/16626595364072644281) started by @anchapin*