### PR TITLE
⚡ Bolt: Memoize ReportSummary to reduce re-renders

### DIFF
--- a/frontend/src/components/ConversionReport/ReportSummary.tsx
+++ b/frontend/src/components/ConversionReport/ReportSummary.tsx
@@ -3,7 +3,7 @@
  * Part of Issue #10 - Conversion Report Generation System
  */
 
-import React from 'react';
+import React, { memo } from 'react';
 import type { SummaryReport } from '../../types/api';
 import styles from './ConversionReport.module.css';
 
@@ -144,7 +144,8 @@ const RecommendedActions: React.FC<{ actions: string[] }> = ({ actions }) => {
   );
 };
 
-export const ReportSummary: React.FC<ReportSummaryProps> = ({ summary }) => {
+// PERFORMANCE OPTIMIZATION: Memoize ReportSummary to prevent unnecessary re-renders when parent component updates other state
+export const ReportSummary: React.FC<ReportSummaryProps> = memo(({ summary }) => {
   const {
     overall_success_rate,
     total_features,
@@ -257,4 +258,6 @@ export const ReportSummary: React.FC<ReportSummaryProps> = ({ summary }) => {
       <RecommendedActions actions={recommended_actions || []} />
     </div>
   );
-};
+});
+
+ReportSummary.displayName = 'ReportSummary';


### PR DESCRIPTION
💡 What: Wrapped `ReportSummary` component in `React.memo()`.
🎯 Why: `ReportSummary` receives a large prop (`summary`) and renders complex UI (charts, metrics, lists). It is a child of `EnhancedConversionReport`, which frequently updates state (e.g., expanding/collapsing sections, filtering logs). Memoizing `ReportSummary` prevents it from re-rendering on every parent state change that doesn't affect the summary data.
📊 Impact: Reduces unnecessary React re-renders of the entire summary section (including charts and multiple child components) when interacting with other parts of the conversion report.
🔬 Measurement: Use React Profiler to verify that `ReportSummary` does not re-render when toggling "Expand All" / "Collapse All" or navigating sections in `EnhancedConversionReport`.

---
*PR created automatically by Jules for task [8311757739368006651](https://jules.google.com/task/8311757739368006651) started by @anchapin*