### PR TITLE
fix: Fix Mutation Testing Python failures in CI (#719)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -812,7 +812,7 @@ jobs:
         cd ${{ matrix.project }}
         
         # Configure mutmut for the project
-        printf '[mutmut]\nruns = 2\nspawn_strategy = 2\nno_progress = 1\ndisable_git_diff = 1\n' > .mutmut.toml
+        printf '[mutmut]\ntest_command = python -m pytest\nno_progress = 1\ndisable_git_diff = 1\n' > .mutmut.toml
 
         # Run mutation tests
         mutmut run

--- a/ai-engine/pyproject.toml
+++ b/ai-engine/pyproject.toml
@@ -59,6 +59,9 @@ ignore = [
 known-first-party = ["src"]
 force-single-line = false
 
+[tool.mutmut]
+paths_to_mutate = ["src"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = false


### PR DESCRIPTION
## Summary

Fixes issue #719 - Mutation Testing Python failures in CI.

## Changes

1. **CI Workflow ():**
   - Added  to the mutmut configuration
   - This tells mutmut how to run tests for mutation testing

2. **AI Engine ():**
   - Added  section with 
   - The ai-engine was missing this configuration, which is needed for mutmut to work properly

## Root Cause

The mutation testing jobs were failing because:
1. Missing  in mutmut configuration - mutmut didn't know how to run the test suite
2. ai-engine was missing the  section in pyproject.toml

## Testing

These changes should allow the mutation testing jobs to run successfully in CI for both backend and ai-engine projects.