### PR TITLE
modporter ci speed up (vibe-kanban)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -86,10 +86,10 @@ jobs:
             ${{ env.REGISTRY }}/${{ github.repository_owner }}/modporter-ai-${{ matrix.tag-suffix }}:${{ github.sha }}
           cache-from: |
             type=gha,scope=${{ matrix.service }}
-            type=registry,ref=ghcr.io/${{ github.repository }}/modporter-ai-${{ matrix.tag-suffix }}:cache
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/modporter-ai/modporter-ai-${{ matrix.tag-suffix }}:cache
           cache-to: |
             type=gha,mode=max,scope=${{ matrix.service }}
-            type=registry,ref=ghcr.io/${{ github.repository }}/modporter-ai-${{ matrix.tag-suffix }}:cache,mode=max
+            type=registry,ref=ghcr.io/${{ github.repository_owner }}/modporter-ai/modporter-ai-${{ matrix.tag-suffix }}:cache,mode=max
           # PRs: AMD64 only (fast). Main/tag pushes: full multi-arch.
           platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           build-args: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,17 +24,30 @@ env:
   NODE_VERSION: '20'
 
 jobs:
-  # Build Docker images
+  # Build Docker images - PARALLEL matrix build instead of sequential steps
   build:
-    name: Build Docker Images
+    name: Build ${{ matrix.service }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
       packages: write
       contents: read
-    outputs:
-      image-tag: ${{ steps.meta.outputs.tags }}
-      image-digest: ${{ steps.build.outputs.digest }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: backend
+            path: .
+            dockerfile: ./backend/Dockerfile
+            tag-suffix: backend
+          - service: ai-engine
+            path: ./ai-engine
+            dockerfile: ./ai-engine/Dockerfile
+            tag-suffix: ai-engine
+          - service: frontend
+            path: .
+            dockerfile: ./frontend/Dockerfile
+            tag-suffix: frontend
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -61,45 +74,26 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=match,pattern=v(\d+\.\d+\.\d+),group=1
 
-      - name: Build and push backend
+      - name: Build and push
         id: build
         uses: docker/build-push-action@v7
         with:
-          context: .
-          file: ./backend/Dockerfile
+          context: ${{ matrix.path }}
+          file: ${{ matrix.dockerfile }}
           push: true
           tags: |
-            ${{ steps.meta.outputs.tags }}-backend
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/modporter-ai-backend:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-
-      - name: Build and push ai-engine
-        uses: docker/build-push-action@v7
-        with:
-          context: ./ai-engine
-          file: ./ai-engine/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}-ai-engine
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/modporter-ai-ai-engine:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-
-      - name: Build and push frontend
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./frontend/Dockerfile
-          push: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}-frontend
-            ${{ env.REGISTRY }}/${{ github.repository_owner }}/modporter-ai-frontend:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+            ${{ steps.meta.outputs.tags }}-${{ matrix.tag-suffix }}
+            ${{ env.REGISTRY }}/${{ github.repository_owner }}/modporter-ai-${{ matrix.tag-suffix }}:${{ github.sha }}
+          cache-from: |
+            type=gha,scope=${{ matrix.service }}
+            type=registry,ref=ghcr.io/${{ github.repository }}/modporter-ai-${{ matrix.tag-suffix }}:cache
+          cache-to: |
+            type=gha,mode=max,scope=${{ matrix.service }}
+            type=registry,ref=ghcr.io/${{ github.repository }}/modporter-ai-${{ matrix.tag-suffix }}:cache,mode=max
+          # PRs: AMD64 only (fast). Main/tag pushes: full multi-arch.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
 
       # Generate artifact attestation disabled - causing failures
       # - name: Generate artifact attestation


### PR DESCRIPTION
Review all of the CI workflows and jobs and look for opportunities to speed up CI, especially with this CI check which takes the longest time to finish: [CD / Build Docker Images (pull\_request)](https://github.com/anchapin/ModPorter-AI/actions/runs/24521571211/job/71680470424?pr=1076)

## Summary by Sourcery

Parallelize Docker image builds in the CD workflow and optimize build caching and platform targets to speed up CI.

Build:
- Refactor the CD Docker build job into a matrix-based parallel job for backend, AI engine, and frontend images.
- Adjust Docker build tags and add scoped GHA and registry-based layer caching per service, including inline cache support.
- Limit pull request builds to linux/amd64 while keeping multi-arch builds for main/tag pushes to reduce CI duration.