### PR TITLE
🎨 Palette: Add focus-visible state to cancel buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2025-04-03 - Improved Notification Close Button Accessibility and Focus Styles
 **Learning:** Decorative characters like "✕" inside buttons that already have `aria-label` attributes can cause redundant or confusing announcements for screen reader users. Additionally, using the `:focus` pseudo-class for buttons triggers focus outlines even on mouse clicks, which can add unnecessary visual noise.
 **Action:** When implementing icon-only buttons with decorative characters, wrap the visual character in `<span aria-hidden="true">` to rely entirely on the `aria-label`. Use `:focus-visible` instead of `:focus` for interactive elements to ensure focus outlines appear only during keyboard navigation.
+
+## 2024-04-12 - Ensure secondary actions have focus states
+**Learning:** Secondary UI elements like cancel buttons in confirmation dialogues often get missed when styling keyboard focus states, breaking keyboard accessibility for secondary paths.
+**Action:** Whenever styling focus states for primary action buttons, always verify that adjacent secondary or cancel buttons also have explicit `:focus-visible` styles applied.

--- a/frontend/src/components/ConversionHistory/ConversionHistory.css
+++ b/frontend/src/components/ConversionHistory/ConversionHistory.css
@@ -164,7 +164,8 @@
 
 /* Accessibility: Focus-visible for header action buttons */
 .delete-selected-btn:focus-visible,
-.clear-all-btn:focus-visible {
+.clear-all-btn:focus-visible,
+.cancel-btn:focus-visible {
   outline: 2px solid #0066cc;
   outline-offset: 2px;
 }


### PR DESCRIPTION
## What
Added the missing `:focus-visible` state to the `.cancel-btn` class in `ConversionHistory.css`.

## Why
When keyboard users navigate the `ConversionHistory` confirmation dialogs, primary actions (`.delete-selected-btn`, `.clear-all-btn`) had clear focus states, but the secondary `.cancel-btn` did not. This addition ensures that users can easily tell when the cancel action is focused, improving overall keyboard accessibility.

## Accessibility
Added explicit focus indication for keyboard users navigating confirmation prompts.

---
*PR created automatically by Jules for task [6300483440611162046](https://jules.google.com/task/6300483440611162046) started by @anchapin*

## Summary by Sourcery

Add a focus-visible state for cancel buttons in ConversionHistory dialogs to improve keyboard accessibility.

Enhancements:
- Ensure the ConversionHistory cancel button has a visible keyboard focus state consistent with primary action buttons.
- Document the accessibility learning about providing focus styles for secondary actions in the palette guidelines.