### PR TITLE
fix: Update Dockerfile to Python 3.11 and add Fly.io config for #1155

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Backend builder
 # ============================================
-FROM python:3.14-slim AS backend-builder
+FROM python:3.11-slim AS backend-builder
 
 WORKDIR /app/backend
 
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 2: AI Engine builder
 # ============================================
-FROM python:3.14-slim AS ai-engine-builder
+FROM python:3.11-slim AS ai-engine-builder
 
 WORKDIR /app/ai-engine
 
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 3: Production backend
 # ============================================
-FROM python:3.14-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 
@@ -54,8 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Python dependencies from builders - use correct Python 3.14 path
-COPY --from=backend-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+# Copy Python dependencies from builders - use correct Python 3.11 path
+COPY --from=backend-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=backend-builder /usr/local/bin /usr/local/bin
 
 # Create non-root user

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,0 +1,72 @@
+# Fly.io configuration for PortKit Backend
+# Deploy with: fly deploy
+
+app = "portkit-backend"
+kill_signal = "SIGINT"
+kill_timeout = "5s"
+
+# Build configuration
+build = [
+  "dockerfile=Dockerfile",
+  "build-arg PYTHON_VERSION=3.11"
+]
+
+# Primary region
+primary_region = "iad"
+
+# Runtime configuration
+[build.args]
+PYTHON_VERSION = "3.11"
+
+[deploy]
+  release_command = "alembic upgrade head"
+
+# Health check
+[healthcheck]
+  port = 8000
+  path = "/api/v1/health"
+  interval = "30s"
+  timeout = "10s"
+  retries = 3
+
+# Port configuration
+[ports]
+  internal = 8000
+
+# Process group
+[processes]
+  app = "uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers 1 --access-log"
+  worker = "celery -A src.services.celery_config worker --loglevel=info"
+
+# Environment variables
+[env]
+  PYTHONUNBUFFERED = "1"
+
+# Volume for persistent storage
+[mounts]
+  source = "portkit_data"
+  destination = "/app/data"
+  initial_size = "1gb"
+
+# HTTP service
+[[services]]
+  internal_port = 8000
+  protocol = "tcp"
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls"]
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+
+  [[services.checks]]
+    path = "/api/v1/health"
+    interval = "30s"
+    timeout = "10s"
+    retries = 3


### PR DESCRIPTION
## Summary

Fixes the Python version issue in Dockerfile (3.14 → 3.11) and adds Fly.io configuration for production deployment.

### Changes

1. **Dockerfile**: Update Python version from 3.14-slim to 3.11-slim in all build stages
2. **backend/fly.toml**: Add Fly.io deployment configuration

### Fixes

- Python 3.14 is not compatible with pyproject.toml's `python_version = "3.11"`
- Issue #1155: Deploy PortKit to production (portkit.ai)

### Testing

- ✅ Dockerfile builds successfully with Python 3.11
- ✅ Fly.io configuration created

## Manual Steps Required

See the issue for full deployment checklist: https://github.com/anchapin/ModPorter-AI/issues/1155