### PR TITLE
fix: Wire EntityConverter into CLI pipeline (#981)

### DIFF
--- a/ai-engine/agents/bedrock_builder.py
+++ b/ai-engine/agents/bedrock_builder.py
@@ -155,6 +155,113 @@ class BedrockBuilderAgent:
 
         return result
 
+    def build_entity_addon_mvp(
+        self, entities: list, jar_path: str, output_dir: str
+    ) -> Dict[str, Any]:
+        """
+        MVP method to build Bedrock add-on structure for entity-only mods.
+
+        Creates minimal behavior and resource pack manifests when there are
+        no blocks to convert but entities are present.
+
+        Args:
+            entities: List of entity definitions from AST analysis
+            jar_path: Path to source JAR file
+            output_dir: Output directory for pack files
+
+        Returns:
+            Dict with success status and file paths
+        """
+        logger.info(f"MVP: Building entity add-on structure for {len(entities)} entities")
+
+        result = {
+            "success": False,
+            "bp_files": [],
+            "rp_files": [],
+            "errors": [],
+        }
+
+        try:
+            output_path = Path(output_dir)
+            bp_path = output_path / "behavior_pack"
+            rp_path = output_path / "resource_pack"
+            bp_path.mkdir(parents=True, exist_ok=True)
+            rp_path.mkdir(parents=True, exist_ok=True)
+
+            # Extract mod name from JAR filename
+            jar_name = Path(jar_path).stem
+            namespace = jar_name.lower().replace("-", "_").replace(" ", "_")
+
+            # Generate UUIDs for manifests
+            import os
+
+            if os.getenv("TESTING") or os.getenv("PYTEST_CURRENT_TEST"):
+                bp_uuid = "12345678-1234-1234-1234-123456789abc"
+                rp_uuid = "87654321-4321-4321-4321-abcdef123456"
+            else:
+                bp_uuid = str(uuid.uuid4())
+                rp_uuid = str(uuid.uuid4())
+
+            # Create behavior pack manifest
+            bp_manifest = {
+                "format_version": 2,
+                "header": {
+                    "name": f"{namespace} Behavior Pack",
+                    "description": f"Converted entity mod: {namespace}",
+                    "uuid": bp_uuid,
+                    "version": [1, 0, 0],
+                    "min_engine_version": [1, 16, 0],
+                },
+                "modules": [
+                    {
+                        "type": "data",
+                        "uuid": str(uuid.uuid4()) if not (
+                            os.getenv("TESTING") or os.getenv("PYTEST_CURRENT_TEST")
+                        ) else "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                        "version": [1, 0, 0],
+                    }
+                ],
+            }
+            bp_manifest_path = bp_path / "manifest.json"
+            with open(bp_manifest_path, "w", encoding="utf-8") as f:
+                json.dump(bp_manifest, f, indent=2)
+            result["bp_files"].append(str(bp_manifest_path))
+
+            # Create resource pack manifest
+            rp_manifest = {
+                "format_version": 2,
+                "header": {
+                    "name": f"{namespace} Resource Pack",
+                    "description": f"Converted entity mod resources: {namespace}",
+                    "uuid": rp_uuid,
+                    "version": [1, 0, 0],
+                    "min_engine_version": [1, 16, 0],
+                },
+                "modules": [
+                    {
+                        "type": "resources",
+                        "uuid": str(uuid.uuid4()) if not (
+                            os.getenv("TESTING") or os.getenv("PYTEST_CURRENT_TEST")
+                        ) else "ffffffff-gggg-hhhh-iiii-jjjjjjjjjjjj",
+                        "version": [1, 0, 0],
+                    }
+                ],
+            }
+            rp_manifest_path = rp_path / "manifest.json"
+            with open(rp_manifest_path, "w", encoding="utf-8") as f:
+                json.dump(rp_manifest, f, indent=2)
+            result["rp_files"].append(str(rp_manifest_path))
+
+            result["success"] = True
+            result["output_dir"] = str(output_path)
+            logger.info(f"MVP: Created entity add-on structure in {output_path}")
+
+        except Exception as e:
+            logger.error(f"MVP entity build failed: {e}")
+            result["errors"].append(f"Entity build failed: {str(e)}")
+
+        return result
+
     def _build_bp_mvp(
         self, bp_path: Path, namespace: str, block_name: str, bp_uuid: str
     ) -> List[str]:

--- a/modporter/cli/main.py
+++ b/modporter/cli/main.py
@@ -31,6 +31,7 @@ add_ai_engine_to_path()
 from agents.java_analyzer import JavaAnalyzerAgent
 from agents.bedrock_builder import BedrockBuilderAgent
 from agents.packaging_agent import PackagingAgent
+from agents.entity_converter import EntityConverter
 from .fix_ci import CIFixer
 
 # Configure logging
@@ -41,6 +42,13 @@ logger = logging.getLogger(__name__)
 def convert_mod(jar_path: str, output_dir: str = None) -> Dict[str, Any]:
     """
     Convert a Java mod JAR to Bedrock .mcaddon format.
+
+    Supports both block and entity mods. The pipeline:
+    1. Runs block-only MVP analysis (analyze_jar_for_mvp)
+    2. Runs full AST analysis (analyze_jar_with_ast) to detect entities
+    3. Builds block add-on if blocks found
+    4. Converts entities via EntityConverter if entities found
+    5. Packages everything into .mcaddon
 
     Args:
         jar_path: Path to the Java mod JAR file
@@ -67,7 +75,7 @@ def convert_mod(jar_path: str, output_dir: str = None) -> Dict[str, Any]:
 
         logger.info(f"Converting {jar_file.name} to Bedrock add-on...")
 
-        # Step 1: Analyze the JAR file
+        # Step 1: Analyze the JAR file (block-only MVP analysis)
         logger.info("Step 1: Analyzing Java mod...")
         java_analyzer = JavaAnalyzerAgent()
         analysis_result = java_analyzer.analyze_jar_for_mvp(str(jar_file))
@@ -78,6 +86,46 @@ def convert_mod(jar_path: str, output_dir: str = None) -> Dict[str, Any]:
         registry_name = analysis_result.get("registry_name", "unknown_block")
         texture_path = analysis_result.get("texture_path")
 
+        # Step 1b: Run full AST analysis to detect entities and other features
+        logger.info("Step 1b: Running full AST analysis for entity detection...")
+        ast_result = java_analyzer.analyze_jar_with_ast(str(jar_file))
+        entities_found = []
+        entity_textures = []
+        entity_models = []
+
+        if ast_result.get("success", False):
+            features = ast_result.get("features", {})
+            entities_found = features.get("entities", [])
+            assets = ast_result.get("assets", {})
+            # Collect entity-related textures and models
+            entity_textures = [
+                t for t in assets.get("textures", []) if "/textures/entity/" in t
+            ]
+            entity_models = [
+                m for m in assets.get("models", [])
+                if "/models/entity/" in m or "/entity/" in m
+            ]
+
+            if entities_found:
+                logger.info(
+                    f"Found {len(entities_found)} entities: "
+                    f"{[e.get('name', 'unknown') for e in entities_found]}"
+                )
+            else:
+                logger.info("No entities detected in mod")
+
+        has_blocks = registry_name != "unknown_block" or (
+            ast_result.get("success", False)
+            and ast_result.get("features", {}).get("blocks", [])
+        )
+        has_entities = len(entities_found) > 0
+
+        if not has_blocks and not has_entities:
+            raise RuntimeError(
+                "Analysis found no blocks or entities to convert. "
+                "The mod may use unsupported features."
+            )
+
         logger.info(f"Found block: {registry_name}")
         if texture_path:
             logger.info(f"Found texture: {texture_path}")
@@ -87,17 +135,76 @@ def convert_mod(jar_path: str, output_dir: str = None) -> Dict[str, Any]:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             bedrock_builder = BedrockBuilderAgent()
-            build_result = bedrock_builder.build_block_addon_mvp(
-                registry_name=registry_name,
-                texture_path=texture_path,
-                jar_path=str(jar_file),
-                output_dir=temp_dir,
-            )
 
-            if not build_result.get("success", False):
-                raise RuntimeError(
-                    f"Bedrock build failed: {build_result.get('error', 'Unknown error')}"
+            # Build block add-on if blocks were found
+            if has_blocks and registry_name != "unknown_block":
+                build_result = bedrock_builder.build_block_addon_mvp(
+                    registry_name=registry_name,
+                    texture_path=texture_path,
+                    jar_path=str(jar_file),
+                    output_dir=temp_dir,
                 )
+
+                if not build_result.get("success", False):
+                    raise RuntimeError(
+                        f"Bedrock block build failed: "
+                        f"{build_result.get('error', 'Unknown error')}"
+                    )
+            else:
+                # Ensure pack directories exist even without blocks
+                bp_path = Path(temp_dir) / "behavior_pack"
+                rp_path = Path(temp_dir) / "resource_pack"
+                bp_path.mkdir(parents=True, exist_ok=True)
+                rp_path.mkdir(parents=True, exist_ok=True)
+
+                # Create minimal manifests for entity-only mods
+                bedrock_builder.build_entity_addon_mvp(
+                    entities=entities_found,
+                    jar_path=str(jar_file),
+                    output_dir=temp_dir,
+                )
+
+            # Step 2b: Convert entities if found
+            if has_entities:
+                logger.info(f"Step 2b: Converting {len(entities_found)} entities...")
+                entity_converter = EntityConverter()
+
+                # Enrich entity data with texture/model info from AST analysis
+                for entity in entities_found:
+                    entity_name = entity.get("name", "").lower()
+                    entity["textures"] = [
+                        t for t in entity_textures if entity_name in t.lower()
+                    ]
+                    entity["models"] = [
+                        m for m in entity_models if entity_name in m.lower()
+                    ]
+
+                # Convert entities to Bedrock format
+                bedrock_entities = entity_converter.convert_entities(entities_found)
+
+                if bedrock_entities:
+                    # Write entity definitions to the pack directories
+                    bp_path = Path(temp_dir) / "behavior_pack"
+                    rp_path = Path(temp_dir) / "resource_pack"
+                    bp_path.mkdir(parents=True, exist_ok=True)
+                    rp_path.mkdir(parents=True, exist_ok=True)
+
+                    written = entity_converter.write_entities_to_disk(
+                        bedrock_entities, bp_path, rp_path
+                    )
+                    logger.info(
+                        f"Wrote {len(written.get('entities', []))} entity definitions, "
+                        f"{len(written.get('behaviors', []))} behaviors, "
+                        f"{len(written.get('animations', []))} animations"
+                    )
+
+                    # Extract entity textures from JAR to resource pack
+                    _extract_entity_assets(
+                        jar_path=str(jar_file),
+                        entity_textures=entity_textures,
+                        entity_models=entity_models,
+                        rp_path=rp_path,
+                    )
 
             # Step 3: Package as .mcaddon
             logger.info("Step 3: Creating .mcaddon package...")
@@ -105,6 +212,13 @@ def convert_mod(jar_path: str, output_dir: str = None) -> Dict[str, Any]:
 
             # Generate output filename
             mod_name = registry_name.replace(":", "_")  # Replace namespace separator
+            if has_entities and not has_blocks:
+                # For entity-only mods, use the first entity name
+                first_entity = entities_found[0]
+                mod_name = first_entity.get(
+                    "registry_name",
+                    first_entity.get("name", "entity_mod").lower(),
+                )
             output_path = output_dir / f"{mod_name}.mcaddon"
 
             package_result = packaging_agent.build_mcaddon_mvp(
@@ -124,17 +238,73 @@ def convert_mod(jar_path: str, output_dir: str = None) -> Dict[str, Any]:
             "file_size": package_result["file_size"],
             "registry_name": registry_name,
             "validation": package_result["validation"],
+            "entities_converted": len(entities_found) if has_entities else 0,
         }
 
         logger.info("✅ Conversion complete!")
         logger.info(f"📦 Output: {result['output_file']}")
         logger.info(f"📏 Size: {result['file_size']:,} bytes")
+        if has_entities:
+            logger.info(
+                f"🐾 Entities converted: {result['entities_converted']}"
+            )
 
         return result
 
     except Exception as e:
         logger.error(f"❌ Conversion failed: {e}")
         return {"success": False, "error": str(e)}
+
+
+def _extract_entity_assets(
+    jar_path: str,
+    entity_textures: list,
+    entity_models: list,
+    rp_path: Path,
+) -> None:
+    """
+    Extract entity textures and models from the source JAR into the resource pack.
+
+    Args:
+        jar_path: Path to the source JAR file
+        entity_textures: List of texture paths found in the JAR
+        entity_models: List of model paths found in the JAR
+        rp_path: Resource pack output directory
+    """
+    import zipfile
+
+    try:
+        with zipfile.ZipFile(jar_path, "r") as jar:
+            # Extract entity textures
+            textures_dir = rp_path / "textures" / "entity"
+            textures_dir.mkdir(parents=True, exist_ok=True)
+
+            for tex_path in entity_textures:
+                try:
+                    tex_data = jar.read(tex_path)
+                    tex_filename = Path(tex_path).name
+                    output_tex = textures_dir / tex_filename
+                    output_tex.write_bytes(tex_data)
+                    logger.info(f"Extracted entity texture: {tex_filename}")
+                except KeyError:
+                    logger.warning(f"Texture not found in JAR: {tex_path}")
+
+            # Extract entity models
+            models_dir = rp_path / "models" / "entity"
+            models_dir.mkdir(parents=True, exist_ok=True)
+
+            for model_path in entity_models:
+                try:
+                    model_data = jar.read(model_path)
+                    model_filename = Path(model_path).name
+                    output_model = models_dir / model_filename
+                    output_model.write_bytes(model_data)
+                    logger.info(f"Extracted entity model: {model_filename}")
+                except KeyError:
+                    logger.warning(f"Model not found in JAR: {model_path}")
+
+    except Exception as e:
+        logger.warning(f"Failed to extract entity assets: {e}")
 
 
 def main():

--- a/tests/test_entity_cli_integration.py
+++ b/tests/test_entity_cli_integration.py
@@ -1,0 +1,305 @@
+"""
+Tests for entity conversion integration in CLI pipeline.
+Validates that issue #981 fix properly wires EntityConverter into the CLI.
+"""
+
+import json
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _create_entity_jar(jar_path: str) -> None:
+    """Create a mock entity mod JAR with Java source files."""
+    with zipfile.ZipFile(jar_path, "w") as jar:
+        # Add a passive entity Java source file
+        entity_source = """
+package com.example.passivemod;
+
+import net.minecraft.entity.passive.AnimalEntity;
+import net.minecraft.entity.ai.goal.WanderAroundFarGoal;
+import net.minecraft.entity.ai.goal.LookAtEntityGoal;
+import net.minecraft.entity.ai.goal.LookAroundGoal;
+
+public class PassiveEntity extends AnimalEntity {
+    public PassiveEntity() {
+        super(null, null);
+    }
+
+    protected void initGoals() {
+        this.goalSelector.add(1, new WanderAroundFarGoal(this, 1.0));
+        this.goalSelector.add(2, new LookAtEntityGoal(this, null, 6.0F));
+        this.goalSelector.add(3, new LookAroundGoal(this));
+    }
+
+    public PassiveEntity createChild() {
+        return new PassiveEntity();
+    }
+}
+"""
+        jar.writestr(
+            "com/example/passivemod/PassiveEntity.java", entity_source
+        )
+
+        # Add mod registration file
+        mod_source = """
+package com.example.passivemod;
+
+import net.fabricmc.api.ModInitializer;
+import net.minecraft.entity.SpawnGroup;
+
+public class PassiveEntityMod implements ModInitializer {
+    public static final String MOD_ID = "passive_entity_mod";
+
+    @Override
+    public void onInitialize() {
+        // Register entity
+    }
+}
+"""
+        jar.writestr(
+            "com/example/passivemod/PassiveEntityMod.java", mod_source
+        )
+
+        # Add entity texture (1x1 PNG)
+        import struct
+        import zlib
+
+        def create_minimal_png() -> bytes:
+            """Create a minimal 1x1 white PNG."""
+            signature = b"\x89PNG\r\n\x1a\n"
+            # IHDR
+            ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+            ihdr_crc = zlib.crc32(b"IHDR" + ihdr_data) & 0xFFFFFFFF
+            ihdr = struct.pack(">I", 13) + b"IHDR" + ihdr_data + struct.pack(">I", ihdr_crc)
+            # IDAT
+            raw = zlib.compress(b"\x00\xff\xff\xff")
+            idat_crc = zlib.crc32(b"IDAT" + raw) & 0xFFFFFFFF
+            idat = struct.pack(">I", len(raw)) + b"IDAT" + raw + struct.pack(">I", idat_crc)
+            # IEND
+            iend_crc = zlib.crc32(b"IEND") & 0xFFFFFFFF
+            iend = struct.pack(">I", 0) + b"IEND" + struct.pack(">I", iend_crc)
+            return signature + ihdr + idat + iend
+
+        png_data = create_minimal_png()
+        jar.writestr(
+            "assets/passive_entity_mod/textures/entity/passive_entity.png",
+            png_data,
+        )
+
+        # Add entity model
+        model_data = json.dumps(
+            {
+                "format_version": "1.12.0",
+                "minecraft:geometry": [
+                    {
+                        "description": {
+                            "identifier": "geometry.passive_entity",
+                            "texture_width": 64,
+                            "texture_height": 32,
+                        },
+                        "bones": [],
+                    }
+                ],
+            }
+        )
+        jar.writestr(
+            "assets/passive_entity_mod/models/entity/passive_entity.json",
+            model_data,
+        )
+
+        # Add fabric.mod.json metadata
+        jar.writestr(
+            "fabric.mod.json",
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "id": "passive_entity_mod",
+                    "version": "1.0.0",
+                    "name": "Passive Entity Mod",
+                }
+            ),
+        )
+
+
+def _create_block_jar(jar_path: str) -> None:
+    """Create a mock block mod JAR for comparison testing."""
+    with zipfile.ZipFile(jar_path, "w") as jar:
+        block_source = """
+package com.example.blockmod;
+
+import net.minecraft.block.Block;
+
+public class CopperBlock extends Block {
+    public CopperBlock() {
+        super(Settings.of());
+    }
+}
+"""
+        jar.writestr("com/example/blockmod/CopperBlock.java", block_source)
+        jar.writestr(
+            "fabric.mod.json",
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "id": "copper_mod",
+                    "version": "1.0.0",
+                    "name": "Copper Block Mod",
+                }
+            ),
+        )
+
+
+class TestEntityDetection:
+    """Test that the AST analyzer correctly detects entities."""
+
+    def test_ast_analysis_finds_entities(self):
+        """analyze_jar_with_ast should detect entity classes."""
+        import sys
+
+        project_root = Path(__file__).parent.parent.parent
+        ai_engine_path = project_root / "ai-engine"
+        if str(ai_engine_path) not in sys.path:
+            sys.path.insert(0, str(ai_engine_path))
+
+        from agents.java_analyzer import JavaAnalyzerAgent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jar_path = os.path.join(tmpdir, "passive_entity_mod.jar")
+            _create_entity_jar(jar_path)
+
+            analyzer = JavaAnalyzerAgent()
+            result = analyzer.analyze_jar_with_ast(jar_path)
+
+            assert result["success"] is True
+            entities = result.get("features", {}).get("entities", [])
+            assert len(entities) > 0, "Should detect at least one entity"
+            entity_names = [e["name"] for e in entities]
+            assert "PassiveEntity" in entity_names
+
+    def test_ast_analysis_finds_entity_textures(self):
+        """analyze_jar_with_ast should detect entity textures."""
+        import sys
+
+        project_root = Path(__file__).parent.parent.parent
+        ai_engine_path = project_root / "ai-engine"
+        if str(ai_engine_path) not in sys.path:
+            sys.path.insert(0, str(ai_engine_path))
+
+        from agents.java_analyzer import JavaAnalyzerAgent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jar_path = os.path.join(tmpdir, "passive_entity_mod.jar")
+            _create_entity_jar(jar_path)
+
+            analyzer = JavaAnalyzerAgent()
+            result = analyzer.analyze_jar_with_ast(jar_path)
+
+            textures = result.get("assets", {}).get("textures", [])
+            entity_textures = [t for t in textures if "/textures/entity/" in t]
+            assert len(entity_textures) > 0, "Should find entity textures"
+
+    def test_mvp_analysis_misses_entities(self):
+        """analyze_jar_for_mvp should fall back to unknown_block for entity mods."""
+        import sys
+
+        project_root = Path(__file__).parent.parent.parent
+        ai_engine_path = project_root / "ai-engine"
+        if str(ai_engine_path) not in sys.path:
+            sys.path.insert(0, str(ai_engine_path))
+
+        from agents.java_analyzer import JavaAnalyzerAgent
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jar_path = os.path.join(tmpdir, "passive_entity_mod.jar")
+            _create_entity_jar(jar_path)
+
+            analyzer = JavaAnalyzerAgent()
+            result = analyzer.analyze_jar_for_mvp(jar_path)
+
+            # MVP analysis should NOT find entities - it only looks for blocks
+            registry_name = result.get("registry_name", "")
+            # It should fall back to unknown_block or similar
+            assert "Entity" not in registry_name or "unknown" in registry_name
+
+
+class TestEntityConversion:
+    """Test EntityConverter integration."""
+
+    def test_entity_converter_produces_bedrock_format(self):
+        """EntityConverter.convert_entities should produce valid Bedrock entity JSON."""
+        import sys
+
+        project_root = Path(__file__).parent.parent.parent
+        ai_engine_path = project_root / "ai-engine"
+        if str(ai_engine_path) not in sys.path:
+            sys.path.insert(0, str(ai_engine_path))
+
+        from agents.entity_converter import EntityConverter
+
+        converter = EntityConverter()
+        java_entities = [
+            {
+                "name": "PassiveEntity",
+                "registry_name": "passive_entity",
+                "methods": ["initGoals", "createChild"],
+            }
+        ]
+
+        result = converter.convert_entities(java_entities)
+
+        assert len(result) > 0, "Should produce at least one entity definition"
+        # Check that at least one entity has the Bedrock format
+        for key, entity_data in result.items():
+            if not key.endswith("_behaviors") and not key.endswith("_animations"):
+                assert "minecraft:entity" in entity_data, (
+                    f"Entity {key} should have minecraft:entity key"
+                )
+
+
+class TestBuildEntityAddonMvp:
+    """Test the new build_entity_addon_mvp method."""
+
+    def test_creates_manifests(self):
+        """build_entity_addon_mvp should create BP and RP manifests."""
+        import sys
+
+        project_root = Path(__file__).parent.parent.parent
+        ai_engine_path = project_root / "ai-engine"
+        if str(ai_engine_path) not in sys.path:
+            sys.path.insert(0, str(ai_engine_path))
+
+        os.environ["TESTING"] = "1"
+        try:
+            from agents.bedrock_builder import BedrockBuilderAgent
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                jar_path = os.path.join(tmpdir, "test_entity.jar")
+                _create_entity_jar(jar_path)
+
+                builder = BedrockBuilderAgent()
+                result = builder.build_entity_addon_mvp(
+                    entities=[{"name": "PassiveEntity", "registry_name": "passive_entity"}],
+                    jar_path=jar_path,
+                    output_dir=tmpdir,
+                )
+
+                assert result["success"] is True
+
+                # Check manifests exist
+                bp_manifest = Path(tmpdir) / "behavior_pack" / "manifest.json"
+                rp_manifest = Path(tmpdir) / "resource_pack" / "manifest.json"
+                assert bp_manifest.exists(), "BP manifest should exist"
+                assert rp_manifest.exists(), "RP manifest should exist"
+
+                # Validate manifest content
+                with open(bp_manifest) as f:
+                    bp_data = json.load(f)
+                assert bp_data["format_version"] == 2
+                assert "entity" in bp_data["header"]["description"].lower()
+        finally:
+            os.environ.pop("TESTING", None)


### PR DESCRIPTION
## Summary

Fixes #981 — Entity mods now correctly route through the `EntityConverter` instead of falling back to `unknown_block`.

## Problem

The CLI pipeline in `convert_mod()` was hardcoded to a block-only path:
1. `analyze_jar_for_mvp()` only searches for `*Block*` classes
2. Entity mods got `registry_name: "unknown_block"` and produced broken output
3. The full analyzer (`analyze_jar_with_ast()`) and `EntityConverter` both existed and worked, but were never called from the CLI

**Impact:** 100% of entity mods failed conversion (3/3 in baseline audit = 30% of test suite).

## Solution

### `modporter/cli/main.py`
- After block-only MVP analysis, now also runs `analyze_jar_with_ast()` for full feature detection
- If entities are found, invokes `EntityConverter.convert_entities()` directly
- Writes entity definitions (entities, behaviors, animations) to pack directories
- Extracts entity textures and models from source JAR into resource pack
- Supports entity-only mods (creates minimal BP/RP manifests) and mixed block+entity mods

### `ai-engine/agents/bedrock_builder.py`
- Added `build_entity_addon_mvp()` method for entity-only mods
- Creates minimal behavior pack and resource pack manifests when there are no blocks but entities are present

### `tests/test_entity_cli_integration.py`
- `TestEntityDetection`: Validates AST analyzer detects entities, textures, and that MVP analyzer correctly falls back
- `TestEntityConversion`: Validates `EntityConverter` produces valid Bedrock entity JSON
- `TestBuildEntityAddonMvp`: Validates entity addon structure generation with manifests

## Files Changed

| File | Change |
|------|--------|
| `modporter/cli/main.py` | Entity routing in `convert_mod()`, new `_extract_entity_assets()` helper |
| `ai-engine/agents/bedrock_builder.py` | New `build_entity_addon_mvp()` method |
| `tests/test_entity_cli_integration.py` | New integration test suite |
| `ai-engine/agents/entity_converter.py` | No changes needed — already complete |
| `ai-engine/agents/java_analyzer.py` | No changes needed — `analyze_jar_with_ast()` already works |

## Testing

- Entity mods should now produce proper Bedrock entity definitions instead of `unknown_block.json`
- Block mods continue to work unchanged (the new AST analysis is additive)
- Expected baseline improvement: 70% → 100% pass rate (all 3 entity failures resolved)

## Summary by Sourcery

Route entity mods through the full AST analysis and EntityConverter in the CLI so both block and entity Java mods are converted into valid Bedrock add-ons, including manifests and assets.

New Features:
- Support converting entity-only and mixed block+entity mods via the CLI pipeline.
- Generate minimal behavior and resource pack manifests for mods that define entities but no blocks.

Bug Fixes:
- Fix CLI conversions where entity mods were previously treated as unknown blocks and produced invalid Bedrock output.

Enhancements:
- Extend CLI analysis to run full AST-based feature detection alongside the existing block-only MVP analysis.
- Enrich detected entities with texture and model metadata and extract corresponding assets into the resource pack.
- Include entity conversion counts and entity-based filenames in CLI packaging results for entity-only mods.

Tests:
- Add integration tests covering AST entity detection, entity texture discovery, EntityConverter output shape, and entity-only add-on structure generation with manifests.