### PR TITLE
fix: reset tracing state in tests (#1213)

### DIFF
--- a/backend/src/tests/unit/test_tracing.py
+++ b/backend/src/tests/unit/test_tracing.py
@@ -4,6 +4,17 @@ from unittest.mock import MagicMock, patch
 from services import tracing
 
 
+@pytest.fixture(autouse=True)
+def reset_tracing_state():
+    tracing._initialized = False
+    tracing._tracer_provider = None
+    tracing._tracer = None
+    yield
+    tracing._initialized = False
+    tracing._tracer_provider = None
+    tracing._tracer = None
+
+
 def test_get_service_name_default():
     with patch.dict(os.environ, {}, clear=True):
         assert tracing.get_service_name() == "portkit-backend"


### PR DESCRIPTION
## Summary
- Add `@pytest.fixture(autouse=True)` in test_tracing.py to reset tracing module state before each test
- Fixes intermittent test failures caused by global state pollution between tests

## Root Cause
The test `test_shutdown_tracing_no_provider` expected `tracing._initialized` to be `False` but other tests (like `test_init_tracing_already_initialized`) set it to `True` without proper cleanup, causing state leakage.

## Fix
Added `reset_tracing_state` fixture that resets all tracing module globals before and after each test to ensure deterministic state.

## Summary by Sourcery

Bug Fixes:
- Reset tracing module globals before and after each test in test_tracing.py via an autouse pytest fixture to prevent state leakage between tests.