### PR TITLE
🎨 Palette: Add ARIA labels to feedback buttons in ConversionReport

### DIFF
--- a/frontend/src/components/ConversionReport/ConversionReport.test.tsx
+++ b/frontend/src/components/ConversionReport/ConversionReport.test.tsx
@@ -267,8 +267,8 @@ describe('Feedback Functionality in ConversionReport', () => {
     render(<ConversionReport conversionResult={minimalMockReport} />);
 
     expect(screen.getByText('Rate this Conversion')).toBeInTheDocument();
-    expect(screen.getByTitle('Thumbs Up')).toBeInTheDocument(); // Using title for emoji buttons
-    expect(screen.getByTitle('Thumbs Down')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Thumbs Up' })).toBeInTheDocument(); // Using title for emoji buttons
+    expect(screen.getByRole('button', { name: 'Thumbs Down' })).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText('Optional: Add any comments here...')
     ).toBeInTheDocument();
@@ -280,8 +280,8 @@ describe('Feedback Functionality in ConversionReport', () => {
   test('feedback type selection works correctly', () => {
     render(<ConversionReport conversionResult={minimalMockReport} />);
 
-    const thumbsUpButton = screen.getByTitle('Thumbs Up');
-    const thumbsDownButton = screen.getByTitle('Thumbs Down');
+    const thumbsUpButton = screen.getByRole('button', { name: 'Thumbs Up' });
+    const thumbsDownButton = screen.getByRole('button', { name: 'Thumbs Down' });
 
     // Initially, neither should be "pressed" - use aria-pressed attribute which is more reliable
     expect(thumbsUpButton).toHaveAttribute('aria-pressed', 'false');
@@ -308,7 +308,7 @@ describe('Feedback Functionality in ConversionReport', () => {
 
     render(<ConversionReport conversionResult={minimalMockReport} />);
 
-    fireEvent.click(screen.getByTitle('Thumbs Up'));
+    fireEvent.click(screen.getByRole('button', { name: 'Thumbs Up' }));
     fireEvent.change(
       screen.getByPlaceholderText('Optional: Add any comments here...'),
       {
@@ -333,7 +333,7 @@ describe('Feedback Functionality in ConversionReport', () => {
     expect(
       screen.queryByRole('button', { name: 'Submit Feedback' })
     ).not.toBeInTheDocument();
-    expect(screen.queryByTitle('Thumbs Up')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Thumbs Up' })).not.toBeInTheDocument();
   });
 
   test('submit feedback API error flow', async () => {
@@ -364,13 +364,13 @@ describe('Feedback Functionality in ConversionReport', () => {
     });
     expect(submitButton).toBeDisabled();
 
-    fireEvent.click(screen.getByTitle('Thumbs Up'));
+    fireEvent.click(screen.getByRole('button', { name: 'Thumbs Up' }));
     expect(submitButton).not.toBeDisabled();
 
-    fireEvent.click(screen.getByTitle('Thumbs Up')); // Deselect
+    fireEvent.click(screen.getByRole('button', { name: 'Thumbs Up' })); // Deselect
     expect(submitButton).toBeDisabled();
 
-    fireEvent.click(screen.getByTitle('Thumbs Down'));
+    fireEvent.click(screen.getByRole('button', { name: 'Thumbs Down' }));
     expect(submitButton).not.toBeDisabled();
   });
 

--- a/frontend/src/components/ConversionReport/ConversionReport.tsx
+++ b/frontend/src/components/ConversionReport/ConversionReport.tsx
@@ -313,16 +313,18 @@ export const ConversionReport: React.FC<ConversionReportProps> = ({
                 className={`${styles.feedbackButton} ${feedbackType === 'thumbs_up' ? styles.feedbackButtonActive : ''}`}
                 aria-pressed={feedbackType === 'thumbs_up'}
                 title="Thumbs Up"
+                aria-label="Thumbs Up"
               >
-                👍
+                <span aria-hidden="true">👍</span>
               </button>
               <button
                 onClick={() => handleFeedbackTypeChange('thumbs_down')}
                 className={`${styles.feedbackButton} ${feedbackType === 'thumbs_down' ? styles.feedbackButtonActive : ''}`}
                 aria-pressed={feedbackType === 'thumbs_down'}
                 title="Thumbs Down"
+                aria-label="Thumbs Down"
               >
-                👎
+                <span aria-hidden="true">👎</span>
               </button>
             </div>
             <textarea


### PR DESCRIPTION
This commit adds missing `aria-label`s to the icon-only "Thumbs Up" and "Thumbs Down" feedback buttons in the `ConversionReport` component to improve accessibility. It also updates the corresponding Vitest/React Testing Library queries to `getByRole('button', { name: '...' })` to prevent test failures.

---
*PR created automatically by Jules for task [13771493643649016467](https://jules.google.com/task/13771493643649016467) started by @anchapin*

## Summary by Sourcery

Improve accessibility of ConversionReport feedback buttons and align tests with ARIA-based queries.

Enhancements:
- Add ARIA labels to the thumbs up/down feedback buttons and hide the emoji icons from screen readers to make the controls accessible.

Tests:
- Update ConversionReport feedback tests to use role-and-name based button queries instead of title-based queries.