### PR TITLE
chore(deps): bump python from 3.11-slim to 3.13-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Backend builder
 # ============================================
-FROM python:3.11-slim AS backend-builder
+FROM python:3.14-slim AS backend-builder
 
 WORKDIR /app/backend
 
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 2: AI Engine builder
 # ============================================
-FROM python:3.11-slim AS ai-engine-builder
+FROM python:3.14-slim AS ai-engine-builder
 
 WORKDIR /app/ai-engine
 
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 3: Production backend
 # ============================================
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 
@@ -54,8 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Python dependencies from builders - use correct Python 3.11 path
-COPY --from=backend-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+# Copy Python dependencies from builders - use correct Python 3.14 path
+COPY --from=backend-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=backend-builder /usr/local/bin /usr/local/bin
 
 # Create non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # ============================================
 # Stage 1: Backend builder
 # ============================================
-FROM python:3.14-slim AS backend-builder
+FROM python:3.13-slim AS backend-builder
 
 WORKDIR /app/backend
 
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 2: AI Engine builder
 # ============================================
-FROM python:3.14-slim AS ai-engine-builder
+FROM python:3.13-slim AS ai-engine-builder
 
 WORKDIR /app/ai-engine
 
@@ -43,7 +43,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # ============================================
 # Stage 3: Production backend
 # ============================================
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 
@@ -55,7 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Python dependencies from builders - use correct Python 3.14 path
-COPY --from=backend-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=backend-builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
 COPY --from=backend-builder /usr/local/bin /usr/local/bin
 
 # Create non-root user

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -16,7 +16,7 @@ RUN npm run build
 # Python dependencies build stage (consolidates all Python deps)
 # Note: Using Python 3.11 to match Debian bookworm's Python version
 # Debian bookworm-slim ships with Python 3.11.2, so we must build packages for 3.11
-FROM python:3.14-slim AS python-builder
+FROM python:3.13-slim AS python-builder
 WORKDIR /tmp
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc g++ curl libmagic1 ffmpeg && \
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy Python packages from consolidated builder (NOT binaries - use production stage's Python)
 # Debian system Python looks in /usr/lib/python3.X/dist-packages, not site-packages
-COPY --from=python-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/dist-packages
+COPY --from=python-builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/dist-packages
 
 # Copy application code
 COPY backend/ /app/backend/

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -16,7 +16,7 @@ RUN npm run build
 # Python dependencies build stage (consolidates all Python deps)
 # Note: Using Python 3.11 to match Debian bookworm's Python version
 # Debian bookworm-slim ships with Python 3.11.2, so we must build packages for 3.11
-FROM python:3.11-slim AS python-builder
+FROM python:3.14-slim AS python-builder
 WORKDIR /tmp
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc g++ curl libmagic1 ffmpeg && \
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy Python packages from consolidated builder (NOT binaries - use production stage's Python)
 # Debian system Python looks in /usr/lib/python3.X/dist-packages, not site-packages
-COPY --from=python-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/dist-packages
+COPY --from=python-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/dist-packages
 
 # Copy application code
 COPY backend/ /app/backend/

--- a/Dockerfile.fly.optimized
+++ b/Dockerfile.fly.optimized
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.npm \
 # =============================================================================
 # Stage 2: Python dependencies (with cache mount for pip)
 # =============================================================================
-FROM python:3.11-slim AS python-builder
+FROM python:3.14-slim AS python-builder
 WORKDIR /tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf python3 /usr/bin/python
 
 # Copy Python packages from builder (using correct Python 3.11 path)
-COPY --from=python-builder /usr/local/lib/python3.11/site-packages /usr/lib/python3.11/site-packages
+COPY --from=python-builder /usr/local/lib/python3.14/site-packages /usr/lib/python3.14/site-packages
 
 # Copy application source code
 COPY backend/ /app/backend/

--- a/Dockerfile.fly.optimized
+++ b/Dockerfile.fly.optimized
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.npm \
 # =============================================================================
 # Stage 2: Python dependencies (with cache mount for pip)
 # =============================================================================
-FROM python:3.14-slim AS python-builder
+FROM python:3.13-slim AS python-builder
 WORKDIR /tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf python3 /usr/bin/python
 
 # Copy Python packages from builder (using correct Python 3.11 path)
-COPY --from=python-builder /usr/local/lib/python3.14/site-packages /usr/lib/python3.14/site-packages
+COPY --from=python-builder /usr/local/lib/python3.13/site-packages /usr/lib/python3.13/site-packages
 
 # Copy application source code
 COPY backend/ /app/backend/


### PR DESCRIPTION
## Summary
Updates Python base image from 3.11-slim to 3.13-slim across all Dockerfiles.

Using 3.13 instead of 3.14 for better package compatibility with existing dependencies.

## Changes
- Dockerfile: Updated all stages from python:3.11-slim to python:3.13-slim
- Dockerfile.fly: Updated python-builder stage from python:3.11-slim to python:3.13-slim
- Dockerfile.fly.optimized: Updated python-builder stage from python:3.11-slim to python:3.13-slim
- Updated site-packages paths from python3.11 to python3.13

## Testing
- [ ] Build succeeds
- [ ] All tests pass

## Related
Original PR #1182 (closed)