### PR TITLE
feat(recipe-converter): handle custom Forge recipe types for Farmer's Delight, Create, and generic Forge patterns

### DIFF
--- a/ai-engine/agents/recipe_converter.py
+++ b/ai-engine/agents/recipe_converter.py
@@ -83,6 +83,63 @@ JAVA_TO_BEDROCK_ITEM_MAP = {
 }
 
 
+CUSTOM_RECIPE_TYPES = {
+    # Farmer's Delight
+    "farmersdelight:cooking": {
+        "category": "cooking_pot",
+        "description": "Cooking pot recipe",
+        "convertible": True,
+    },
+    "farmersdelight:cutting": {
+        "category": "cutting_board",
+        "description": "Cutting board recipe",
+        "convertible": True,
+    },
+    # Create
+    "create:sequenced_assembly": {
+        "category": "sequenced_assembly",
+        "description": "Sequenced assembly recipe",
+        "convertible": False,
+    },
+    "create:mechanical_crafting": {
+        "category": "mechanical_crafting",
+        "description": "Mechanical crafting (9x9 grid)",
+        "convertible": True,
+    },
+    "create:mixing": {
+        "category": "mixing",
+        "description": "Mixing recipe",
+        "convertible": False,
+    },
+    "create:pressing": {
+        "category": "pressing",
+        "description": "Pressing recipe",
+        "convertible": True,
+    },
+    "create:deploying": {
+        "category": "deploying",
+        "description": "Deploying recipe",
+        "convertible": False,
+    },
+    "create:filling": {
+        "category": "filling",
+        "description": "Filling recipe",
+        "convertible": False,
+    },
+    "create:emptying": {
+        "category": "emptying",
+        "description": "Emptying recipe",
+        "convertible": False,
+    },
+    # Generic Forge patterns
+    "forge:conditional": {
+        "category": "conditional",
+        "description": "Conditional recipe",
+        "convertible": False,
+    },
+}
+
+
 class RecipeConverterAgent:
     """
     Agent responsible for converting Java mod recipes to Bedrock format.
@@ -95,6 +152,7 @@ class RecipeConverterAgent:
     - Smithing recipes
     - Campfire and smoking recipes
     - Stonecutter recipes
+    - Custom Forge recipe types (Farmer's Delight, Create, etc.)
     """
 
     _instance = None
@@ -102,6 +160,7 @@ class RecipeConverterAgent:
     def __init__(self):
         self.item_mapping = JAVA_TO_BEDROCK_ITEM_MAP.copy()
         self.custom_mappings = {}
+        self.manual_review_reasons = []
 
     @classmethod
     def get_instance(cls):
@@ -148,17 +207,30 @@ class RecipeConverterAgent:
             "key": {},
             "cooking_time": None,
             "experience": 0.0,
+            "requires_manual_review": False,
+            "manual_review_reason": None,
+            "container": None,
+            "tool": None,
         }
 
-        # Parse result
+        # Handle forge:conditional - unwrap inner recipe
+        if "forge:conditional" in recipe_type:
+            recipe_data = self._unwrap_conditional_recipe(recipe_data)
+            recipe_type = recipe_data.get("type", "")
+
+        # Parse result - handle multi-output recipes (result array)
         result = recipe_data.get("result", {})
         if isinstance(result, dict):
-            # NeoForge 1.21+ uses 'id' instead of 'item'
             normalized["result_item"] = result.get("item", result.get("id", ""))
             normalized["result_count"] = result.get("count", 1)
             normalized["result_data"] = result.get("data", 0)
         elif isinstance(result, str):
             normalized["result_item"] = result
+        elif isinstance(result, list) and len(result) > 0:
+            first_result = result[0] if isinstance(result[0], dict) else {"item": result[0]}
+            normalized["result_item"] = first_result.get("item", first_result.get("id", ""))
+            normalized["result_count"] = first_result.get("count", 1)
+            normalized["result_data"] = first_result.get("data", 0)
 
         # Handle different recipe types
         if "crafting_shaped" in recipe_type:
@@ -206,11 +278,81 @@ class RecipeConverterAgent:
             normalized["base"] = recipe_data.get("base")
             normalized["addition"] = recipe_data.get("addition")
             normalized["template"] = recipe_data.get("template")
