### PR TITLE
fix: Make docker-publish.yml compatible with act CLI (#837)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,19 +31,15 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request' && !env.ACT
+        if: github.event_name != 'pull_request' && ${{ !env.ACT }}
         uses: docker/login-action@v4
-        env:
-          ACT: ${{ env.ACT }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request' && !env.ACT
+        if: github.event_name != 'pull_request' && ${{ !env.ACT }}
         uses: docker/login-action@v4
-        env:
-          ACT: ${{ env.ACT }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
This PR fixes GitHub issue #837 by making the docker-publish.yml workflow compatible with the local act CLI execution.

## Problem
The act CLI fails to parse workflows that use secrets in certain ways. Error message:
```
workflow is not valid. 'docker-publish.yml': Line: 9 Column: 5
Failed to match job-factory: Line: 33 Column: 9
Unknown Variable Access secrets
```

## Changes Made
1. Changed `!env.ACT` to `${{ !env.ACT }}` to use proper GitHub Actions expression syntax
2. Removed unnecessary `env:` sections that mapped ACT to itself
3. The Docker login steps will now be skipped when running locally via act CLI

## Testing
- The workflow can be tested locally using: `act release -W .github/workflows/docker-publish.yml`
- The login steps will be automatically skipped when running via act CLI since the secrets are not available locally

Closes #837