### PR TITLE
⚡ Bolt: [performance improvement] optimize form builder error parsing

### DIFF
--- a/frontend/src/components/BehaviorEditor/VisualEditor/FormBuilder.tsx
+++ b/frontend/src/components/BehaviorEditor/VisualEditor/FormBuilder.tsx
@@ -78,12 +78,16 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
   const getFieldErrorState = useCallback(
     (field: FormField) => {
       const errors = getFieldErrors(field.name);
-      return {
-        hasError: errors.some((e) => e.severity === 'error'),
-        helperText:
-          errors.find((e) => e.severity === 'error')?.message ||
-          field.description,
-      };
+      let hasError = false;
+      let helperText = field.description;
+      for (const e of errors) {
+        if (e.severity === 'error') {
+          hasError = true;
+          helperText = e.message;
+          break;
+        }
+      }
+      return { hasError, helperText };
     },
     [getFieldErrors]
   );
@@ -94,11 +98,7 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
       type: 'text' | 'number' | 'textarea',
       extraProps: Record<string, any> = {}
     ) => {
-      const errors = getFieldErrors(field.name);
-      const hasError = errors.some((e) => e.severity === 'error');
-      const helperText =
-        errors.find((e) => e.severity === 'error')?.message ||
-        field.description;
+      const { hasError, helperText } = getFieldErrorState(field);
 
       const handleChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (type === 'number') {
@@ -126,7 +126,7 @@ export const FormBuilder: React.FC<FormBuilderProps> = ({
         />
       );
     },
-    [data, getFieldErrors, handleChange, readOnly]
+    [data, getFieldErrorState, handleChange, readOnly]
   );
 
   const renderField = useCallback(


### PR DESCRIPTION
💡 What: The optimization replaces redundant array traversals (`.some()` and `.find()`) inside `FormBuilder.tsx` with a single loop that returns early upon finding an error. Furthermore, `renderTextField` now directly reuses this single-pass state extraction rather than performing the same unoptimized lookups redundantly.
🎯 Why: React components dealing with large configurations or heavily dynamic forms suffer when recalculations contain O(N) array loops repeated on every render, across multiple form fields. Combining the iterations decreases the array scanning overhead directly.
📊 Impact: Expected to cut the time spent finding and assigning error details per field during form validation logic by at least 50% (combines two full O(N) checks into a single check with an early break). 
🔬 Measurement: Verify by interacting with forms generated by `FormBuilder` with large datasets or validation failures. Rendering profiling via React DevTools should show improved rendering times inside the component tree.

---
*PR created automatically by Jules for task [6418929480050009022](https://jules.google.com/task/6418929480050009022) started by @anchapin*

## Summary by Sourcery

Optimize form field error state handling in the FormBuilder to avoid redundant error array scans and centralize error computation.

Enhancements:
- Refine getFieldErrorState to determine error presence and helper text in a single pass over field errors.
- Update renderTextField to reuse getFieldErrorState instead of recomputing error details locally, reducing repeated work.