+        # Custom Forge recipe types
+        elif "farmersdelight:cooking" in recipe_type:
+            normalized["recipe_category"] = "cooking_pot"
+            normalized["cooking_time"] = recipe_data.get("cookingtime", 200)
+            normalized["experience"] = recipe_data.get("experience", 0.0)
+            normalized["container"] = recipe_data.get("container")
+            ingredient = recipe_data.get("ingredient")
+            if ingredient:
+                normalized["ingredients"] = [ingredient]
+        elif "farmersdelight:cutting" in recipe_type:
+            normalized["recipe_category"] = "cutting_board"
+            normalized["tool"] = recipe_data.get("tool")
+            ingredients = recipe_data.get("ingredients", [])
+            normalized["ingredients"] = ingredients
+        elif "create:mechanical_crafting" in recipe_type:
+            normalized["recipe_category"] = "mechanical_crafting"
+            normalized["pattern"] = recipe_data.get("pattern", [])
+            normalized["key"] = recipe_data.get("key", {})
+        elif "create:pressing" in recipe_type:
+            normalized["recipe_category"] = "pressing"
+            ingredient = recipe_data.get("ingredient")
+            if ingredient:
+                normalized["ingredients"] = [ingredient]
+        elif "create:sequenced_assembly" in recipe_type:
+            normalized["recipe_category"] = "sequenced_assembly"
+            normalized["requires_manual_review"] = True
+            normalized["manual_review_reason"] = (
+                "Sequenced assembly requires multi-step crafting not supported in Bedrock"
+            )
+        elif "create:mixing" in recipe_type:
+            normalized["recipe_category"] = "mixing"
+            normalized["requires_manual_review"] = True
+            normalized["manual_review_reason"] = (
+                "Mixing recipes require Create's mixer block not available in Bedrock"
+            )
+        elif "create:deploying" in recipe_type:
+            normalized["recipe_category"] = "deploying"
+            normalized["requires_manual_review"] = True
+            normalized["manual_review_reason"] = (
+                "Deploying recipes require Create's deployer not available in Bedrock"
+            )
+        elif "create:filling" in recipe_type or "create:emptying" in recipe_type:
+            normalized["recipe_category"] = "fluid_interaction"
+            normalized["requires_manual_review"] = True
+            normalized["manual_review_reason"] = (
+                "Fluid interaction recipes require Create's fluid mechanisms not available in Bedrock"
+            )
+        elif self._is_custom_recipe_type(recipe_type):
+            normalized["recipe_category"] = "custom"
+            normalized["requires_manual_review"] = True
+            normalized["manual_review_reason"] = (
+                f"Custom Forge recipe type '{recipe_type}' requires manual review"
+            )
         else:
             normalized["recipe_category"] = "unknown"
+            normalized["requires_manual_review"] = True
+            normalized["manual_review_reason"] = f"Unknown recipe type: {recipe_type}"
             logger.warning(f"Unknown recipe type: {recipe_type}")
 
         return normalized
+
+    def _is_custom_recipe_type(self, recipe_type: str) -> bool:
+        """Check if a recipe type is a known custom Forge recipe type."""
+        for custom_type in CUSTOM_RECIPE_TYPES.keys():
+            if custom_type in recipe_type:
+                return True
+        return False
+
+    def _unwrap_conditional_recipe(self, recipe_data: Dict) -> Dict:
+        """Unwrap a forge:conditional recipe to get the inner recipe."""
+        if "recipe" in recipe_data:
+            inner = recipe_data["recipe"]
+            if isinstance(inner, dict):
+                return inner
+        return recipe_data
 
     def _convert_shaped_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
@@ -434,6 +576,251 @@ class RecipeConverterAgent:
 
         return bedrock_recipe
 
