### PR TITLE
🎨 Palette: Add focus-visible styles to Cookie Consent Banner

### DIFF
--- a/frontend/src/components/common/CookieConsentBanner.css
+++ b/frontend/src/components/common/CookieConsentBanner.css
@@ -55,6 +55,11 @@
   text-decoration: underline;
 }
 
+.cookie-consent-links a:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
 .cookie-consent-actions {
   display: flex;
   gap: 0.75rem;
@@ -69,6 +74,11 @@
   cursor: pointer;
   transition: all 0.2s;
   border: none;
+}
+
+.cookie-consent-btn:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
 }
 
 .cookie-consent-decline {


### PR DESCRIPTION
Added `:focus-visible` pseudo-class to the links and buttons in the Cookie Consent Banner to improve keyboard accessibility and provide a clear visual indicator of focus.

---
*PR created automatically by Jules for task [4276854477470380104](https://jules.google.com/task/4276854477470380104) started by @anchapin*

## Summary by Sourcery

Improve keyboard focus visibility for interactive elements in the Cookie Consent Banner.

Enhancements:
- Add explicit :focus-visible outlines to cookie consent links to provide a clear focus indicator for keyboard users.
- Add :focus-visible outlines to cookie consent action buttons to align focus behavior across interactive controls.