### PR TITLE
fix: Batch consolidate PRs #879, #882, #883

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - '**/requirements*.txt'
       - '**/package.json'
+      - 'package-lock.json'
       - 'pnpm-lock.yaml'
       - 'docker/base-images/**'
 
@@ -190,7 +191,7 @@ jobs:
     - name: Extract Node dependencies hash
       id: deps-hash
       run: |
-        HASH=$(sha256sum frontend/pnpm-lock.yaml | cut -d' ' -f1 | head -c16)
+        HASH=$(sha256sum frontend/package-lock.json | cut -d' ' -f1 | head -c16)
         echo "hash=$HASH" >> $GITHUB_OUTPUT
         echo "Node deps hash: $HASH"
     

--- a/docker/base-images/Dockerfile.node-base
+++ b/docker/base-images/Dockerfile.node-base
@@ -1,19 +1,16 @@
 # Node.js Base Image with Pre-installed Dependencies
-# Built weekly or when package.json/pnpm-lock.yaml changes
+# Built weekly or when package.json/package-lock.json changes
 
 FROM node:20-slim
 
 # Create app directory
 WORKDIR /app
 
-# Install pnpm first
-RUN npm install -g pnpm
-
 # Copy package files
-COPY package.json pnpm-lock.yaml* ./
+COPY package.json package-lock.json* ./
 
 # Install dependencies
-RUN pnpm install --prod --ignore-scripts && pnpm store prune
+RUN npm install --prod --ignore-scripts
 
 # Create app user
 RUN adduser --disabled-password --gecos '' appuser && \


### PR DESCRIPTION
## Summary

This PR consolidates fixes from three previously conflicting PRs into a single merged PR.

## Consolidated Fixes

### From PR #879 (act CLI workflow compatibility)
- Adds  configuration for local GitHub Actions execution

### From PR #882 (Build Base Images workflow fix)
- Fixes  to use npm instead of pnpm (frontend uses npm, not pnpm)
- Updates  to use  instead of 
- Adds  to workflow trigger paths

### From PR #883 (CI workflow rebase)
- Workflow compatibility updates

## Changes Made

1. **docker/base-images/Dockerfile.node-base**:
   - Removed pnpm installation
   - Changed from  to 
   - Changed from Scope: all 2 workspace projects
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +230 -46
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------

   ╭──────────────────────────────────────────╮
   │                                          │
   │   Update available! 10.30.3 → 10.32.1.   │
   │   Changelog: https://pnpm.io/v/10.32.1   │
   │     To update, run: pnpm self-update     │
   │                                          │
   ╰──────────────────────────────────────────╯

Progress: resolved 230, reused 229, downloaded 0, added 224, done
.../node_modules/msw postinstall$ node -e "import('./config/scripts/postinstall.js').catch(() => void 0)"
.../node_modules/msw postinstall: Done

devDependencies:
+ @commitlint/cli 19.8.1
+ @commitlint/config-conventional 19.8.1
+ husky 9.1.7
+ jscpd 3.5.10

. prepare$ husky install
. prepare: husky - install command is DEPRECATED
. prepare: Done
╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: unrs-resolver@1.11.1.                                             │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
Done in 1.6s using pnpm v10.30.3 to 

2. **.github/workflows/build-base-images.yml**:
   - Changed Node deps hash calculation from  to 
   - Added  to trigger paths

3. **.actrc**:
   - Already present (no changes needed)

## Testing

- Workflow files are syntactically valid
- Build-base-images workflow should now correctly trigger on frontend package changes

Closes #837
Closes #859
Closes #836

## Summary by Sourcery

Consolidate CI workflow and Docker base image adjustments to align Node dependency handling with the frontend’s npm setup and ensure correct workflow triggering.

Bug Fixes:
- Fix mismatch between CI Node dependency hashing and the frontend’s actual npm lockfile, preventing incorrect cache behavior or missed rebuilds.

Build:
- Update the build-base-images GitHub Actions workflow to hash frontend/package-lock.json instead of pnpm-lock.yaml for Node dependency cache keys and include package-lock.json in the workflow trigger paths.

CI:
- Align the build-base-images workflow configuration with the frontend’s use of npm by switching dependency hashing to package-lock.json and updating paths that trigger the workflow.