### PR TITLE
🛡️ Sentinel: [HIGH] Remove insecure secret retrieval from environment variables

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,8 @@
 **Vulnerability:** The application used a hardcoded fallback secret key (`"dev-secret-key-do-not-use-in-production-change-me"`) for JWT token generation and validation if the `SECRET_KEY` environment variable was missing.
 **Learning:** Hardcoded cryptographic secrets are a severe vulnerability (CWE-798). If the environment variable isn't set properly, the application falls back to an insecure, easily guessable default in production, compromising all tokens.
 **Prevention:** Never use default fallback values for cryptographic secrets. When removing hardcoded cryptographic secrets to use environment variables, ensure the application fails securely (e.g., raises a `ValueError`) if the variable is unset, rather than falling back to an insecure default. For testing, set dummy values in `conftest.py` before application imports.
+
+## 2025-04-05 - Remove insecure secret retrieval from environment variables
+**Vulnerability:** Retrieving API keys directly from `os.getenv` instead of using the centralized secrets management solution.
+**Learning:** Hardcoded environment variables don't support dynamic rotation, centralized security management (AWS Secrets Manager, Vault, etc), and potentially risk exposure if `.env` files are accidentally committed or logged. Using `core.secrets.get_secret()` allows transparent migration to secure vaults.
+**Prevention:** Always use `get_secret` from `core.secrets` when accessing secrets like API keys or credentials.

--- a/backend/src/services/curseforge_service.py
+++ b/backend/src/services/curseforge_service.py
@@ -9,13 +9,14 @@ import os
 import httpx
 from typing import Optional, Dict, Any
 import logging
+from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
 # CurseForge API configuration
 CURSEFORGE_API_BASE_URL = "https://api.curseforge.com/v1"
 # Note: Requires API key in production - get from https://console.curseforge.com/
-CURSEFORGE_API_KEY = os.getenv("CURSEFORGE_API_KEY", "")
+CURSEFORGE_API_KEY = get_secret("CURSEFORGE_API_KEY", "")
 
 
 class CurseForgeService:

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -7,6 +7,7 @@ SendGrid integration for transactional emails.
 import logging
 from typing import Optional, List, Dict, Any
 from dataclasses import dataclass
+from core.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +284,7 @@ def get_email_service(
     if _email_service is None:
         import os
 
-        api_key = api_key or os.getenv("SENDGRID_API_KEY")
+        api_key = api_key or get_secret("SENDGRID_API_KEY")
 
         if not api_key:
             logger.warning("SendGrid API key not configured. Emails will be logged only.")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Hardcoded environment variables don't support dynamic rotation, centralized security management (AWS Secrets Manager, Vault, etc), and potentially risk exposure if `.env` files are accidentally committed or logged.
🎯 Impact: Using `core.secrets.get_secret()` allows transparent migration to secure vaults.
🔧 Fix: Replaced `os.getenv` with `get_secret` from `core.secrets` when accessing secrets like API keys or credentials.
✅ Verification: Ran `pytest` backend tests to ensure no regressions.

---
*PR created automatically by Jules for task [5917544077159129643](https://jules.google.com/task/5917544077159129643) started by @anchapin*

## Summary by Sourcery

Replace direct environment variable access for external service credentials with centralized secret retrieval to improve security.

Enhancements:
- Use core.secrets.get_secret for CurseForge API key configuration instead of reading from environment variables directly.
- Use core.secrets.get_secret for SendGrid API key retrieval in the email service to align with centralized secret management.

Documentation:
- Document the new security practice of using centralized secret retrieval instead of direct environment variable access in Sentinel security notes.