### PR TITLE
fix(ci): clear all __pycache__ to resolve pytest duplicate module collision

### DIFF
--- a/.github/workflows/ai-quality-gates.yml
+++ b/.github/workflows/ai-quality-gates.yml
@@ -68,6 +68,8 @@ jobs:
       - name: Clear any cached coverage/test artifacts
         run: |
           rm -rf backend/.pytest_cache backend/coverage.json backend/.coverage 2>/dev/null || true
+          find backend/src/tests -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+          find backend/src/tests -name "*.pyc" -delete 2>/dev/null || true
           rm -f backend/src/tests/unit/test_byok_vault.py backend/src/tests/unit/test_billing.py 2>/dev/null || true
 
       - name: Set up Python
@@ -111,6 +113,8 @@ jobs:
       - name: Clear any cached coverage/test artifacts
         run: |
           rm -rf backend/.pytest_cache backend/coverage.json backend/.coverage 2>/dev/null || true
+          find backend/src/tests -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+          find backend/src/tests -name "*.pyc" -delete 2>/dev/null || true
           rm -f backend/src/tests/unit/test_byok_vault.py backend/src/tests/unit/test_billing.py 2>/dev/null || true
 
       - name: Set up Python
@@ -155,6 +159,8 @@ jobs:
       - name: Clear any cached coverage/test artifacts
         run: |
           rm -rf backend/.pytest_cache backend/coverage.json backend/.coverage 2>/dev/null || true
+          find backend/src/tests -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+          find backend/src/tests -name "*.pyc" -delete 2>/dev/null || true
           rm -f backend/src/tests/unit/test_byok_vault.py backend/src/tests/unit/test_billing.py 2>/dev/null || true
 
       - name: Set up Python
@@ -213,6 +219,8 @@ jobs:
       - name: Clear any cached files that might include deleted tests
         run: |
           rm -rf backend/.pytest_cache backend/coverage.json backend/.coverage 2>/dev/null || true
+          find backend/src/tests -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+          find backend/src/tests -name "*.pyc" -delete 2>/dev/null || true
           rm -f backend/src/tests/unit/test_byok_vault.py backend/src/tests/unit/test_billing.py 2>/dev/null || true
 
       - name: Verify test_byok_vault.py does not exist

--- a/.github/workflows/ci-backend-unit-tests.yml
+++ b/.github/workflows/ci-backend-unit-tests.yml
@@ -46,6 +46,8 @@ jobs:
       - name: Clear pytest cache and remove deleted test files
         run: |
           rm -rf backend/.pytest_cache backend/coverage.json backend/.coverage 2>/dev/null || true
+          find backend/src/tests -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+          find backend/src/tests -name "*.pyc" -delete 2>/dev/null || true
           rm -f backend/src/tests/unit/test_byok_vault.py backend/src/tests/unit/test_billing.py 2>/dev/null || true
 
       - name: Set up Python
@@ -114,6 +116,8 @@ jobs:
       - name: Clear pytest cache and remove deleted test files
         run: |
           rm -rf backend/.pytest_cache 2>/dev/null || true
+          find backend/src/tests -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+          find backend/src/tests -name "*.pyc" -delete 2>/dev/null || true
           rm -f backend/src/tests/unit/test_byok_vault.py backend/src/tests/unit/test_billing.py 2>/dev/null || true
 
       - name: Set up Python


### PR DESCRIPTION
## Summary

The `backend-test` job was failing across ALL dependabot PRs due to a pytest import cache issue.

### Root Cause

The pytest cache cleanup step was only clearing `backend/.pytest_cache` but NOT the nested `__pycache__` directories inside `backend/src/tests/`. When two test files with the same module name exist:
- `backend/src/tests/test_mod_dependency_handler.py`
- `backend/src/tests/unit/test_mod_dependency_handler.py`

Pytest's import cache from the top-level file was polluting the unit subdirectory run, causing:
```
ERROR src/tests/unit/test_mod_dependency_handler.py - import file mismatch:
  imported module 'test_mod_dependency_handler' has this __file__ attribute:
    /home/runner/work/portkit/portkit/backend/src/tests/test_mod_dependency_handler.py
  which is not the same as the test file we want to collect
```

### Fix

Added `find` commands to the cache cleanup step to recursively clear ALL `__pycache__` directories and `.pyc` files:

```yaml
- name: Clear pytest cache and remove deleted test files
  run: |
    rm -rf backend/.pytest_cache backend/coverage.json backend/.coverage 2>/dev/null || true
    find backend/src/tests -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
    find backend/src/tests -name "*.pyc" -delete 2>/dev/null || true
```

### Files Changed

- `.github/workflows/ci-backend-unit-tests.yml` - Both parallel and serial test jobs
- `.github/workflows/ai-quality-gates.yml` - All 4 cache cleanup steps

### Verification

This fix applies to all 6 open dependabot PRs (1260-1265) which were ALL failing the `backend-test` check with the same error.