### PR TITLE
🎨 Palette: Add aria-expanded to collapsible sections

### DIFF
--- a/frontend/src/components/BehaviorEditor/VisualEditor/VisualEditor.tsx
+++ b/frontend/src/components/BehaviorEditor/VisualEditor/VisualEditor.tsx
@@ -151,13 +151,16 @@ export const VisualEditor: React.FC<VisualEditorProps> = ({
   // ⚡ Bolt optimization: Group validation errors by field in a single O(M) pass
   // instead of filtering the array inside a callback for every single field O(N*M).
   const fieldErrorsMap = useMemo(() => {
-    return validationErrors.reduce((acc, error) => {
-      if (!acc[error.field]) {
-        acc[error.field] = [];
-      }
-      acc[error.field].push(error);
-      return acc;
-    }, {} as Record<string, ValidationRule[]>);
+    return validationErrors.reduce(
+      (acc, error) => {
+        if (!acc[error.field]) {
+          acc[error.field] = [];
+        }
+        acc[error.field].push(error);
+        return acc;
+      },
+      {} as Record<string, ValidationRule[]>
+    );
   }, [validationErrors]);
 
   // Get field errors

--- a/frontend/src/components/ConversionReport/AssumptionsReport.tsx
+++ b/frontend/src/components/ConversionReport/AssumptionsReport.tsx
@@ -371,7 +371,11 @@ export const AssumptionsReport: React.FC<AssumptionsReportProps> = ({
           <h3 className={styles.sectionTitle}>
             🧠 Smart Assumptions (0 applied)
           </h3>
-          <button className={styles.toggleButton}>
+          <button
+            className={styles.toggleButton}
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? 'Collapse' : 'Expand'}
+          >
             {isExpanded ? '▼' : '▶'}
           </button>
         </div>
@@ -395,6 +399,7 @@ export const AssumptionsReport: React.FC<AssumptionsReportProps> = ({
         </h3>
         <button
           className={styles.toggleButton}
+          aria-expanded={isExpanded}
           aria-label={isExpanded ? 'Collapse' : 'Expand'}
         >
           {isExpanded ? '▼' : '▶'}

--- a/frontend/src/components/ConversionReport/DeveloperLog.tsx
+++ b/frontend/src/components/ConversionReport/DeveloperLog.tsx
@@ -150,6 +150,7 @@ const LogSection: React.FC<LogSectionProps> = ({
         </div>
         <button
           className={styles.toggleButton}
+          aria-expanded={isExpanded}
           aria-label={isExpanded ? 'Collapse' : 'Expand'}
         >
           {isExpanded ? '▼' : '▶'}
@@ -385,6 +386,7 @@ export const DeveloperLog: React.FC<DeveloperLogProps> = ({
         <div className={styles.logSummary}>{totalLogEntries} entries</div>
         <button
           className={styles.toggleButton}
+          aria-expanded={isExpanded}
           aria-label={isExpanded ? 'Collapse' : 'Expand'}
         >
           {isExpanded ? '▼' : '▶'}

--- a/frontend/src/components/ConversionReport/FeatureAnalysis.tsx
+++ b/frontend/src/components/ConversionReport/FeatureAnalysis.tsx
@@ -321,6 +321,7 @@ export const FeatureAnalysis: React.FC<FeatureAnalysisProps> = ({
         </h3>
         <button
           className={styles.toggleButton}
+          aria-expanded={isExpanded}
           aria-label={isExpanded ? 'Collapse' : 'Expand'}
         >
           {isExpanded ? '▼' : '▶'}


### PR DESCRIPTION
Added `aria-expanded` attributes to `AssumptionsReport.tsx`, `FeatureAnalysis.tsx`, and `DeveloperLog.tsx` toggle buttons so that screen readers can correctly announce the open/closed state of these sections. Also added `aria-label` to one of the toggle buttons that lacked it.

---
*PR created automatically by Jules for task [2377455614544965459](https://jules.google.com/task/2377455614544965459) started by @anchapin*

## Summary by Sourcery

Improve accessibility of collapsible sections and perform minor code cleanup.

Bug Fixes:
- Expose the expanded/collapsed state of conversion report toggle buttons via aria-expanded for better screen reader support.

Enhancements:
- Add aria-labels to conversion report toggle buttons to clarify their purpose to assistive technologies.
- Reformat the visual editor validation error reduction for improved readability without changing behavior.