### PR TITLE
fix: Support non-standard JAR layout patterns for 8 popular mods (Issue #1105) (Vibe Kanban)

### DIFF
--- a/ai-engine/agents/bedrock_builder.py
+++ b/ai-engine/agents/bedrock_builder.py
@@ -145,6 +145,7 @@ class BedrockBuilderAgent:
             result["bulk_textures_extracted"] = bulk_texture_results.get("extracted_count", 0)
             result["bulk_textures_copied"] = len(bulk_texture_results.get("copied_files", []))
             result["bulk_texture_errors"] = bulk_texture_results.get("errors", [])
+            result["bulk_texture_warnings"] = bulk_texture_results.get("warnings", [])
 
             # Atlas texture extraction: extract sprites from texture atlases (Issue #1104 fix)
             # This handles JEI, JourneyMap, and other mods that use sprite sheet atlases
@@ -479,56 +480,101 @@ class BedrockBuilderAgent:
         that were explicitly referenced by detected blocks/entities, missing the
         majority of textures in complex mods.
 
+        Also handles non-standard JAR layouts (Issue #1105) by trying alternative
+        texture locations when standard patterns yield no results.
+
         Args:
             jar_path: Path to the source JAR file
             rp_path: Path to the resource pack directory
             namespace: Default namespace if not found in JAR
 
         Returns:
-            Dict with extraction results (extracted_count, copied_files, errors)
+            Dict with extraction results (extracted_count, copied_files, errors, warnings)
         """
         result = {
             "extracted_count": 0,
             "copied_files": [],
             "errors": [],
             "skipped_count": 0,
+            "warnings": [],
+            "layout_detected": "standard",
         }
 
         try:
             with zipfile.ZipFile(jar_path, "r") as jar:
                 file_list = jar.namelist()
 
-                # Find ALL texture files in assets/*/textures/
-                # Issue #999: Don't filter by type - extract everything
-                texture_files = [
+                texture_files = []
+                mcmeta_files = set()
+
+                standard_texture_files = [
                     f
                     for f in file_list
                     if f.startswith("assets/") and "/textures/" in f and f.endswith(".png")
                 ]
 
-                # Also find associated .mcmeta animation files
                 mcmeta_files = set(
                     f
                     for f in file_list
                     if f.startswith("assets/") and "/textures/" in f and f.endswith(".png.mcmeta")
                 )
 
-                logger.info(f"Bulk texture extraction: found {len(texture_files)} textures in JAR")
+                if standard_texture_files:
+                    texture_files = standard_texture_files
+                    result["layout_detected"] = "standard"
+                    logger.info(
+                        f"Bulk texture extraction: found {len(texture_files)} textures in standard layout"
+                    )
+                else:
+                    alt_patterns = ["textures/", "assets/textures/", "/textures/"]
+                    alt_texture_files = [
+                        f
+                        for f in file_list
+                        if any(f.startswith(pattern) for pattern in alt_patterns)
+                        and f.endswith(".png")
+                    ]
+
+                    if alt_texture_files:
+                        texture_files = alt_texture_files
+                        result["layout_detected"] = "non-standard"
+                        result["warnings"].append(
+                            f"Non-standard JAR layout detected (Issue #1105). "
+                            f"Found {len(texture_files)} textures in alternative locations. "
+                            f"Standard assets/*/textures/ pattern yielded 0 results."
+                        )
+                        logger.warning(
+                            f"Bulk texture extraction: found {len(texture_files)} textures in non-standard layout "
+                            f"(alternative patterns). Standard assets/*/textures/ pattern yielded 0 results."
+                        )
+
+                        alt_mcmeta_files = [
+                            f
+                            for f in file_list
+                            if any(f.startswith(pattern) for pattern in alt_patterns)
+                            and f.endswith(".png.mcmeta")
+                        ]
+                        mcmeta_files = set(alt_mcmeta_files)
+                    else:
+                        result["layout_detected"] = "none"
+                        result["warnings"].append(
+                            "No textures found in JAR. Tried standard assets/*/textures/ and "
+                            "alternative patterns (textures/, assets/textures/, /textures/). "
+                            "This may indicate a non-standard mod structure or empty asset directory."
+                        )
+                        logger.warning(
+                            "Bulk texture extraction: No textures found in JAR. "
+                            "Tried standard assets/*/textures/ and alternative patterns."
+                        )
 
                 for texture_file in texture_files:
                     try:
-                        # Read texture data from JAR
                         texture_data = jar.read(texture_file)
 
-                        # Map Java texture path to Bedrock path
-                        # assets/namespace/textures/block/name.png -> textures/blocks/name.png
                         bedrock_path = self._map_java_texture_to_bedrock(texture_file)
 
-                        # Create output subdirectories
                         full_output_dir = rp_path / Path(bedrock_path).parent
                         full_output_dir.mkdir(parents=True, exist_ok=True)
 
-                        # Save texture
                         output_file = rp_path / bedrock_path
                         with open(output_file, "wb") as f:
                             f.write(texture_data)
@@ -542,7 +588,6 @@ class BedrockBuilderAgent:
                         )
                         result["extracted_count"] += 1
 
-                        # Check for associated .mcmeta animation file
                         mcmeta_path = texture_file + ".mcmeta"
                         if mcmeta_path in mcmeta_files:
                             mcmeta_data = jar.read(mcmeta_path)
@@ -564,7 +609,8 @@ class BedrockBuilderAgent:
 
                 logger.info(
                     f"Bulk texture extraction complete: {result['extracted_count']} textures, "
-                    f"{result['skipped_count']} skipped, {len(result['errors'])} errors"
+                    f"{result['skipped_count']} skipped, {len(result['errors'])} errors, "
+                    f"layout={result['layout_detected']}"
                 )
 
         except zipfile.BadZipFile:
@@ -728,8 +774,13 @@ class BedrockBuilderAgent:
         """
         Map Java mod texture path to Bedrock resource pack texture path.
 
-        Java: assets/<namespace>/textures/<type>/<name>.png
+        Java (standard): assets/<namespace>/textures/<type>/<name>.png
+        Java (non-standard): textures/<type>/<name>.png or assets/textures/<type>/<name>.png
         Bedrock: textures/<type>s/<name>.png (e.g., textures/blocks/name.png)
+
+        Handles non-standard layouts (Issue #1105) where textures may be at:
+        - textures/<type>/<name>.png (without assets/namespace/ prefix)
+        - assets/textures/<type>/<name>.png (without namespace)
 
         Args:
             java_path: Java mod texture path
@@ -739,17 +790,24 @@ class BedrockBuilderAgent:
         """
         parts = java_path.replace("\\", "/").split("/")
 
-        # Parse: assets/namespace/textures/type/name.png
         if len(parts) >= 5 and parts[0] == "assets" and parts[2] == "textures":
-            texture_type = parts[3]  # block, item, entity, etc.
-            texture_name = parts[4]  # name.png
-
-            # Map Java texture types to Bedrock (plural form)
+            texture_type = parts[3]
+            texture_name = parts[4]
             bedrock_type = self._map_texture_type_to_bedrock(texture_type)
-
             return f"textures/{bedrock_type}/{texture_name}"
 
-        # Fallback: just use the filename
+        if len(parts) >= 3 and parts[0] == "textures":
+            texture_type = parts[1]
+            texture_name = parts[2] if len(parts) >= 3 else Path(java_path).name
+            bedrock_type = self._map_texture_type_to_bedrock(texture_type)
+            return f"textures/{bedrock_type}/{texture_name}"
+
+        if len(parts) >= 4 and parts[0] == "assets" and parts[1] == "textures":
+            texture_type = parts[2]
+            texture_name = parts[3] if len(parts) >= 4 else Path(java_path).name
+            bedrock_type = self._map_texture_type_to_bedrock(texture_type)
+            return f"textures/{bedrock_type}/{texture_name}"
+
         return f"textures/misc/{Path(java_path).name}"
 
     def _map_texture_type_to_bedrock(self, java_type: str) -> str:

--- a/ai-engine/tests/test_bedrock_builder_mvp.py
+++ b/ai-engine/tests/test_bedrock_builder_mvp.py
@@ -378,6 +378,135 @@ class TestBedrockBuilderMVP:
         assert any("MVP: Building block add-on" in msg for msg in info_calls)
         assert any("MVP: Successfully created" in msg for msg in info_calls)
 
+    def test_non_standard_layout_textures_at_root(self, builder, output_dir):
+        """Test extraction from non-standard JAR layout with textures at root (Issue #1105).
+
+        Some mods have textures at 'textures/block/name.png' instead of
+        'assets/modid/textures/block/name.png'. This test verifies that the
+        fallback mechanism properly detects and extracts these textures.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            with zipfile.ZipFile(jar_file.name, "w") as zf:
+                from PIL import Image
+                import io
+
+                textures = [
+                    ("textures/block/stone.png", (128, 128, 128, 255)),
+                    ("textures/block/dirt.png", (139, 69, 19, 255)),
+                    ("textures/item/iron_sword.png", (200, 200, 200, 255)),
+                ]
+
+                for texture_path, color in textures:
+                    img = Image.new("RGBA", (16, 16), color)
+                    png_buffer = io.BytesIO()
+                    img.save(png_buffer, format="PNG")
+                    zf.writestr(texture_path, png_buffer.getvalue())
+
+            try:
+                result = builder.build_block_addon_mvp(
+                    registry_name="test_mod:nonstandard_block",
+                    texture_path="textures/block/stone.png",
+                    jar_path=jar_file.name,
+                    output_dir=output_dir,
+                )
+
+                assert result["success"] is True
+                assert "bulk_texture_warnings" in result or len(result.get("errors", [])) == 0
+                assert result["bulk_textures_extracted"] >= 3, (
+                    f"Expected at least 3 textures from non-standard layout, got {result['bulk_textures_extracted']}"
+                )
+
+                rp_path = Path(output_dir) / "resource_pack"
+                assert (rp_path / "textures" / "blocks").exists(), (
+                    "blocks texture dir should exist for non-standard layout"
+                )
+
+            finally:
+                os.unlink(jar_file.name)
+
+    def test_non_standard_layout_assets_textures_without_namespace(self, builder, output_dir):
+        """Test extraction from non-standard JAR layout with assets/textures/ (Issue #1105).
+
+        Some mods have textures at 'assets/textures/block/name.png' instead of
+        'assets/modid/textures/block/name.png'.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            with zipfile.ZipFile(jar_file.name, "w") as zf:
+                from PIL import Image
+                import io
+
+                textures = [
+                    ("assets/textures/block/stone.png", (128, 128, 128, 255)),
+                    ("assets/textures/block/dirt.png", (139, 69, 19, 255)),
+                ]
+
+                for texture_path, color in textures:
+                    img = Image.new("RGBA", (16, 16), color)
+                    png_buffer = io.BytesIO()
+                    img.save(png_buffer, format="PNG")
+                    zf.writestr(texture_path, png_buffer.getvalue())
+
+            try:
+                result = builder.build_block_addon_mvp(
+                    registry_name="test_mod:alt_layout_block",
+                    texture_path="assets/textures/block/stone.png",
+                    jar_path=jar_file.name,
+                    output_dir=output_dir,
+                )
+
+                assert result["success"] is True
+                assert result["bulk_textures_extracted"] >= 2, (
+                    f"Expected at least 2 textures from assets/textures layout, got {result['bulk_textures_extracted']}"
+                )
+
+            finally:
+                os.unlink(jar_file.name)
+
+    def test_empty_jar_no_textures(self, builder, output_dir):
+        """Test handling of JAR with no textures (Issue #1105).
+
+        When a JAR contains no textures, appropriate warnings should be surfaced.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".jar", delete=False) as jar_file:
+            with zipfile.ZipFile(jar_file.name, "w") as zf:
+                zf.writestr("README.txt", b"This mod has no textures")
+                zf.writestr(
+                    "data/modid/recipes/example.json", b'{"type":"minecraft:crafting_shaped"}'
+                )
+
+            try:
+                result = builder.build_block_addon_mvp(
+                    registry_name="test_mod:empty_block",
+                    texture_path="assets/test/textures/block/stone.png",
+                    jar_path=jar_file.name,
+                    output_dir=output_dir,
+                )
+
+                assert result["bulk_textures_extracted"] == 0, (
+                    "Should report 0 textures extracted for empty JAR"
+                )
+                assert result.get("bulk_texture_warnings") or len(result.get("errors", [])) > 0, (
+                    "Should have warnings or errors for empty texture extraction"
+                )
+
+            finally:
+                os.unlink(jar_file.name)
+
+    def test_map_java_texture_to_bedrock_nonstandard_path(self, builder):
+        """Test _map_java_texture_to_bedrock handles non-standard paths (Issue #1105)."""
+        standard_path = "assets/modid/textures/block/stone.png"
+        root_path = "textures/block/stone.png"
+        assets_textures_path = "assets/textures/block/stone.png"
+
+        standard_result = builder._map_java_texture_to_bedrock(standard_path)
+        assert standard_result == "textures/blocks/stone.png"
+
+        root_result = builder._map_java_texture_to_bedrock(root_path)
+        assert root_result == "textures/blocks/stone.png"
+
+        assets_textures_result = builder._map_java_texture_to_bedrock(assets_textures_path)
+        assert assets_textures_result == "textures/blocks/stone.png"
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary

This PR fixes Issue #1105 by adding support for non-standard JAR layout patterns. Currently, 8 popular mods (REI, Storage Drawers, Astral Sorcery, Silent Gear, Tinkers' Construct, ProjectE, AbyssalCraft, Compact Machines) produce zero output because their JARs do not follow the standard assets/<modid>/textures/ layout.

## Changes Made

### ai-engine/agents/bedrock_builder.py

- _extract_all_textures_from_jar: Added fallback mechanism to try alternative texture patterns when standard assets/*/textures/ yields no results
- _map_java_texture_to_bedrock: Enhanced to parse non-standard texture paths
- build_block_addon_mvp: Propagates bulk_texture_warnings to result

### ai-engine/tests/test_bedrock_builder_mvp.py

Added 4 new tests for non-standard layout scenarios.

## Why This Matters

The v6 audit showed 8/30 mods producing zero output. Silent zero-output on popular mods is a hard blocker for beta credibility.

All 15 tests in test_bedrock_builder_mvp.py pass.

---

This PR was written using Vibe Kanban