### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix exposed tokens in auth logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -37,3 +37,7 @@
 **Vulnerability:** The application used a hardcoded fallback secret key (`"dev-secret-key-do-not-use-in-production-change-me"`) for JWT token generation and validation if the `SECRET_KEY` environment variable was missing.
 **Learning:** Hardcoded cryptographic secrets are a severe vulnerability (CWE-798). If the environment variable isn't set properly, the application falls back to an insecure, easily guessable default in production, compromising all tokens.
 **Prevention:** Never use default fallback values for cryptographic secrets. When removing hardcoded cryptographic secrets to use environment variables, ensure the application fails securely (e.g., raises a `ValueError`) if the variable is unset, rather than falling back to an insecure default. For testing, set dummy values in `conftest.py` before application imports.
+## 2026-04-07 - Stop Logging Sensitive Tokens
+**Vulnerability:** Found `verification_token` and `reset_token` being logged in plain text in `backend/src/api/auth.py`.
+**Learning:** Developers sometimes log URLs with tokens to help with local testing, inadvertently pushing this logic to production which leaks sensitive credentials into application logs.
+**Prevention:** Never log authentication tokens or secrets. For local testing, rely on mock services or console output meant only for local environments rather than the central application logger.

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -208,10 +208,7 @@ async def register(
     await db.commit()
     await db.refresh(user)
 
-    logger.info(f"Email verification token for {request_data.email}: {verification_token}")
-    logger.info(
-        f"Verification URL: http://localhost:8080/api/v1/auth/verify-email/{verification_token}"
-    )
+    logger.info(f"Generated email verification token for {request_data.email}")
 
     return RegisterResponse(
         message="User registered. Please check email for verification link.",
@@ -347,8 +344,7 @@ async def forgot_password(
         user.reset_token_expires = datetime.now(timezone.utc) + timedelta(hours=1)
         await db.commit()
 
-        logger.info(f"Password reset token for {request_data.email}: {reset_token}")
-        logger.info(f"Reset URL: http://localhost:8080/api/v1/auth/reset-password/{reset_token}")
+        logger.info(f"Generated password reset token for {request_data.email}")
 
     return MessageResponse(
         message="If the email is registered, a password reset link has been sent."


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The email verification and password reset tokens were being logged in plain text.
🎯 **Impact:** Exposing sensitive tokens in server logs could allow anyone with access to the logs (like monitoring systems or disgruntled employees) to hijack user accounts or reset passwords.
🔧 **Fix:** Changed the logging statements to confirm the *generation* of the tokens without outputting the token strings themselves. 
✅ **Verification:** Verified log output generation and ensured `backend/src/api/auth.py` was correctly linted.

---
*PR created automatically by Jules for task [782578277364226338](https://jules.google.com/task/782578277364226338) started by @anchapin*

## Summary by Sourcery

Remove sensitive email verification and password reset tokens from authentication logs and document the security fix in Sentinel notes.

Bug Fixes:
- Stop logging raw email verification tokens and reset tokens in authentication flows to prevent exposure of sensitive credentials.

Documentation:
- Add Sentinel security note describing the logging vulnerability, its root cause, and recommended prevention practices.