### PR TITLE
fix(security): add security-events write permission to Trivy scan job (Vibe Kanban)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -77,6 +77,9 @@ jobs:
     name: Trivy Dependency Scan
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Added the required security-events write permission to the trivy-dependency-scan job in the security workflow.

## What Changed

Added permissions block to the trivy-dependency-scan job with:
- security-events: write - Required to upload Trivy scan results to GitHub dependency graph
- contents: read - Required for checkout operations

## Why This Fix Was Needed

The Trivy upload step in the security workflow was failing because the job lacked the security-events: write permission required to upload scan results to GitHub. This caused the main branch CI to fail.

## Implementation Details

- Affected file: .github/workflows/security.yml
- Job affected: trivy-dependency-scan
- Issue reference: Fixes #1132

## Notes

- Does NOT block PR merges (individual PRs show green CI)
- Only affects main branch CI runs

---

This PR was written using Vibe Kanban (https://vibekanban.com)