### PR TITLE
Integrate RecipeConverterAgent into conversion pipeline for full recipe support (Vibe Kanban)

### DIFF
--- a/ai-engine/agents/__init__.py
+++ b/ai-engine/agents/__init__.py
@@ -62,6 +62,13 @@ except ImportError:
     QAValidator = None
 
 try:
+    from .recipe_converter import RecipeConverterAgent as RecipeConverter
+
+    __all__.append("RecipeConverter")
+except ImportError:
+    RecipeConverter = None
+
+try:
     from .validation_agent import (
         ValidationAgent,
         LLMSemanticAnalyzer,

--- a/ai-engine/agents/block_item_generator.py
+++ b/ai-engine/agents/block_item_generator.py
@@ -217,25 +217,70 @@ class BlockItemGenerator:
         logger.info(f"Successfully generated {len(bedrock_items)} Bedrock items")
         return bedrock_items
 
-    def generate_recipes(self, java_recipes: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def generate_recipes(
+        self, java_recipes: List[Dict[str, Any]], namespace: str = "mod"
+    ) -> Dict[str, Any]:
         """
-        Convert Java recipes to Bedrock format.
+        Convert Java recipes to Bedrock format using RecipeConverterAgent.
 
         Args:
             java_recipes: List of Java recipe definitions
+            namespace: Namespace for the recipes (default: "mod")
 
         Returns:
             Dictionary of Bedrock recipes
         """
+        from agents.recipe_converter import RecipeConverterAgent
+
         logger.info(f"Converting {len(java_recipes)} Java recipes to Bedrock format")
         bedrock_recipes = {}
 
+        recipe_converter = RecipeConverterAgent.get_instance()
+
         for java_recipe in java_recipes:
             try:
-                bedrock_recipe = self._convert_java_recipe(java_recipe)
-                if bedrock_recipe:
-                    recipe_id = bedrock_recipe.get("identifier", f"recipe_{len(bedrock_recipes)}")
-                    bedrock_recipes[recipe_id] = bedrock_recipe
+                recipe_type = java_recipe.get("type", "")
+                result_item = java_recipe.get("result", {})
+                if isinstance(result_item, dict):
+                    result_item_id = result_item.get("item", "unknown")
+                elif isinstance(result_item, str):
+                    result_item_id = result_item
+                else:
+                    result_item_id = "unknown"
+
+                if ":" in result_item_id:
+                    _, recipe_name = result_item_id.split(":", 1)
+                else:
+                    recipe_name = result_item_id
+
+                bedrock_recipe = recipe_converter.convert_recipe(
+                    java_recipe, namespace, recipe_name
+                )
+
+                if (
+                    bedrock_recipe
+                    and not isinstance(bedrock_recipe, dict)
+                    or (
+                        isinstance(bedrock_recipe, dict) and not bedrock_recipe.get("success", True)
+                    )
+                ):
+                    if isinstance(bedrock_recipe, dict) and bedrock_recipe.get("success") is False:
+                        logger.warning(
+                            f"Recipe conversion failed: {bedrock_recipe.get('error', 'Unknown error')}"
+                        )
+                        continue
+
+                if isinstance(bedrock_recipe, dict):
+                    for recipe_key, recipe_content in bedrock_recipe.items():
+                        if recipe_key.startswith("minecraft:recipe_"):
+                            recipe_id = recipe_content.get("description", {}).get(
+                                "identifier", f"recipe_{len(bedrock_recipes)}"
+                            )
+                            bedrock_recipes[recipe_id] = bedrock_recipe
+                            break
+                    else:
+                        if "identifier" in bedrock_recipe:
+                            bedrock_recipes[bedrock_recipe["identifier"]] = bedrock_recipe
             except Exception as e:
                 logger.error(f"Failed to convert recipe {java_recipe.get('id', 'unknown')}: {e}")
                 continue

--- a/ai-engine/tests/test_bedrock_addon_generation.py
+++ b/ai-engine/tests/test_bedrock_addon_generation.py
@@ -192,7 +192,7 @@ class TestBlockItemGenerator:
         assert item_def["minecraft:item"]["description"]["identifier"] == item_id
 
     def test_generate_recipes(self):
-        """Test recipe generation."""
+        """Test recipe generation using RecipeConverterAgent."""
         sample_recipes = [
             {
                 "id": "test_recipe",
@@ -203,16 +203,19 @@ class TestBlockItemGenerator:
             }
         ]
 
-        bedrock_recipes = self.generator.generate_recipes(sample_recipes)
+        bedrock_recipes = self.generator.generate_recipes(sample_recipes, namespace="testmod")
 
         assert len(bedrock_recipes) == 1
 
-        # Get the first (and only) recipe key
         recipe_key = list(bedrock_recipes.keys())[0]
         recipe_def = bedrock_recipes[recipe_key]
 
         assert "minecraft:recipe_shaped" in recipe_def
-        assert recipe_def["minecraft:recipe_shaped"]["description"]["identifier"] == "test_recipe"
+        assert (
+            recipe_def["minecraft:recipe_shaped"]["description"]["identifier"]
+            == "testmod:test_block"
+        )
+        assert recipe_def["minecraft:recipe_shaped"]["pattern"] == ["XXX", "X X", "XXX"]
 
     def test_block_properties_parsing(self):
         """Test parsing of Java block properties."""


### PR DESCRIPTION
This PR integrates the existing RecipeConverterAgent into the conversion pipeline to enable proper Java data pack recipe conversion to Bedrock format.

The RecipeConverterAgent was not being used by BlockItemGenerator.generate_recipes(). This change:
- Exports RecipeConverterAgent in agents/__init__.py
- Uses RecipeConverterAgent in BlockItemGenerator.generate_recipes()
- Updates test to use correct Bedrock identifier format

All 83 recipe-related tests pass.

This PR was written using Vibe Kanban (https://vibekanban.com)