### PR TITLE
⚡ Bolt: Optimize field filtering in VisualEditor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,3 +14,6 @@
 ## 2026-03-19 - [Avoid O(N*M) lookups inside list renders]
 **Learning:** Passing a callback that performs `.filter` on a full array down to child components that iterate over lists (like `FormBuilder` iterating over `fields` and calling `getFieldErrors(field.name)`) results in O(N*M) time complexity.
 **Action:** Replace callback filters with a single pass O(M) `.reduce` or loop inside a `useMemo` to construct a grouped hash map by ID, turning child component lookups into O(1).
+## 2024-05-14 - Optimize array filtering with Set and Map
+**Learning:** Found an `O(N*M)` performance bottleneck in `VisualEditor.tsx` where array filtering inside a callback (`fields.filter((field) => category.fields.includes(field.name))`) was occurring on every render.
+**Action:** Replaced it with a pre-computed `Map` using `useMemo` and an inner `Set` to provide `O(1)` lookups, significantly improving rendering performance for forms with many fields and categories.

--- a/frontend/src/components/BehaviorEditor/VisualEditor/VisualEditor.tsx
+++ b/frontend/src/components/BehaviorEditor/VisualEditor/VisualEditor.tsx
@@ -123,17 +123,29 @@ export const VisualEditor: React.FC<VisualEditorProps> = ({
     onValidationChange?.(errors);
   }, [formData, fields, validationRules, onValidationChange]);
 
+  // ⚡ Bolt optimization: Pre-compute fields by category to avoid O(N*M) array filtering
+  // with .includes() on every render
+  const categoryFieldsMap = useMemo(() => {
+    const map = new Map<string, FormField[]>();
+    categories.forEach((category) => {
+      const fieldSet = new Set(category.fields);
+      map.set(
+        category.id,
+        fields.filter((field) => fieldSet.has(field.name))
+      );
+    });
+    return map;
+  }, [fields, categories]);
+
   // Get fields for specific category or all fields
   const getFieldsForCategory = useCallback(
     (categoryId?: string): FormField[] => {
       if (!categoryId || categories.length === 0) {
         return fields;
       }
-      const category = categories.find((c) => c.id === categoryId);
-      if (!category) return [];
-      return fields.filter((field) => category.fields.includes(field.name));
+      return categoryFieldsMap.get(categoryId) || [];
     },
-    [fields, categories]
+    [fields, categories, categoryFieldsMap]
   );
 
   // ⚡ Bolt optimization: Group validation errors by field in a single O(M) pass


### PR DESCRIPTION
💡 **What**: Optimized the array filtering logic in `getFieldsForCategory` inside `VisualEditor.tsx`.
🎯 **Why**: The previous implementation performed a nested array iteration (`.filter()` containing `.includes()`) on every function call/render, creating an `O(N*M)` operation that would slow down as the number of fields and categories grew.
📊 **Impact**: Reduces time complexity to `O(N+M)` by pre-computing a map of filtered fields using a fast `Set` lookup. Prevented re-computations by memoizing the mapped values using `useMemo`. This provides O(1) reads during rendering.
🔬 **Measurement**: Verify by navigating to a Behavior Editor containing a visual form with multiple fields and tabbed categories, and observing faster rendering during category swaps. Validated with existing Jest unit test suite (`pnpm run test:frontend`) and ESLint (`pnpm run lint:frontend`).

---
*PR created automatically by Jules for task [11938580172174293264](https://jules.google.com/task/11938580172174293264) started by @anchapin*

## Summary by Sourcery

Optimize field retrieval in the visual behavior editor to reduce per-render time complexity when filtering fields by category.

Enhancements:
- Pre-compute a memoized map of fields per category in VisualEditor to avoid repeated O(N*M) filtering during renders.
- Document the performance optimization and its rationale in the Bolt engineering notes.