### PR TITLE
chore(deps): bump python from 3.11-slim to 3.14-slim (backport of #1182)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Backend builder
 # ============================================
-FROM python:3.11-slim AS backend-builder
+FROM python:3.14-slim AS backend-builder
 
 WORKDIR /app/backend
 
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 2: AI Engine builder
 # ============================================
-FROM python:3.11-slim AS ai-engine-builder
+FROM python:3.14-slim AS ai-engine-builder
 
 WORKDIR /app/ai-engine
 
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 3: Production backend
 # ============================================
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -16,7 +16,7 @@ RUN npm run build
 # Python dependencies build stage (consolidates all Python deps)
 # Note: Using Python 3.11 to match Debian bookworm's Python version
 # Debian bookworm-slim ships with Python 3.11.2, so we must build packages for 3.11
-FROM python:3.11-slim AS python-builder
+FROM python:3.14-slim AS python-builder
 WORKDIR /tmp
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc g++ curl libmagic1 ffmpeg && \

--- a/Dockerfile.fly.optimized
+++ b/Dockerfile.fly.optimized
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.npm \
 # =============================================================================
 # Stage 2: Python dependencies (with cache mount for pip)
 # =============================================================================
-FROM python:3.11-slim AS python-builder
+FROM python:3.14-slim AS python-builder
 WORKDIR /tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
Backport of #1182 - bump Python base image from 3.11-slim to 3.14-slim

## Changes
- Dockerfile: python:3.11-slim → python:3.14-slim
- Dockerfile.fly: python:3.11-slim → python:3.14-slim

## Testing
- [ ] Build succeeds
- [ ] All tests pass