### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Information Exposure in API Exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -45,3 +45,8 @@
 **Vulnerability:** The `upload.py` API endpoint directly exposed internal exception details (e.g., file system errors, stack traces) to clients by passing `str(e)` to `HTTPException(detail=...)`.
 **Learning:** Developers often include raw exception strings in HTTP error responses for easier debugging, unintentionally violating the "fail securely" principle and causing Information Exposure (CWE-200).
 **Prevention:** Always log detailed exceptions internally using `logger.error(f"... {str(e)}")` but return a generic, static, and safe error message (e.g., "An unexpected error occurred.") to the client.
+
+## 2024-05-24 - Prevent Information Exposure in API Exceptions
+**Vulnerability:** The application directly exposed internal exception details (e.g., file system errors, stack traces) to clients by passing `str(e)` to `HTTPException(detail=...)` across multiple files.
+**Learning:** Developers often include raw exception strings in HTTP error responses for easier debugging, unintentionally violating the "fail securely" principle and causing Information Exposure (CWE-200).
+**Prevention:** Always log detailed exceptions internally using `logger.error(f"... {str(e)}")` but return a generic, static, and safe error message (e.g., "An unexpected error occurred.") to the client.

--- a/ai-engine/main.py
+++ b/ai-engine/main.py
@@ -742,7 +742,7 @@ async def evaluate_rag_query(request: RAGEvaluationRequest):
 
     except Exception as e:
         logger.error(f"RAG evaluation failed: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Evaluation failed: {str(e)}")
+        raise HTTPException(status_code=500, detail="Evaluation failed.")
 
 
 @app.get("/api/v1/rag/health", tags=["evaluation"], summary="Check RAG evaluation service health")

--- a/backend/src/api/automation_metrics.py
+++ b/backend/src/api/automation_metrics.py
@@ -253,7 +253,7 @@ async def get_automation_metrics(
         )
     except Exception as e:
         logger.error(f"Failed to get automation metrics: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get automation metrics: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get automation metrics.")
 
 
 @router.get("/automation/dashboard", response_model=DashboardData)
@@ -324,7 +324,7 @@ async def get_automation_dashboard(
         )
     except Exception as e:
         logger.error(f"Failed to get dashboard data: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get dashboard data: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get dashboard data.")
 
 
 @router.post("/automation/record", response_model=ConversionEventResponse, status_code=201)
@@ -364,7 +364,7 @@ async def record_conversion_event(
         )
     except Exception as e:
         logger.error(f"Failed to record conversion event: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to record conversion event: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to record conversion event.")
 
 
 @router.get("/automation/history", response_model=HistoricalDataResponse)
@@ -403,7 +403,7 @@ async def get_automation_history(
         )
     except Exception as e:
         logger.error(f"Failed to get historical data: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get historical data: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get historical data.")
 
 
 @router.get("/automation/events", response_model=HistoryEventsResponse)
@@ -448,7 +448,7 @@ async def get_conversion_events(
         )
     except Exception as e:
         logger.error(f"Failed to get conversion events: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get conversion events: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get conversion events.")
 
 
 @router.post("/automation/reset")
@@ -469,4 +469,4 @@ async def reset_automation_metrics():
         }
     except Exception as e:
         logger.error(f"Failed to reset metrics: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to reset metrics: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to reset metrics.")

