### PR TITLE
fix: Fix ConversionUpload.test.tsx URL validation tests (#783)

### DIFF
--- a/frontend/src/utils/urlParser.ts
+++ b/frontend/src/utils/urlParser.ts
@@ -33,7 +33,7 @@ export function parseModUrl(url: string): ParsedModURL {
 
   // Try CurseForge patterns
   const curseforgePatterns = [
-    /(?:https?:\/\/)?(?:www\.)?curseforge\.com\/minecraft\/mods\/([^/?]+)/i,
+    /(?:https?:\/\/)?(?:www\.)?curseforge\.com\/minecraft\/(?:mc-)?mods\/([^/?]+)/i,
     /(?:https?:\/\/)?(?:www\.)?curseforge\.com\/minecraft\/modpacks\/([^/?]+)/i, // Modpacks
   ];
 


### PR DESCRIPTION
## Summary
Fixed the failing URL validation test in ConversionUpload.test.tsx by updating the URL parser regex pattern to support both `/minecraft/mods/` and `/minecraft/mc-mods/` CurseForge URL formats.

## Problem
The test "accepts valid CurseForge URLs" was failing because the URL parser regex only matched URLs like:
- `https://www.curseforge.com/minecraft/mods/example-mod`

But not the equally valid format:
- `https://www.curseforge.com/minecraft/mc-mods/example-mod`

While the domain validation passed (curseforge.com is a supported domain), the path validation failed, causing the component to show "Invalid URL - Supported: CurseForge, Modrinth" for valid URLs.

## Solution
Updated the regex pattern in `frontend/src/utils/urlParser.ts` to make the `mc-` prefix optional:
- Changed: `/minecraft\/mods\/([^/?]+)/`
- To: `/minecraft\/(?:mc-)?mods\/([^/?]+)/`

This allows both URL formats to be correctly recognized as valid CurseForge URLs.

## Testing
All 11 tests in ConversionUpload.test.tsx now pass:
- ✓ validates URL types according to PRD specs
- ✓ accepts valid CurseForge URLs (previously failing)

Closes #783