### PR TITLE
⚡ Bolt: [performance improvement] Hoist toLowerCase() in DeveloperLog array filter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2024-05-14 - Optimize array filtering with Set and Map
 **Learning:** Found an `O(N*M)` performance bottleneck in `VisualEditor.tsx` where array filtering inside a callback (`fields.filter((field) => category.fields.includes(field.name))`) was occurring on every render.
 **Action:** Replaced it with a pre-computed `Map` using `useMemo` and an inner `Set` to provide `O(1)` lookups, significantly improving rendering performance for forms with many fields and categories.
+## 2024-04-14 - Array Filter Loop Hoisting
+**Learning:** React `useMemo` hooks often contain `.filter()` or `.map()` loops over large arrays. If operations inside the callback (like `.toLowerCase()` or creating standard regex patterns) are purely dependent on external closure variables and not the current array item, they will be wastefully recalculated $O(N)$ times, causing redundant allocations and performance overhead.
+**Action:** Always identify loop-invariant variables and operations within array iterations and manually hoist them outside the `.filter()` or `.map()` block, strictly before the loop begins.

--- a/frontend/src/components/ConversionReport/DeveloperLog.tsx
+++ b/frontend/src/components/ConversionReport/DeveloperLog.tsx
@@ -101,8 +101,12 @@ const LogSection: React.FC<LogSectionProps> = ({
 
   const filteredLogs = useMemo(() => {
     if (levelFilter === 'all') return logs;
+
+    // ⚡ Bolt optimization: Hoist toLowerCase() outside the loop to prevent O(N) redundant string allocations
+    const filterLower = levelFilter.toLowerCase();
+
     return logs.filter(
-      (log) => log.level.toLowerCase() === levelFilter.toLowerCase()
+      (log) => log.level.toLowerCase() === filterLower
     );
   }, [logs, levelFilter]);
 

--- a/frontend/src/components/ConversionReport/DeveloperLog.tsx
+++ b/frontend/src/components/ConversionReport/DeveloperLog.tsx
@@ -105,9 +105,7 @@ const LogSection: React.FC<LogSectionProps> = ({
     // ⚡ Bolt optimization: Hoist toLowerCase() outside the loop to prevent O(N) redundant string allocations
     const filterLower = levelFilter.toLowerCase();
 
-    return logs.filter(
-      (log) => log.level.toLowerCase() === filterLower
-    );
+    return logs.filter((log) => log.level.toLowerCase() === filterLower);
   }, [logs, levelFilter]);
 
   const logCounts = useMemo(() => {


### PR DESCRIPTION
💡 What: Hoisted the `levelFilter.toLowerCase()` calculation outside the `.filter()` callback inside `DeveloperLog.tsx`'s `filteredLogs` hook.
🎯 Why: `useMemo` hooks often contain `.filter()` loops over potentially large arrays. Recomputing a loop-invariant value like `levelFilter.toLowerCase()` inside the callback causes unnecessary O(N) string allocations and performance overhead. 
📊 Impact: Reduces CPU allocations and string operations from O(N) to O(1) during log filtering, making the filter interactions snappier and memory efficient.
🔬 Measurement: Verify the change by searching/filtering the Developer Log in the Conversion Report and ensuring logs are successfully filtered by level with equivalent functionality.

---
*PR created automatically by Jules for task [13137388737746741664](https://jules.google.com/task/13137388737746741664) started by @anchapin*

## Summary by Sourcery

Optimize Developer Log filtering performance by hoisting loop-invariant string computation and document the pattern in Bolt guidelines.

Enhancements:
- Improve Developer Log array filtering performance by computing the lowercased level filter once per memoized computation instead of on every item in the filter loop.

Documentation:
- Add a Bolt guideline entry describing the practice of hoisting loop-invariant computations out of array iteration callbacks to avoid redundant work.