### PR TITLE
fix: Mutation Testing still failing on main (#748)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,10 +819,11 @@ jobs:
         printf '[mutmut]\ntest_command = python -m pytest\nno_progress = 1\ndisable_git_diff = 1\n' > .mutmut.toml
 
         # Run mutation tests
-        mutmut run
+        # Using || true to prevent step failure from blocking threshold check
+        mutmut run || true
         
-        # Show results
-        mutmut results
+        # Show results - || true to prevent exit code 1 from unchecked mutations
+        mutmut results || true
 
     - name: Check mutation testing threshold
       run: |


### PR DESCRIPTION
## Summary

This PR addresses issue #748 where mutation testing jobs were continuing to fail on the main branch even after the structlog fix in PR #738.

## Root Cause

The previous fix (#738) only addressed the "Check mutation testing threshold" step by adding `|| true` to the `mutmut results` command. However, the **"Run mutation testing"** step was still failing because:

1. `mutmut run` can return exit code 1 when mutations fail or timeout
2. `mutmut results` can return exit code 1 when there are unchecked mutations

When these commands fail in the "Run mutation testing" step, the entire step fails immediately, preventing the "Check mutation testing threshold" step from ever running.

## Fix

This fix adds `|| true` to both `mutmut run` and `mutmut results` commands in the "Run mutation testing" step to ensure:

1. The step always passes regardless of mutation test results
2. The threshold check step can run and complete the mutation testing process
3. Mutation testing results are still collected and displayed in CI logs

This ensures mutation testing runs gracefully in CI without blocking deployments due to false failures.

## Testing

The fix has been verified by examining the CI workflow and ensuring the commands will no longer cause step failures.

Co-authored-by: openhands <openhands@all-hands.dev>