### PR TITLE
feat: Add metrics collection (#697)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -74,7 +74,7 @@ from services.report_generator import (
     MOCK_CONVERSION_RESULT_SUCCESS,
     MOCK_CONVERSION_RESULT_FAILURE,
 )
-from services.metrics import get_metrics
+from services.metrics import get_metrics, MetricsMiddleware
 from services.structured_logging import configure_structlog
 
 # Configure logging
@@ -174,6 +174,9 @@ app.add_middleware(SecurityHeadersMiddleware)
 # Request/Response Logging Middleware
 app.add_middleware(LoggingMiddleware)
 app.add_middleware(RequestContextMiddleware)
+
+# Metrics Middleware for Prometheus
+app.add_middleware(MetricsMiddleware)
 
 
 @app.on_event("startup")
@@ -1523,6 +1526,14 @@ async def export_addon_mcaddon(addon_id: PyUUID, db: AsyncSession = Depends(get_
 
 
 # Metrics endpoint for Prometheus scraping
+@app.get("/metrics", tags=["monitoring"])
+async def prometheus_metrics():
+    """
+    Prometheus metrics endpoint (standard path).
+    """
+    return Response(content=get_metrics(), media_type="text/plain")
+
+
 @app.get("/api/v1/metrics", tags=["monitoring"])
 async def metrics():
     """


### PR DESCRIPTION
## Summary

Implements Prometheus metrics collection for system monitoring as requested in issue #697.

### Changes Made

1. **Added Prometheus Metrics Middleware**
   - Imported  from the existing metrics service
   - Integrated middleware into FastAPI application
   - Automatically records HTTP request metrics (count, duration, status codes)

2. **Added Metrics Endpoints**
   -  - Standard Prometheus scraping endpoint
   -  - Backwards compatible endpoint

### Key Metrics Defined

The existing metrics service already defines comprehensive metrics for all services:

- **HTTP Metrics**: Request counts, response times by endpoint
- **Conversion Metrics**: Job counts, duration, queue size, active conversions
- **Agent Metrics**: Execution counts and duration
- **Token/Cost Metrics**: LLM token usage and API costs
- **Asset Metrics**: Assets processed and conversion times
- **Database Metrics**: Operation duration by table
- **Cache Metrics**: Hit/miss operations
- **Business Metrics**: Success rates, average conversion times
- **Error Metrics**: Error counts by category
- **Rate Limiting Metrics**: Hits, requests, and active clients

### Testing

- Syntax validation passed
- Changes are minimal and focused on enabling the existing metrics infrastructure

Closes #697