### PR TITLE
feat(api): enable Swagger/OpenAPI endpoint for Studio tier (#1161)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -162,8 +162,9 @@ app = FastAPI(
             "description": "Post-conversion behavior file editing",
         },
     ],
-    docs_url="/docs",
-    redoc_url="/redoc",
+    docs_url="/api/v1/docs",
+    redoc_url="/api/v1/redoc",
+    openapi_url="/api/v1/openapi.json",
 )
 
 # CORS middleware

--- a/backend/src/services/celery_tasks.py
+++ b/backend/src/services/celery_tasks.py
@@ -497,9 +497,7 @@ def handle_conversion_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     file_id = payload.get("file_id")
     logger.info(f"Processing conversion job: {job_id}")
     try:
-        return asyncio.get_event_loop().run_until_complete(
-            _process(payload)
-        )
+        return asyncio.get_event_loop().run_until_complete(_process(payload))
     except Exception as e:
         logger.error(f"Conversion job {job_id} failed: {e}")
         raise
@@ -512,9 +510,7 @@ def handle_asset_conversion_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     asset_id = payload.get("asset_id")
     logger.info(f"Processing asset conversion: {asset_id}")
     try:
-        return asyncio.get_event_loop().run_until_complete(
-            _svc.convert_asset(asset_id)
-        )
+        return asyncio.get_event_loop().run_until_complete(_svc.convert_asset(asset_id))
     except Exception as e:
         logger.error(f"Asset conversion {asset_id} failed: {e}")
         raise
@@ -529,6 +525,7 @@ def handle_java_analysis_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     mod_id = payload.get("mod_id")
     logger.info(f"Processing Java analysis: {mod_id}")
     try:
+
         async def _analyze():
             async with AsyncSessionLocal() as session:
                 mod = await crud.get_mod(session, mod_id)
@@ -552,9 +549,7 @@ def handle_texture_extraction_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     logger.info(f"Processing texture extraction: {jar_path}")
     try:
         extractor = TextureMetadataExtractor()
-        result = asyncio.get_event_loop().run_until_complete(
-            extractor.extract_from_jar(jar_path)
-        )
+        result = asyncio.get_event_loop().run_until_complete(extractor.extract_from_jar(jar_path))
         return {"jar_path": jar_path, "status": "extracted", "result": result}
     except Exception as e:
         logger.error(f"Texture extraction {jar_path} failed: {e}")
@@ -568,9 +563,7 @@ def handle_model_conversion_task(payload: Dict[str, Any]) -> Dict[str, Any]:
     model_id = payload.get("model_id")
     logger.info(f"Processing model conversion: {model_id}")
     try:
-        return asyncio.get_event_loop().run_until_complete(
-            _svc.convert_asset(model_id)
-        )
+        return asyncio.get_event_loop().run_until_complete(_svc.convert_asset(model_id))
     except Exception as e:
         logger.error(f"Model conversion {model_id} failed: {e}")
         raise

--- a/backend/src/services/logging_middleware.py
+++ b/backend/src/services/logging_middleware.py
@@ -42,9 +42,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             "/api/v1/metrics",
             "/health",
             "/metrics",
-            "/docs",
-            "/redoc",
-            "/openapi.json",
+            "/api/v1/docs",
+            "/api/v1/redoc",
+            "/api/v1/openapi.json",
         ]
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:

--- a/backend/src/services/rate_limiter.py
+++ b/backend/src/services/rate_limiter.py
@@ -327,7 +327,7 @@ class UserContextMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         # Skip for health checks and docs
-        if request.url.path in {"/api/v1/health", "/docs", "/redoc", "/openapi.json"}:
+        if request.url.path in {"/api/v1/health", "/api/v1/docs", "/api/v1/redoc", "/api/v1/openapi.json"}:
             return await call_next(request)
 
         # Try to extract user info from token
@@ -353,9 +353,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         # Endpoints to exclude from rate limiting
         self.exclude_paths = {
             "/api/v1/health",
-            "/docs",
-            "/redoc",
-            "/openapi.json",
+            "/api/v1/docs",
+            "/api/v1/redoc",
+            "/api/v1/openapi.json",
             "/api/v1/metrics",
             "/api/v1/rate-limit/dashboard",
             "/api/v1/rate-limit/summary",


### PR DESCRIPTION
## Summary

Enables the Swagger/OpenAPI docs endpoint at `/api/v1/docs` for Studio tier B2B API access.

## Changes

- Changed FastAPI `docs_url` from `/docs` to `/api/v1/docs`
- Changed `redoc_url` from `/redoc` to `/api/v1/redoc`  
- Added explicit `openapi_url="/api/v1/openapi.json"`
- Updated `RateLimitMiddleware.exclude_paths` to skip rate limiting for docs endpoints
- Updated `UserContextMiddleware` skip paths to match
- Updated `LoggingMiddleware` exclude paths to match

## Verification

- [x] `/api/v1/docs` (Swagger UI) accessible in production
- [x] `/api/v1/openapi.json` returns valid OpenAPI spec
- [x] Docs endpoint is excluded from rate limiting (public access for API discovery)
- [x] API key auth already implemented on conversion endpoints via `Authorization: Bearer <api_key>` header with `mpk_` prefix

## Notes

- `FEATURE_API_KEYS=true` is enabled — API key generation is scaffolded
- Studio and Enterprise tiers have `has_api_access: true` in tier limits
- Docs are excluded from rate limiting to allow unauthenticated API discovery
- API endpoints themselves require Bearer token authentication

Fixes #1161