+    def _convert_cooking_pot_to_bedrock(
+        self, normalized_recipe: Dict, namespace: str, recipe_name: str
+    ) -> Dict:
+        """Convert a Farmer's Delight cooking pot recipe to Bedrock format.
+
+        Cooking pot recipes are converted to furnace recipes with additional
+        container and cooking time info preserved in comments/tags.
+        """
+        ingredients = normalized_recipe.get("ingredients", [])
+        if not ingredients:
+            return self._create_manual_review_result(
+                namespace, recipe_name, "Cooking pot recipe has no ingredients"
+            )
+
+        ingredient = ingredients[0]
+        if isinstance(ingredient, dict):
+            item_data = ingredient.get("item", "")
+            item_data_val = ingredient.get("data", 0)
+        else:
+            item_data = ingredient
+            item_data_val = 0
+
+        bedrock_ingredient = {
+            "item": self._map_java_item_to_bedrock(item_data),
+            "data": item_data_val,
+        }
+
+        bedrock_result = {
+            "item": self._map_java_item_to_bedrock(normalized_recipe.get("result_item", "")),
+            "data": normalized_recipe.get("result_data", 0),
+            "count": normalized_recipe.get("result_count", 1),
+        }
+
+        container = normalized_recipe.get("container")
+        cooking_time = normalized_recipe.get("cooking_time", 200)
+        experience = normalized_recipe.get("experience", 0.0)
+
+        bedrock_recipe = {
+            "format_version": "1.20.10",
+            "minecraft:recipe_furnace": {
+                "description": {"identifier": f"{namespace}:{recipe_name}"},
+                "tags": ["crafting_table", "cooking_pot"],
+                "ingredients": [bedrock_ingredient],
+                "result": bedrock_result,
+                "cookingtime": cooking_time,
+                "experience": experience,
+                "备注": f"Original container: {container}"
+                if container
+                else "Farmer's Delight cooking pot recipe",
+            },
+        }
+
+        return bedrock_recipe
+
+    def _convert_cutting_board_to_bedrock(
+        self, normalized_recipe: Dict, namespace: str, recipe_name: str
+    ) -> Dict:
+        """Convert a Farmer's Delight cutting board recipe to Bedrock format.
+
+        Cutting board recipes use a tool + ingredients -> result pattern.
+        We convert to a shaped recipe with the tool as part of the key.
+        """
+        ingredients = normalized_recipe.get("ingredients", [])
+        tool = normalized_recipe.get("tool")
+
+        if not ingredients:
+            return self._create_manual_review_result(
+                namespace, recipe_name, "Cutting board recipe has no ingredients"
+            )
+
+        bedrock_ingredients = []
+        for ingredient in ingredients:
+            if isinstance(ingredient, dict):
+                item_data = ingredient.get("item", "")
+                item_count = ingredient.get("count", 1)
+                item_data_val = ingredient.get("data", 0)
+            elif isinstance(ingredient, str):
+                item_data = ingredient
+                item_count = 1
+                item_data_val = 0
+            else:
+                continue
+
+            bedrock_item = self._map_java_item_to_bedrock(item_data)
+            entry = {"item": bedrock_item, "data": item_data_val}
+            if item_count > 1:
+                entry["count"] = item_count
+            bedrock_ingredients.append(entry)
+
+        bedrock_result = {
+            "item": self._map_java_item_to_bedrock(normalized_recipe.get("result_item", "")),
+            "data": normalized_recipe.get("result_data", 0),
+            "count": normalized_recipe.get("result_count", 1),
+        }
+
+        tool_info = ""
+        if tool:
+            tool_item = tool.get("item", tool) if isinstance(tool, dict) else tool
+            tool_info = f" - Requires tool: {tool_item}"
+
+        bedrock_recipe = {
+            "format_version": "1.20.10",
+            "minecraft:recipe_shaped": {
+                "description": {"identifier": f"{namespace}:{recipe_name}"},
+                "tags": ["crafting_table", "cutting_board"],
+                "pattern": ["A", "B"],
+                "key": {
+                    "A": bedrock_ingredients[0]
+                    if len(bedrock_ingredients) > 0
+                    else {"item": "minecraft:air"},
+                    "B": {"item": "minecraft:air"}
+                    if len(bedrock_ingredients) <= 1
+                    else bedrock_ingredients[1],
+                },
+                "result": bedrock_result,
+                "备注": f"Cutting board recipe{tool_info}",
+            },
+        }
+
+        return bedrock_recipe
+
+    def _convert_mechanical_crafting_to_bedrock(
+        self, normalized_recipe: Dict, namespace: str, recipe_name: str
+    ) -> Dict:
+        """Convert a Create mechanical crafting recipe to Bedrock format.
+
+        Mechanical crafting supports up to 9x9 grids. We convert to a standard
+        shaped recipe (Bedrock supports 3x3 max).
+        """
+        pattern = normalized_recipe.get("pattern", [])
+        key = normalized_recipe.get("key", {})
+
+        if not pattern or not key:
+            return self._create_manual_review_result(
+                namespace, recipe_name, "Mechanical crafting recipe has no pattern or key"
+            )
+
+        # Check if pattern exceeds 3x3 (Bedrock limit)
+        max_row_len = max(len(row) for row in pattern) if pattern else 0
+        if max_row_len > 3 or len(pattern) > 3:
+            return self._create_manual_review_result(
+                namespace,
+                recipe_name,
+                f"Mechanical crafting uses {max_row_len}x{len(pattern)} grid, Bedrock supports max 3x3",
+            )
+
+        bedrock_key = {}
+        for key_char, ingredient in key.items():
+            if isinstance(ingredient, list):
+                item_data = ingredient[0].get("item", "") if ingredient else "minecraft:air"
+                item_count = 1
+                item_data_val = 0
+            elif isinstance(ingredient, str):
+                item_data = ingredient
+                item_count = 1
+                item_data_val = 0
+            elif isinstance(ingredient, dict):
+                item_data = ingredient.get("item", "")
+                item_count = ingredient.get("count", 1)
+                item_data_val = ingredient.get("data", 0)
+            else:
+                continue
+
+            bedrock_item = self._map_java_item_to_bedrock(item_data)
+            entry = {"item": bedrock_item, "data": item_data_val}
+            if item_count > 1:
+                entry["count"] = item_count
+            bedrock_key[key_char] = entry
+
+        bedrock_result = {
+            "item": self._map_java_item_to_bedrock(normalized_recipe.get("result_item", "")),
+            "data": normalized_recipe.get("result_data", 0),
+            "count": normalized_recipe.get("result_count", 1),
+        }
+
+        bedrock_recipe = {
+            "format_version": "1.20.10",
+            "minecraft:recipe_shaped": {
+                "description": {"identifier": f"{namespace}:{recipe_name}"},
+                "tags": ["crafting_table", "mechanical_crafting"],
+                "pattern": pattern,
+                "key": bedrock_key,
+                "result": bedrock_result,
+            },
+        }
+
+        return bedrock_recipe
+
+    def _convert_pressing_to_bedrock(
+        self, normalized_recipe: Dict, namespace: str, recipe_name: str
+    ) -> Dict:
+        """Convert a Create pressing recipe to Bedrock format.
+
+        Pressing recipes are converted to a shaped recipe with the ingredient
+        as the main input.
+        """
+        ingredients = normalized_recipe.get("ingredients", [])
+        if not ingredients:
+            return self._create_manual_review_result(
+                namespace, recipe_name, "Pressing recipe has no ingredients"
+            )
+
+        ingredient = ingredients[0]
+        if isinstance(ingredient, dict):
+            item_data = ingredient.get("item", "")
+            item_data_val = ingredient.get("data", 0)
+        else:
+            item_data = ingredient
+            item_data_val = 0
+
+        bedrock_ingredient = {
+            "item": self._map_java_item_to_bedrock(item_data),
+            "data": item_data_val,
+        }
+
+        bedrock_result = {
+            "item": self._map_java_item_to_bedrock(normalized_recipe.get("result_item", "")),
+            "data": normalized_recipe.get("result_data", 0),
+            "count": normalized_recipe.get("result_count", 1),
+        }
+
+        bedrock_recipe = {
+            "format_version": "1.20.10",
+            "minecraft:recipe_shaped": {
+                "description": {"identifier": f"{namespace}:{recipe_name}"},
+                "tags": ["crafting_table", "pressing"],
+                "pattern": ["A"],
+                "key": {"A": bedrock_ingredient},
+                "result": bedrock_result,
+                "备注": "Create pressing recipe",
+            },
+        }
+
+        return bedrock_recipe
+
+    def _create_manual_review_result(self, namespace: str, recipe_name: str, reason: str) -> Dict:
+        """Create a result indicating the recipe requires manual review."""
+        return {
+            "format_version": "1.20.10",
+            "manual_review_required": True,
+            "reason": reason,
+            "original_recipe": f"{namespace}:{recipe_name}",
+            "description": {"identifier": f"{namespace}:{recipe_name}"},
+        }
+
     def convert_recipe(
         self, recipe_data: Dict, namespace: str = "mod", recipe_name: str = None
     ) -> Dict:
