### PR TITLE
fix: resolve circuit breaker deadlock and N818 docstring error

### DIFF
--- a/ai-engine/utils/error_recovery.py
+++ b/ai-engine/utils/error_recovery.py
@@ -119,7 +119,7 @@ class CircuitBreaker:
         self._success_count = 0
         self._last_failure_time: Optional[float] = None
         self._half_open_calls = 0
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()  # Use RLock for reentrant locking
 
         logger.info(
             f"CircuitBreaker '{name}' initialized: fail_max={fail_max}, reset_timeout={reset_timeout}s"
@@ -154,7 +154,7 @@ class CircuitBreaker:
             Function result
 
         Raises:
-            CircuitBreakerError: If circuit is open
+            CircuitBreakerOpenError: If circuit is open
         """
         with self._lock:
             current_state = self.state


### PR DESCRIPTION
## Summary

- Change threading.Lock() to threading.RLock() to prevent deadlock when call() method accesses self.state while already holding the lock
- Fix docstring: CircuitBreakerError -> CircuitBreakerOpenError

## Test Plan
- Verify circuit breaker functionality with existing tests
- Verify import works without errors

Co-Authored-By: Mastra Code (openrouter/minimax/minimax-m2.5:free) <noreply@mastra.ai>

## Summary by Sourcery

Prevent circuit breaker deadlocks and correct its documented error type.

Bug Fixes:
- Use a reentrant lock in the circuit breaker to avoid deadlocks when accessing state while already holding the lock.
- Update the circuit breaker docstring to reference the correct CircuitBreakerOpenError exception type.