### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Information Leakage in Upload Error Response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,7 @@
 **Vulnerability:** Verification and password reset tokens were being logged in plaintext in the auth API endpoints.
 **Learning:** Even during development or when trying to be helpful for debugging, sensitive URLs containing single-use tokens must not be logged, as logs can be accessed by unauthorized personnel or systems.
 **Prevention:** Remove sensitive values from logger statements and only log the action that occurred (e.g. "Token generated for user X").
+## 2024-05-24 - Prevent Information Exposure in API Exceptions
+**Vulnerability:** The `upload.py` API endpoint directly exposed internal exception details (e.g., file system errors, stack traces) to clients by passing `str(e)` to `HTTPException(detail=...)`.
+**Learning:** Developers often include raw exception strings in HTTP error responses for easier debugging, unintentionally violating the "fail securely" principle and causing Information Exposure (CWE-200).
+**Prevention:** Always log detailed exceptions internally using `logger.error(f"... {str(e)}")` but return a generic, static, and safe error message (e.g., "An unexpected error occurred.") to the client.

--- a/backend/src/api/upload.py
+++ b/backend/src/api/upload.py
@@ -236,7 +236,9 @@ async def upload_jar_file(
             ip_address=ip_address,
         )
         logger.error(f"Error uploading file: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Failed to upload file: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail="Failed to upload file. An unexpected error occurred."
+        )
 
 
 @router.post("/chunked/init", response_model=UploadInitResponse)


### PR DESCRIPTION
This PR fixes a security issue (Information Exposure, CWE-200) in the `upload.py` API endpoint.

**Vulnerability:**
The `upload.py` endpoint was catching generic exceptions and returning `str(e)` in the `HTTPException` detail. This exposes internal exception details (such as database errors, file system paths, or downstream service errors) directly to the client.

**Fix:**
Replaced the detailed error message in the HTTP response with a generic "An unexpected error occurred." message. The detailed error is still logged internally via `logger.error` for debugging purposes, adhering to the "fail securely" principle.

---
*PR created automatically by Jules for task [393843588667497212](https://jules.google.com/task/393843588667497212) started by @anchapin*

## Summary by Sourcery

Prevent sensitive internal exception details from being exposed in the upload API error response and document the security fix in Sentinel notes.

Bug Fixes:
- Return a generic error message from the upload API instead of propagating raw exception strings to clients to avoid information leakage.

Documentation:
- Add a Sentinel security entry describing the information exposure issue in API exceptions and the secure handling pattern for error responses.