### PR TITLE
fix(backend): propagate original error messages in API exception details (Vibe Kanban)

### DIFF
--- a/backend/src/api/automation_metrics.py
+++ b/backend/src/api/automation_metrics.py
@@ -253,7 +253,7 @@ async def get_automation_metrics(
         )
     except Exception as e:
         logger.error(f"Failed to get automation metrics: {e}")
-        raise HTTPException(status_code=500, detail="Failed to get automation metrics.")
+        raise HTTPException(status_code=500, detail=f"Failed to get automation metrics: {e}")
 
 
 @router.get("/automation/dashboard", response_model=DashboardData)

--- a/backend/src/api/mode_classification.py
+++ b/backend/src/api/mode_classification.py
@@ -83,9 +83,7 @@ async def classify_mod(
 
     except ValueError as e:
         logger.error(f"Classification error: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid request parameters."
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Unexpected error during classification: {e}", exc_info=True)
         raise HTTPException(


### PR DESCRIPTION
## Summary

Fixes two failing CI checks on Dependabot PR #1178 (postcss 8.5.9 → 8.5.10) by updating API error handlers to include the original exception message in `HTTPException.detail` instead of returning generic error strings.

## Problem

PR #1178's CI pipeline had **3 failing checks** — `backend-test`, `Unit Tests (a-c*)`, and `Unit Tests (d-m*)` — all caused by 2 test assertion mismatches:

| Test | Expected | Actual |
|------|----------|--------|
| `test_get_automation_metrics_error` | `"db down"` in detail | `"Failed to get automation metrics."` |
| `test_classify_value_error` | `"bad input"` in detail | `"Invalid request parameters."` |

The API endpoints were swallowing the original exception messages and returning generic strings, so tests that asserted on the propagated error text failed.

## Changes

- **`backend/src/api/automation_metrics.py:256`** — Changed `detail="Failed to get automation metrics."` → `detail=f"Failed to get automation metrics: {e}"` so the underlying error (e.g. `"db down"`) is included in the response.
- **`backend/src/api/mode_classification.py:87`** — Changed `detail="Invalid request parameters."` → `detail=str(e)` so `ValueError` messages (e.g. `"bad input"`) propagate to the client.

## Verification

- All 3,225 backend unit tests pass (0 failures)
- Coverage: 87.46% (above 80% threshold)
- `ruff check` passes with no issues

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*