### PR TITLE
fix: Correct structlog processor order for exception handling

### DIFF
--- a/ai-engine/utils/logging_config.py
+++ b/ai-engine/utils/logging_config.py
@@ -58,24 +58,23 @@ def configure_structlog(
     log_dir = os.getenv("LOG_DIR", "/tmp/modporter-ai/logs")
     
     # Configure processors based on format
+    # Order matters: context merging -> logger info -> level -> timestamper -> exception handling -> renderer
     processors = [
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
     ]
-    
+
     if debug_mode:
         processors.append(structlog.dev.ConsoleRenderer())
     elif json_format:
         processors.append(structlog.processors.JSONRenderer())
     else:
         processors.append(structlog.dev.ConsoleRenderer(colors=False))
-    
-    # Add exception info processor
-    processors.append(structlog.processors.StackInfoRenderer())
-    processors.append(structlog.processors.format_exc_info)
     
     # Configure structlog
     structlog.configure(

--- a/backend/src/services/structured_logging.py
+++ b/backend/src/services/structured_logging.py
@@ -56,12 +56,15 @@ def configure_structlog(
     log_dir = os.getenv("LOG_DIR", "/var/log/modporter")
 
     # Configure processors based on format
+    # Order matters: context merging -> logger info -> level -> timestamper -> exception handling -> renderer
     processors = [
         structlog.contextvars.merge_contextvars,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
         TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
     ]
 
     if debug_mode:
@@ -70,10 +73,6 @@ def configure_structlog(
         processors.append(JSONRenderer())
     else:
         processors.append(structlog.dev.ConsoleRenderer(colors=False))
-
-    # Add exception info processor
-    processors.append(structlog.processors.StackInfoRenderer())
-    processors.append(structlog.processors.format_exc_info)
 
     # Configure structlog
     structlog.configure(


### PR DESCRIPTION
## Summary

This PR fixes a bug in the structlog configuration that was causing an AttributeError when trying to log exceptions.

## Problem

The StackInfoRenderer and format_exc_info processors were being added AFTER the renderer in the processor list. This caused structlog to pass a string event to these processors instead of a dictionary, resulting in the error.

## Solution

Reordered the processors so that exception handling happens before the renderer.

## Changes

- backend/src/services/structured_logging.py: Fixed processor order
- ai-engine/utils/logging_config.py: Fixed processor order

## Testing

Verified that:
- Backend structured logging works in debug mode
- Backend structured logging works in JSON/production mode
- AI engine structured logging works in debug mode
- AI engine structured logging works in JSON/production mode
- Correlation ID support works

## Related Issue

- Fixes #695 (Add structured logging)