@@ -466,6 +853,22 @@ class RecipeConverterAgent:
             return self._convert_stonecutter_to_bedrock(normalized, namespace, recipe_name)
         elif category == "smithing":
             return self._convert_smithing_to_bedrock(normalized, namespace, recipe_name)
+        elif category == "cooking_pot":
+            return self._convert_cooking_pot_to_bedrock(normalized, namespace, recipe_name)
+        elif category == "cutting_board":
+            return self._convert_cutting_board_to_bedrock(normalized, namespace, recipe_name)
+        elif category == "mechanical_crafting":
+            return self._convert_mechanical_crafting_to_bedrock(normalized, namespace, recipe_name)
+        elif category == "pressing":
+            return self._convert_pressing_to_bedrock(normalized, namespace, recipe_name)
+        elif category in ("sequenced_assembly", "mixing", "deploying", "fluid_interaction"):
+            reason = normalized.get(
+                "manual_review_reason", "Custom recipe type requires manual review"
+            )
+            return self._create_manual_review_result(namespace, recipe_name, reason)
+        elif category == "custom":
+            reason = normalized.get("manual_review_reason", "Unknown custom Forge recipe type")
+            return self._create_manual_review_result(namespace, recipe_name, reason)
         else:
             logger.warning(f"Cannot convert unknown recipe category: {category}")
             return {"success": False, "error": f"Unknown recipe category: {category}"}

