### PR TITLE
fix: Replace invalid coalesce() with || operator in CI workflow (#771)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
     # Use Python base image only when dependencies changed and prepare-base-images has an image
     # When dependencies haven't changed, use the default python image
     container:
-      image: ${{ coalesce(needs.prepare-base-images.outputs.python-image, 'python:3.11-slim') }}
+      image: ${{ needs.prepare-base-images.outputs.python-image || 'python:3.11-slim' }}
       options: --name test-container-${{ matrix.test-suite }} --user root
 
     services:


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions CI workflow failure caused by using the unsupported  function.

## Problem
The workflow was failing with:


GitHub Actions does NOT support the  function.

## Fix
Changed line 213 in  from:

to:


Using  is the standard YAML/GitHub Actions fallback operator.

## Testing
- Integration tests pass locally: 5 passed, 8 skipped