### PR TITLE
fix(legal): remove Biomes O' Plenty (CC BY-NC-ND license violation) #1021

### DIFF
--- a/docs/legal/conversion-audit.md
+++ b/docs/legal/conversion-audit.md
@@ -1,0 +1,72 @@
+# Conversion Audit - Test Mod Shortlist
+
+## Purpose
+
+This document tracks mods used for conversion testing and their license compliance. Only mods with permissive licenses that allow derivative works are approved for use in ModPorter AI's conversion testing.
+
+## License Requirements
+
+**Required License Characteristics:**
+- Must allow creation of derivative works
+- Must be compatible with commercial use
+- Cannot restrict modifications or conversions
+
+**Approved Licenses:** MIT, BSD, Apache 2.0, GPL 3.0+, CC0, Unlicense
+
+**Prohibited Licenses:** CC BY-NC-ND, CC BY-NC, proprietary/eula
+
+## Approved Test Mods
+
+| Mod Name | Category | License | Conversion Focus |
+|----------|----------|---------|-----------------|
+| Simple Copper Block | Block | MIT | Basic block conversion |
+| The Aether | Dimension/World Gen | GPL 3.0 | World generation, dimensions |
+| Terralith | World Gen Datapack | MIT | Biome and terrain conversion |
+| Blue Skies | Dimension/Biome | MIT | Multi-dimensional biome conversion |
+| Oh The Biomes You'll Go | Biome | MIT | Biome generation and mapping |
+
+## Removed Mods
+
+### Biomes O' Plenty (REMOVED)
+- **Reason:** CC BY-NC-ND 4.0 license violation
+- **Issue:** [#1021](https://github.com/anchapin/ModPorter-AI/issues/1021)
+- **Removal Date:** 2026-04-09
+- **Impact:** Cannot legally produce derivative works from this mod
+- **Replacement:** Terralith (MIT licensed)
+
+## Replacement Justification
+
+### Terralith (Selected)
+- **License:** MIT License (permissive, allows derivatives)
+- **Coverage:** World generation, biome/terrain conversion
+- **Type:** Datapack format (demonstrates datapack conversion)
+- **Repository:** https://github.com/Terralith-Vanilla/terralith
+
+### Alternative Candidates (Not Selected)
+- **The Aether** - GPL 3.0 (strong copyleft, may complicate commercial use)
+- **Blue Skies** - MIT (valid alternative, different biome set)
+- **Oh The Biomes You'll Go** - MIT (valid alternative)
+
+## QA Test Library Registry
+
+Test mods must be registered in `tests/fixtures/README.md` with:
+- License verification
+- Conversion capability coverage
+- Maintenance status
+
+### Registry Categories
+1. **Baseline Mods** - Basic features for fundamental conversion testing
+2. **Feature Mods** - Test specific conversion capabilities (entities, GUIs, dimensions)
+3. **Complex Logic Mods** - Test advanced conversion scenarios
+
+## Compliance Verification
+
+Before adding a mod to the test shortlist:
+1. Verify license allows derivative works
+2. Confirm license is on approved list
+3. Document conversion coverage in registry
+4. Add to this document with license info
+
+## Related Issues
+
+- [#1021](https://github.com/anchapin/ModPorter-AI/issues/1021) - Biomes O' Plenty license violation

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -36,6 +36,15 @@ tests/fixtures/
         └── complex_logic_conversion_expectations.json
 ```
 
+## 📋 License Compliance
+
+All test mods must comply with ModPorter AI's license requirements. See [`docs/legal/conversion-audit.md`](../../docs/legal/conversion-audit.md) for the approved test mod shortlist and license compliance guidelines.
+
+**Key Points:**
+- Only mods with permissive licenses (MIT, BSD, Apache 2.0, GPL 3.0+, CC0) are approved
+- Mods with CC BY-NC-ND or similar non-derivative licenses are prohibited
+- License verification is required before adding new test mods
+
 ## 🎯 Test Mod Categories
 
 ### 📦 Existing Mods (Baseline)
@@ -302,6 +311,18 @@ generator.create_complex_logic_mod("machinery")
 2. Regenerate affected test mods
 3. Re-run validation to ensure integrity
 4. Update expected outputs if needed
+
+## 🌍 World Gen / Biome Reference Mods
+
+External mods used for testing world generation and biome conversion capabilities:
+
+| Mod Name | License | Coverage | Notes |
+|----------|---------|----------|-------|
+| Terralith | MIT | World gen, biomes, terrain | Primary reference for world gen testing |
+| The Aether | GPL 3.0 | Dimensions, world gen | Alternative dimension mod |
+| Blue Skies | MIT | Multi-biome, dimension | Alternative biome mod |
+
+**Note:** Biomes O' Plenty was removed due to CC BY-NC-ND license (see [`docs/legal/conversion-audit.md`](../../docs/legal/conversion-audit.md))
 
 ## Legacy Files
 


### PR DESCRIPTION
## Summary

- Created `docs/legal/conversion-audit.md` documenting license-compliant test mods
- Removed Biomes O' Plenty from test shortlist due to CC BY-NC-ND 4.0 license violation
- Added Terralith (MIT licensed) as replacement for world gen/biome testing
- Updated `tests/fixtures/README.md` with license compliance documentation

## Changes

### New file: `docs/legal/conversion-audit.md`
- Documents approved licenses (MIT, BSD, Apache 2.0, GPL 3.0+, CC0)
- Lists prohibited licenses (CC BY-NC-ND, CC BY-NC, proprietary)
- Documents removal of Biomes O' Plenty with issue reference
- Lists approved test mods: Terralith, The Aether, Blue Skies

### Modified: `tests/fixtures/README.md`
- Added License Compliance section referencing conversion-audit.md
- Added World Gen / Biome Reference Mods section documenting approved external mods

## Acceptance Criteria

- [x] Biomes O' Plenty removed from test shortlist in `conversion-audit.md`
- [x] Replacement mod added with verified permissive license (Terralith - MIT)
- [x] Replacement mod covers world gen / biome converter testing
- [x] Updated in QA test library registry

Closes #1021

## Summary by Sourcery

Document and enforce license-compliant test mods by replacing a non-compliant worldgen mod and recording approved alternatives.

Documentation:
- Add a legal conversion audit document listing approved and prohibited licenses and tracking test mods and removals.
- Update the fixtures README with license compliance guidance and a registry of approved world generation/biome reference mods.

Tests:
- Register approved world generation and biome reference mods for testing, replacing the removed Biomes O' Plenty with Terralith and other compliant mods.