--- a/ai-engine/tests/unit/test_recipe_converter.py
+++ b/ai-engine/tests/unit/test_recipe_converter.py
@@ -6,8 +6,6 @@ which converts Java mod recipes to Bedrock format.
 """
 
 import pytest
-import json
-from unittest.mock import Mock, patch, MagicMock
 
 # Import the agent
 from agents.recipe_converter import RecipeConverterAgent
@@ -64,14 +62,11 @@ class TestRecipeConverterAgent:
         java_recipe = {
             "type": "minecraft:crafting_shaped",
             "pattern": ["###", "#X#", "###"],
-            "key": {
-                "#": {"item": "minecraft:iron_ingot"},
-                "X": {"item": "minecraft:diamond"}
-            },
-            "result": {"item": "minecraft:iron_block", "count": 1}
+            "key": {"#": {"item": "minecraft:iron_ingot"}, "X": {"item": "minecraft:diamond"}},
+            "result": {"item": "minecraft:iron_block", "count": 1},
         }
         result = agent._parse_java_recipe(java_recipe)
-        
+
         assert result["original_type"] == "minecraft:crafting_shaped"
         assert result["recipe_category"] == "shaped"
         assert result["pattern"] == ["###", "#X#", "###"]
@@ -82,14 +77,11 @@ class TestRecipeConverterAgent:
         """Test parsing Java shapeless recipe"""
         java_recipe = {
             "type": "minecraft:crafting_shapeless",
-            "ingredients": [
-                {"item": "minecraft:paper"},
-                {"item": "minecraft:book"}
-            ],
-            "result": {"item": "minecraft:writable_book", "count": 1}
+            "ingredients": [{"item": "minecraft:paper"}, {"item": "minecraft:book"}],
+            "result": {"item": "minecraft:writable_book", "count": 1},
         }
         result = agent._parse_java_recipe(java_recipe)
-        
+
         assert result["original_type"] == "minecraft:crafting_shapeless"
         assert result["recipe_category"] == "shapeless"
         assert len(result["ingredients"]) == 2
@@ -100,10 +92,10 @@ class TestRecipeConverterAgent:
             "type": "minecraft:smelting",
             "ingredient": {"item": "minecraft:iron_ore"},
             "result": "minecraft:iron_ingot",
-            "experience": 0.7
+            "experience": 0.7,
         }
         result = agent._parse_java_recipe(java_recipe)
-        
+
         assert result["original_type"] == "minecraft:smelting"
         assert result["recipe_category"] == "smelting"
         assert result["result_item"] == "minecraft:iron_ingot"
@@ -113,32 +105,26 @@ class TestRecipeConverterAgent:
         """Test conversion of shaped recipes"""
         normalized = {
             "pattern": ["###", "#X#", "###"],
-            "key": {
-                "#": {"item": "minecraft:iron_ingot"},
-                "X": {"item": "minecraft:diamond"}
-            },
+            "key": {"#": {"item": "minecraft:iron_ingot"}, "X": {"item": "minecraft:diamond"}},
             "result_item": "minecraft:iron_block",
             "result_count": 1,
-            "result_data": 0
+            "result_data": 0,
         }
         result = agent._convert_shaped_to_bedrock(normalized, "test_mod", "iron_block")
-        
+
         assert result["format_version"] == "1.20.10"
         assert "minecraft:recipe_shaped" in result
 
     def test_convert_shapeless_to_bedrock(self, agent):
         """Test conversion of shapeless recipes"""
         normalized = {
-            "ingredients": [
-                {"item": "minecraft:paper"},
-                {"item": "minecraft:book"}
-            ],
+            "ingredients": [{"item": "minecraft:paper"}, {"item": "minecraft:book"}],
             "result_item": "minecraft:writable_book",
             "result_count": 1,
-            "result_data": 0
+            "result_data": 0,
         }
         result = agent._convert_shapeless_to_bedrock(normalized, "test_mod", "writable_book")
-        
+
         assert result["format_version"] == "1.20.10"
         assert "minecraft:recipe_shapeless" in result
 
@@ -148,10 +134,12 @@ class TestRecipeConverterAgent:
             "ingredients": [{"item": "minecraft:iron_ore"}],
             "result_item": "minecraft:iron_ingot",
             "result_count": 1,
-            "experience": 0.7
+            "experience": 0.7,
         }
-        result = agent._convert_smelting_to_bedrock(normalized, "test_mod", "iron_ingot", "smelting")
-        
+        result = agent._convert_smelting_to_bedrock(
+            normalized, "test_mod", "iron_ingot", "smelting"
+        )
+
         assert result["format_version"] == "1.20.10"
         # Bedrock uses recipe_furnace for smelting
         assert "minecraft:recipe_furnace" in result
@@ -161,10 +149,10 @@ class TestRecipeConverterAgent:
         normalized = {
             "ingredients": [{"item": "minecraft:stone"}],
             "result_item": "minecraft:stone_bricks",
-            "result_count": 1
+            "result_count": 1,
         }
         result = agent._convert_stonecutter_to_bedrock(normalized, "test_mod", "stone_bricks")
-        
+
         assert result["format_version"] == "1.20.10"
         assert "minecraft:recipe_stonecutter" in result
 
@@ -173,10 +161,10 @@ class TestRecipeConverterAgent:
         normalized = {
             "base": {"item": "minecraft:netherite_sword"},
             "addition": {"item": "minecraft:emerald"},
-            "result_item": "minecraft:netherite_sword"
+            "result_item": "minecraft:netherite_sword",
         }
         result = agent._convert_smithing_to_bedrock(normalized, "test_mod", "netherite_sword")
-        
+
         assert result["format_version"] == "1.20.10"
         # Smithing uses recipe_smithing_transform
         assert "minecraft:recipe_smithing_transform" in result
@@ -186,14 +174,11 @@ class TestRecipeConverterAgent:
         recipe = {
             "type": "minecraft:crafting_shaped",
             "pattern": ["###", "#X#", "###"],
-            "key": {
-                "#": {"item": "minecraft:iron_ingot"},
-                "X": {"item": "minecraft:diamond"}
-            },
-            "result": {"item": "minecraft:iron_block", "count": 1}
+            "key": {"#": {"item": "minecraft:iron_ingot"}, "X": {"item": "minecraft:diamond"}},
+            "result": {"item": "minecraft:iron_block", "count": 1},
         }
         result = agent.convert_recipe(recipe, namespace="test_mod", recipe_name="iron_block")
-        
+
         assert result is not None
         assert "format_version" in result
         assert "minecraft:recipe_shaped" in result
@@ -202,14 +187,11 @@ class TestRecipeConverterAgent:
         """Test main convert_recipe method with shapeless recipe"""
         recipe = {
             "type": "minecraft:crafting_shapeless",
-            "ingredients": [
-                {"item": "minecraft:paper"},
-                {"item": "minecraft:book"}
-            ],
-            "result": {"item": "minecraft:writable_book", "count": 1}
+            "ingredients": [{"item": "minecraft:paper"}, {"item": "minecraft:book"}],
+            "result": {"item": "minecraft:writable_book", "count": 1},
         }
         result = agent.convert_recipe(recipe, namespace="test_mod", recipe_name="writable_book")
-        
+
         assert result is not None
         assert "format_version" in result
 
@@ -219,25 +201,22 @@ class TestRecipeConverterAgent:
             "type": "minecraft:smelting",
             "ingredient": {"item": "minecraft:iron_ore"},
             "result": "minecraft:iron_ingot",
-            "experience": 0.7
+            "experience": 0.7,
         }
         result = agent.convert_recipe(recipe, namespace="test_mod", recipe_name="iron_ingot")
-        
+
         assert result is not None
         assert "format_version" in result
 
     def test_convert_recipe_unknown_type(self, agent):
         """Test convert_recipe with unknown recipe type"""
-        recipe = {
-            "type": "unknown_recipe_type",
-            "data": "test"
-        }
+        recipe = {"type": "unknown_recipe_type", "data": "test"}
         result = agent.convert_recipe(recipe)
-        
+
         # Should return error dict for unknown type
         assert result is not None
         if isinstance(result, dict):
-            assert result.get("success") == False or "unknown" in str(result).lower()
+            assert not result.get("success") or "unknown" in str(result).lower()
 
 
 class TestRecipeConverterTools:
@@ -263,11 +242,11 @@ class TestRecipeConverterTools:
             "key": {"X": {"item": "minecraft:diamond"}},
             "result": {"item": "minecraft:diamond_block", "count": 1},
             "namespace": "test_mod",
-            "recipe_name": "diamond_block"
+            "recipe_name": "diamond_block",
         }
-        
+
         result = agent.convert_recipe(recipe)
-        
+
         assert result is not None
         assert "format_version" in result
         assert "minecraft:recipe_shaped" in result
@@ -281,22 +260,22 @@ class TestRecipeConverterTools:
                 "key": {"X": {"item": "minecraft:iron_ingot"}},
                 "result": {"item": "minecraft:iron_block", "count": 1},
                 "namespace": "test_mod",
-                "recipe_name": "iron_block"
+                "recipe_name": "iron_block",
             },
             {
                 "type": "minecraft:smelting",
                 "ingredient": {"item": "minecraft:iron_ore"},
                 "result": "minecraft:iron_ingot",
                 "namespace": "test_mod",
-                "recipe_name": "iron_ingot"
-            }
+                "recipe_name": "iron_ingot",
+            },
         ]
-        
+
         results = []
         for recipe in recipes:
             result = agent.convert_recipe(recipe)
             results.append(result)
-        
+
         assert len(results) == 2
         for result in results:
             assert result is not None
@@ -305,7 +284,7 @@ class TestRecipeConverterTools:
     def test_add_custom_mapping(self, agent):
         """Test adding custom item mapping"""
         agent.add_custom_item_mapping("modid:custom_ingot", "minecraft:gold_ingot")
-        
+
         # Verify mapping works
         result = agent._map_java_item_to_bedrock("modid:custom_ingot")
         assert result == "minecraft:gold_ingot"
@@ -322,7 +301,7 @@ class TestRecipeConverterEdgeCases:
         """Test handling of empty recipe"""
         result = agent.convert_recipe({})
         # Empty recipe has no type so returns None or error
-        assert result is None or (isinstance(result, dict) and result.get("success") == False)
+        assert result is None or (isinstance(result, dict) and not result.get("success"))
 
     def test_none_recipe(self, agent):
         """Test handling of None recipe"""
@@ -345,18 +324,18 @@ class TestRecipeConverterEdgeCases:
 
     def test_recipe_with_count(self, agent):
         """Test recipe with count > 1"""
-        recipe = {
-            "type": "minecraft:crafting_shaped",
-            "pattern": ["X"],
-            "key": {"X": {"item": "minecraft:iron_ingot"}},
-            "result": {"item": "minecraft:iron_block", "count": 4}
-        }
         result = agent._convert_shaped_to_bedrock(
-            {"pattern": ["X"], "key": {"X": {"item": "minecraft:iron_ingot"}}, 
-             "result_item": "minecraft:iron_block", "result_count": 4, "result_data": 0},
-            "test", "iron_block"
+            {
+                "pattern": ["X"],
+                "key": {"X": {"item": "minecraft:iron_ingot"}},
+                "result_item": "minecraft:iron_block",
+                "result_count": 4,
+                "result_data": 0,
+            },
+            "test",
+            "iron_block",
         )
-        
+
         assert result is not None
         recipe_data = result.get("minecraft:recipe_shaped", {})
         assert "result" in recipe_data
@@ -368,14 +347,14 @@ class TestRecipeConverterEdgeCases:
                 {"item": "minecraft:paper"},
                 {"item": "minecraft:paper"},
                 {"item": "minecraft:paper"},
-                {"item": "minecraft:leather"}
+                {"item": "minecraft:leather"},
             ],
             "result_item": "minecraft:book",
             "result_count": 1,
-            "result_data": 0
+            "result_data": 0,
         }
         result = agent._convert_shapeless_to_bedrock(normalized, "test", "book")
-        
+
         assert result is not None
         assert "minecraft:recipe_shapeless" in result
 
@@ -385,9 +364,220 @@ class TestRecipeConverterEdgeCases:
             "ingredients": [{"item": "minecraft:gold_ore"}],
             "result_item": "minecraft:gold_ingot",
             "result_count": 1,
-            "experience": 1.0
+            "experience": 1.0,
         }
         result = agent._convert_smelting_to_bedrock(normalized, "test", "gold_ingot", "smelting")
-        
+
         assert result is not None
         # Experience should be handled
+
+
+class TestCustomForgeRecipeTypes:
+    """Test cases for custom Forge recipe type handling"""
+
+    @pytest.fixture
+    def agent(self):
+        return RecipeConverterAgent()
+
+    def test_parse_farmersdelight_cooking(self, agent):
+        """Test parsing Farmer's Delight cooking pot recipe"""
+        java_recipe = {
+            "type": "farmersdelight:cooking",
+            "ingredient": {"item": "minecraft:beef"},
+            "result": {"item": "minecraft:cooked_beef", "count": 1},
+            "container": {"item": "minecraft:bowl"},
+            "cookingtime": 200,
+            "experience": 0.35,
+        }
+        result = agent._parse_java_recipe(java_recipe)
+
+        assert result["recipe_category"] == "cooking_pot"
+        assert result["container"] == {"item": "minecraft:bowl"}
+        assert result["cooking_time"] == 200
+        assert result["experience"] == 0.35
+
+    def test_parse_farmersdelight_cutting(self, agent):
+        """Test parsing Farmer's Delight cutting board recipe"""
+        java_recipe = {
+            "type": "farmersdelight:cutting",
+            "ingredients": [{"item": "minecraft:oak_log"}, {"item": "minecraft:iron_axe"}],
+            "result": {"item": "minecraft:oak_planks", "count": 6},
+            "tool": {"item": "minecraft:iron_axe"},
+        }
+        result = agent._parse_java_recipe(java_recipe)
+
+        assert result["recipe_category"] == "cutting_board"
+        assert result["tool"] == {"item": "minecraft:iron_axe"}
+        assert len(result["ingredients"]) == 2
+
+    def test_parse_create_mechanical_crafting(self, agent):
+        """Test parsing Create mechanical crafting recipe"""
+        java_recipe = {
+            "type": "create:mechanical_crafting",
+            "pattern": ["AAAAA", "BBBBB", "CCCCC"],
+            "key": {
+                "A": {"item": "create:andesite"},
+                "B": {"item": "create:copper_sheet"},
+                "C": {"item": "minecraft:iron_ingot"},
+            },
+            "result": {"item": "create:gearbox", "count": 1},
+        }
+        result = agent._parse_java_recipe(java_recipe)
+
+        assert result["recipe_category"] == "mechanical_crafting"
+        assert len(result["pattern"]) == 3
+
+    def test_parse_create_pressing(self, agent):
+        """Test parsing Create pressing recipe"""
+        java_recipe = {
+            "type": "create:pressing",
+            "ingredient": {"item": "create:copper_sheet"},
+            "result": {"item": "create:copper_block", "count": 1},
+        }
+        result = agent._parse_java_recipe(java_recipe)
+
+        assert result["recipe_category"] == "pressing"
+
+    def test_parse_create_sequenced_assembly(self, agent):
+        """Test parsing Create sequenced assembly (should require manual review)"""
+        java_recipe = {
+            "type": "create:sequenced_assembly",
+            "sequence": [],
+            "result": {"item": "create:precision_mechanism", "count": 1},
+        }
+        result = agent._parse_java_recipe(java_recipe)
+
+        assert result["recipe_category"] == "sequenced_assembly"
+        assert result["requires_manual_review"] is True
+        assert "Sequenced assembly" in result["manual_review_reason"]
+
+    def test_parse_create_mixing(self, agent):
+        """Test parsing Create mixing recipe (should require manual review)"""
+        java_recipe = {
+            "type": "create:mixing",
+            "ingredients": [],
+            "result": {"item": "minecraft:clay", "count": 1},
+        }
+        result = agent._parse_java_recipe(java_recipe)
+
+        assert result["recipe_category"] == "mixing"
+        assert result["requires_manual_review"] is True
+
+    def test_convert_cooking_pot(self, agent):
+        """Test conversion of cooking pot recipe"""
+        recipe = {
+            "type": "farmersdelight:cooking",
+            "ingredient": {"item": "minecraft:beef"},
+            "result": {"item": "minecraft:cooked_beef", "count": 1},
+            "container": {"item": "minecraft:bowl"},
+            "cookingtime": 200,
+            "experience": 0.35,
+        }
+        result = agent.convert_recipe(recipe, namespace="farmersdelight", recipe_name="cooked_beef")
+
+        assert result["format_version"] == "1.20.10"
+        assert "minecraft:recipe_furnace" in result
+        assert result["minecraft:recipe_furnace"]["tags"] == ["crafting_table", "cooking_pot"]
+
+    def test_convert_cutting_board(self, agent):
+        """Test conversion of cutting board recipe"""
+        recipe = {
+            "type": "farmersdelight:cutting",
+            "ingredients": [{"item": "minecraft:oak_log"}],
+            "result": {"item": "minecraft:oak_planks", "count": 6},
+            "tool": {"item": "minecraft:iron_axe"},
+        }
+        result = agent.convert_recipe(recipe, namespace="farmersdelight", recipe_name="oak_planks")
+
+        assert result["format_version"] == "1.20.10"
+        assert "minecraft:recipe_shaped" in result
+        assert "cutting_board" in result["minecraft:recipe_shaped"]["tags"]
+
+    def test_convert_mechanical_crafting_within_3x3(self, agent):
+        """Test conversion of mechanical crafting within Bedrock limits"""
+        recipe = {
+            "type": "create:mechanical_crafting",
+            "pattern": ["A", "B"],
+            "key": {"A": {"item": "create:andesite"}, "B": {"item": "minecraft:iron_ingot"}},
+            "result": {"item": "create:windmill", "count": 1},
+        }
+        result = agent.convert_recipe(recipe, namespace="create", recipe_name="windmill")
+
+        assert result["format_version"] == "1.20.10"
+        assert "minecraft:recipe_shaped" in result
+        assert "mechanical_crafting" in result["minecraft:recipe_shaped"]["tags"]
+
+    def test_convert_pressing(self, agent):
+        """Test conversion of pressing recipe"""
+        recipe = {
+            "type": "create:pressing",
+            "ingredient": {"item": "create:copper_sheet"},
+            "result": {"item": "create:copper_block", "count": 1},
+        }
+        result = agent.convert_recipe(recipe, namespace="create", recipe_name="copper_block")
+
+        assert result["format_version"] == "1.20.10"
+        assert "minecraft:recipe_shaped" in result
+        assert "pressing" in result["minecraft:recipe_shaped"]["tags"]
+
+    def test_convert_sequenced_assembly_requires_manual_review(self, agent):
+        """Test that sequenced assembly requires manual review"""
+        recipe = {
+            "type": "create:sequenced_assembly",
+            "sequence": [],
+            "result": {"item": "create:precision_mechanism", "count": 1},
+        }
+        result = agent.convert_recipe(recipe, namespace="create", recipe_name="precision_mechanism")
+
+        assert result["manual_review_required"] is True
+        assert "Sequenced assembly" in result["reason"]
+
+    def test_convert_multi_output_recipe_uses_first_result(self, agent):
+        """Test that multi-output recipes use the first result"""
+        recipe = {
+            "type": "minecraft:crafting_shaped",
+            "pattern": ["X"],
+            "key": {"X": {"item": "minecraft:diamond"}},
+            "result": [
+                {"item": "minecraft:diamond_sword", "count": 1},
+                {"item": "minecraft:diamond_pickaxe", "count": 1},
+            ],
+        }
+        result = agent.convert_recipe(recipe, namespace="test", recipe_name="multi")
+
+        assert result["format_version"] == "1.20.10"
+        # Should use first result
+        assert result["minecraft:recipe_shaped"]["result"]["item"] == "minecraft:diamond_sword"
+
+    def test_convert_forge_conditional_recipe(self, agent):
+        """Test that forge:conditional recipes are unwrapped"""
+        recipe = {
+            "type": "forge:conditional",
+            "recipe": {
+                "type": "minecraft:crafting_shaped",
+                "pattern": ["X"],
+                "key": {"X": {"item": "minecraft:gold_ingot"}},
+                "result": {"item": "minecraft:gold_block", "count": 1},
+            },
+        }
+        result = agent.convert_recipe(recipe, namespace="test", recipe_name="gold_block")
+
+        assert result["format_version"] == "1.20.10"
+        assert "minecraft:recipe_shaped" in result
+
+    def test_create_manual_review_result(self, agent):
+        """Test manual review result creation"""
+        result = agent._create_manual_review_result("test", "recipe_name", "Test reason")
+
+        assert result["manual_review_required"] is True
+        assert result["reason"] == "Test reason"
+        assert result["original_recipe"] == "test:recipe_name"
+        assert result["format_version"] == "1.20.10"
+
+    def test_is_custom_recipe_type(self, agent):
+        """Test custom recipe type detection"""
+        assert agent._is_custom_recipe_type("farmersdelight:cooking") is True
+        assert agent._is_custom_recipe_type("create:sequenced_assembly") is True
+        assert agent._is_custom_recipe_type("create:mixing") is True
+        assert agent._is_custom_recipe_type("minecraft:crafting_shaped") is False
+        assert agent._is_custom_recipe_type("unknown:custom_type") is False


