### PR TITLE
fix: Frontend Lint failing on main (#746)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,7 +731,7 @@ jobs:
             ;;
           "lint")
             # Clear node_modules/.cache to fix zod-validation-error export issue
-            rm -rf frontend/node_modules/.cache
+            rm -rf node_modules/.cache
             # Run linting
             npm run lint
             ;;


### PR DESCRIPTION
## Summary

The cache clear command in the lint step was using an incorrect path.

## Root Cause

In the CI workflow's lint step, after  is executed, the current directory is already . The command  was trying to find a non-existent directory at , so the cache was never actually being cleared.

## Fix

Changed  to  since we're already in the frontend directory when this command runs.

## Testing

- Local lint runs successfully
- The fix targets the correct path in CI

## Summary by Sourcery

CI:
- Update lint workflow step to remove node_modules cache from the current frontend working directory instead of a non-existent nested path.