### PR TITLE
🎨 Palette: [Accessibility] Add aria-label to remove button in RecipeGrid

### DIFF
--- a/frontend/src/components/BehaviorEditor/RecipeBuilder/RecipeGrid.tsx
+++ b/frontend/src/components/BehaviorEditor/RecipeBuilder/RecipeGrid.tsx
@@ -146,6 +146,7 @@ export const RecipeGrid: React.FC<RecipeGridProps> = ({
               <IconButton
                 size="small"
                 className="remove-button"
+                aria-label={`Remove ${slot.item.name}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   onItemRemove(slot);


### PR DESCRIPTION
Added `aria-label` to the `IconButton` used for removing items in `frontend/src/components/BehaviorEditor/RecipeBuilder/RecipeGrid.tsx` to improve accessibility for screen readers.

---
*PR created automatically by Jules for task [9168283912573998056](https://jules.google.com/task/9168283912573998056) started by @anchapin*

## Summary by Sourcery

Enhancements:
- Add an aria-label to the recipe grid remove icon button so screen readers can announce which item will be removed.