### PR TITLE
fix: Correct container image logic in CI workflow (Issue #772)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,9 @@ jobs:
             test-path: 'ai-engine/tests/integration/test_imports.py'
             container-name: 'ai-engine-test'
 
-    # Use Python base image if available, fallback to setup-python
+    # Use Python base image only when dependencies changed, otherwise use runner's Python
     container:
-      image: ${{ needs.prepare-base-images.outputs.should-build == 'false' && needs.prepare-base-images.outputs.python-image || '' }}
+      image: ${{ needs.prepare-base-images.outputs.python-image }}
       options: --name test-container-${{ matrix.test-suite }} --user root
 
     services:


### PR DESCRIPTION
## Summary\n\nFixes the inverted logic bug in  that was causing Dependabot PRs to fail with base image issues.\n\n### Root Cause\n\nThe container image selection had inverted logic at line 191:\n\n\n\nThis meant:\n- When  (image already exists): uses the  ✓\n- When  (image was just built): uses empty string ✗\n\n### Fix\n\nChanged to simply use the  output directly:\n\n\n\nThis works correctly because:\n- When dependencies change:  runs →  has value → uses the base image ✓\n- When dependencies NOT changed:  is skipped →  is empty → GitHub Actions uses runner's default Python ✓\n\nCloses #772