--- a/backend/src/api/billing.py
+++ b/backend/src/api/billing.py
@@ -244,7 +244,9 @@ async def create_checkout_session(
 
     except stripe.error.StripeError as e:
         logger.error(f"Stripe checkout error: {e}")
-        raise HTTPException(status_code=500, detail="Failed to create checkout session. Please try again later.")
+        raise HTTPException(
+            status_code=500, detail="Failed to create checkout session. Please try again later."
+        )
 
 
 @router.post("/portal", response_model=PortalResponse)
@@ -292,7 +294,9 @@ async def create_portal_session(
 
     except stripe.error.StripeError as e:
         logger.error(f"Stripe portal error: {e}")
-        raise HTTPException(status_code=500, detail="Failed to create portal session. Please try again later.")
+        raise HTTPException(
+            status_code=500, detail="Failed to create portal session. Please try again later."
+        )
 
 
 @router.post("/webhook")

--- a/backend/src/api/billing.py
+++ b/backend/src/api/billing.py
@@ -244,7 +244,7 @@ async def create_checkout_session(
 
     except stripe.error.StripeError as e:
         logger.error(f"Stripe checkout error: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to create checkout session: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to create checkout session. Please try again later.")
 
 
 @router.post("/portal", response_model=PortalResponse)
@@ -292,7 +292,7 @@ async def create_portal_session(
 
     except stripe.error.StripeError as e:
         logger.error(f"Stripe portal error: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to create portal session: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to create portal session. Please try again later.")
 
 
 @router.post("/webhook")

--- a/backend/src/api/embeddings.py
+++ b/backend/src/api/embeddings.py
@@ -355,13 +355,13 @@ async def index_document(
         logger.error(f"Invalid chunking strategy: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid chunking strategy: {str(e)}",
+            detail="Invalid chunking strategy.",
         )
     except Exception as e:
         logger.error(f"Error indexing document: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error indexing document: {str(e)}",
+            detail="Error indexing document.",
         )
 
 
@@ -731,12 +731,12 @@ async def hybrid_search(  # noqa: C901
         logger.error("Required module not available", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Required module not available: {str(e)}",
+            detail="Required module not available.",
         )
     except Exception as e:
         logger.error(f"Hybrid search failed: {e}", exc_info=True)
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Search failed: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Search failed."
         )
 
 
@@ -1059,5 +1059,5 @@ async def search_similar_embeddings_enhanced(
     except Exception as e:
         logger.error(f"Error in enhanced search: {e}", exc_info=True)
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Search failed: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Search failed."
         )

--- a/backend/src/api/knowledge_base.py
+++ b/backend/src/api/knowledge_base.py
@@ -193,13 +193,13 @@ async def submit_pattern(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e),
+            detail="An unexpected error occurred.",
         )
     except Exception as e:
         logger.error(f"Error submitting pattern: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to submit pattern: {str(e)}",
+            detail="Failed to submit pattern.",
         )
 
 
@@ -223,7 +223,7 @@ async def get_pending_submissions(
         logger.error(f"Error getting pending submissions: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get pending submissions: {str(e)}",
+            detail="Failed to get pending submissions.",
         )
 
 
@@ -271,13 +271,13 @@ async def review_pattern(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e),
+            detail="An unexpected error occurred.",
         )
     except Exception as e:
         logger.error(f"Error reviewing pattern: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to review pattern: {str(e)}",
+            detail="Failed to review pattern.",
         )
 
 
@@ -323,13 +323,13 @@ async def vote_on_pattern(
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e),
+            detail="An unexpected error occurred.",
         )
     except Exception as e:
         logger.error(f"Error voting on pattern: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to vote on pattern: {str(e)}",
+            detail="Failed to vote on pattern.",
         )
 
 
@@ -383,7 +383,7 @@ async def get_pattern_library(
         logger.error(f"Error getting pattern library: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get pattern library: {str(e)}",
+            detail="Failed to get pattern library.",
         )
 
 
@@ -466,7 +466,7 @@ async def get_related_chunks(
         logger.error(f"Error getting related chunks: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to get related chunks: {str(e)}",
+            detail="Failed to get related chunks.",
         )
 
 
@@ -510,7 +510,7 @@ async def analyze_chunk_relationships(
         logger.error(f"Error analyzing chunk relationships: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to analyze chunk: {str(e)}",
+            detail="Failed to analyze chunk.",
         )
 
 
@@ -544,7 +544,7 @@ async def build_concept_graph(
         logger.error(f"Error building concept graph: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to build concept graph: {str(e)}",
+            detail="Failed to build concept graph.",
         )
 
 
@@ -705,7 +705,7 @@ async def upload_texture_asset(
         logger.error(f"Error uploading texture asset: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to upload texture: {str(e)}",
+            detail="Failed to upload texture.",
         )
 
 
@@ -793,7 +793,7 @@ async def upload_model_asset(
         logger.error(f"Error uploading model asset: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to upload model: {str(e)}",
+            detail="Failed to upload model.",
         )
 
 
@@ -859,7 +859,7 @@ async def search_multimodal(
         logger.error(f"Error in multi-modal search: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Search failed: {str(e)}",
+            detail="Search failed.",
         )
 
 
@@ -913,5 +913,5 @@ async def get_related_across_modalities(
         logger.error(f"Error finding related modalities: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to find related content: {str(e)}",
+            detail="Failed to find related content.",
         )

--- a/backend/src/api/mode_classification.py
+++ b/backend/src/api/mode_classification.py
@@ -83,7 +83,9 @@ async def classify_mod(
 
     except ValueError as e:
         logger.error(f"Classification error: {e}")
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid request parameters.")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid request parameters."
+        )
     except Exception as e:
         logger.error(f"Unexpected error during classification: {e}", exc_info=True)
         raise HTTPException(

--- a/backend/src/api/mode_classification.py
+++ b/backend/src/api/mode_classification.py
@@ -83,7 +83,7 @@ async def classify_mod(
 
     except ValueError as e:
         logger.error(f"Classification error: {e}")
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid request parameters.")
     except Exception as e:
         logger.error(f"Unexpected error during classification: {e}", exc_info=True)
         raise HTTPException(

--- a/backend/src/api/rag.py
+++ b/backend/src/api/rag.py
@@ -137,7 +137,7 @@ async def rag_search(request: RAGSearchRequest):
     except Exception as e:
         logger.error(f"RAG search failed: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Search failed: {str(e)}"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Search failed."
         )
 
 


### PR DESCRIPTION
This pull request addresses a Medium priority security issue where internal exception details, including stack trace lines or backend file paths, were being directly exposed to clients through API `HTTPException`s.

🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Information Exposure (CWE-200) in multiple backend API endpoints. Raw exceptions `str(e)` were passed to `HTTPException(detail=...)`.
🎯 **Impact**: Exposed system paths, tracebacks, database schema hints, and third-party API error details (e.g. Stripe checkout) directly to the user when unexpected faults occurred.
🔧 **Fix**: Substituted the `str(e)` with safe, generic status messages across all endpoints, ensuring the actual exceptions are only logged internally using `logger.error()`.
✅ **Verification**: Run `grep -rn "HTTPException" backend/src/api/ ai-engine/ | grep "str(e)"` to confirm zero leaks, and run `uv run pytest src/tests` to confirm no core logic breaking.

---
*PR created automatically by Jules for task [482099144337593156](https://jules.google.com/task/482099144337593156) started by @anchapin*