### PR DESCRIPTION
## Summary

Implements support for custom Forge recipe types in the recipe converter to address issue #1078, which identified custom recipe handling as the primary gap preventing recipe coverage from exceeding 25.8% for popular mods.

## Changes Made

### New Recipe Type Support

| Mod | Recipe Type | Handling |
|-----|-------------|----------|
| **Farmer's Delight** | `farmersdelight:cooking` | Converts to Bedrock furnace recipe with `cooking_pot` tag |
| **Farmer's Delight** | `farmersdelight:cutting` | Converts to Bedrock shaped recipe with `cutting_board` tag |
| **Create** | `create:mechanical_crafting` | Converts to Bedrock shaped recipe (3x3 max); larger grids flagged for manual review |
| **Create** | `create:pressing` | Converts to Bedrock shaped recipe with `pressing` tag |
| **Create** | `create:sequenced_assembly` | Flagged `manual_review_required` |
| **Create** | `create:mixing` | Flagged `manual_review_required` |
| **Create** | `create:deploying` | Flagged `manual_review_required` |
| **Create** | `create:filling` / `create:emptying` | Flagged `manual_review_required` |
| **Forge** | `forge:conditional` | Unwraps and processes inner recipe |

### Additional Improvements

- **Multi-output recipes**: When recipes have an array of results, the converter now uses the first result
- **Manual review pathway**: Non-convertible recipe types return `manual_review_required: true` with a structured reason field
- **Recipe parsing normalization**: Added support for `container`, `tool`, and other custom metadata fields

## Implementation Details

- Added `CUSTOM_RECIPE_TYPES` constant to maintain the registry of known custom Forge recipe types
- Added helper methods: `_is_custom_recipe_type()`, `_unwrap_conditional_recipe()`, `_create_manual_review_result()`
- Added 4 new conversion methods for convertible custom types
- Updated `_parse_java_recipe()` to detect all custom recipe types
- Updated `convert_recipe()` to dispatch to appropriate conversion methods

## Testing

- 15 new unit tests added in `TestCustomForgeRecipeTypes` class
- All 42 tests passing (27 existing + 15 new)
- Ruff linting: All checks passed

## Expected Impact

- Recipe coverage for Farmer's Delight and Create should increase from ~22-25% toward 50%+
- Manual review flags provide clear handoff UX for non-convertible recipe types

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*