### PR TITLE
docs: implement beta recruitment plan (#1166)

### DIFF
--- a/docs/beta-discord-channels.md
+++ b/docs/beta-discord-channels.md
@@ -1,0 +1,225 @@
+# Beta Discord Channels Setup
+
+**Purpose:** Set up #beta-general, #beta-bugs, and #beta-feedback channels for beta testers
+**Related:** docs/DISCORD-SETUP.md (existing server setup)
+
+---
+
+## Beta Channels Overview
+
+| Channel | Purpose | Permissions |
+|---------|---------|-------------|
+| #beta-general | General discussion for beta testers | Beta Tester role only |
+| #beta-bugs | Bug reports and issue tracking | Beta Tester role only |
+| #beta-feedback | Feature feedback and suggestions | Beta Tester role only |
+
+---
+
+## Channel Setup Instructions
+
+### Via Discord UI
+
+1. **Open Discord** and navigate to the Portkit server
+2. **Create a new category** (optional, for organization):
+   - Right-click server → "Create Category"
+   - Name: "BETA TESTERS" or similar
+3. **Create each channel:**
+   - Click "+" next to category
+   - Channel type: Text Channel
+   - Add the following channels:
+     - `beta-general` - General beta discussion
+     - `beta-bugs` - Bug report submissions
+     - `beta-feedback` - Feature suggestions and feedback
+
+### Via Discord API / Bot Commands
+
+```discord
+#create beta-general
+#create beta-bugs
+#create beta-feedback
+
+#set #beta-general topic "General discussion for beta testers. Read rules before posting."
+#set #beta-bugs topic "Report bugs here. Use the template: https://portkit.ai/bug-template"
+#set #beta-feedback topic "Share feature suggestions and product feedback."
+```
+
+---
+
+## Channel Permissions
+
+### Beta Tester Role Permissions (for each beta channel)
+
+| Permission | Status |
+|------------|--------|
+| View Channel | Allowed |
+| Send Messages | Allowed |
+| Embed Links | Allowed |
+| Attach Files | Allowed |
+| Add Reactions | Allowed |
+| Use Threads | Allowed |
+| Create Public Threads | Disallowed |
+| Create Private Threads | Allowed |
+| Manage Threads | Disallowed |
+| Manage Messages | Disallowed |
+| Pin Messages | Disallowed |
+
+### Default Role (@everyone)
+
+| Permission | Status |
+|------------|--------|
+| View Channel | Disallowed (unless public) |
+| Send Messages | Disallowed |
+
+---
+
+## Channel Topics / Descriptions
+
+### #beta-general
+
+Welcome to the beta general channel!
+
+This is a space for beta testers to:
+- Discuss their conversion experiences
+- Ask questions about the beta program
+- Share tips and tricks
+- Connect with other beta testers
+
+Guidelines:
+- Be respectful to other testers
+- Don't share beta features publicly (confidentiality)
+- Search before asking common questions
+
+Beta Timeline: 8 weeks
+Your tier: Creator (free during beta)
+
+### #beta-bugs
+
+Bug Report Guidelines:
+
+Before submitting a bug:
+1. Search if it's already reported
+2. Check known limitations (custom rendering, network packets)
+
+Bug Report Template:
+```
+## Bug Report
+**Mod used:** [mod name]
+**Conversion type:** [items/entities/recipes]
+**Date:** [YYYY-MM-DD]
+**Description:** [what happened]
+**Expected:** [what should happen]
+**Actual:** [what actually happened]
+**Logs:** [attach conversion logs]
+```
+
+Response time: < 24 hours
+For critical bugs, DM @developer directly.
+
+### #beta-feedback
+
+Feature Feedback & Suggestions
+
+We want to hear what you think!
+
+What to share:
+- Features you'd like to see
+- UX improvements
+- Conversion quality feedback
+- Third-party tool integrations
+
+Feedback is reviewed weekly by the dev team.
+
+Top suggestions get priority consideration for the roadmap.
+(Your feedback shapes Portkit's future!)
+
+---
+
+## Welcome Messages
+
+### #beta-general Welcome
+
+👋 Welcome to #beta-general!
+
+This is your space to connect with other beta testers.
+
+**What you can do here:**
+- Ask general questions about the beta
+- Share your conversion experiences
+- Discuss modding topics with fellow creators
+- Get help with common issues
+
+**Beta Program Info:**
+- Timeline: 8 weeks
+- Your tier: Creator (free access)
+- Discord: https://discord.gg/portkit
+
+Happy testing! 🎮
+
+### #beta-bugs Welcome
+
+🐛 Welcome to #beta-bugs!
+
+This channel is for reporting bugs and issues you encounter during conversion.
+
+**Before posting:**
+- Check if the bug is already reported
+- Review known limitations (custom rendering, network packets)
+- Gather your conversion logs
+
+**Bug Report Template:**
+```
+## Bug Report
+**Mod used:** [mod name]
+**Conversion type:** [items/entities/recipes]
+**Date:** [YYYY-MM-DD]
+**Description:** [what happened]
+**Expected:** [what should happen]
+**Actual:** [what actually happened]
+**Logs:** [attach conversion logs]
+```
+
+Response time: < 24 hours
+
+### #beta-feedback Welcome
+
+💡 Welcome to #beta-feedback!
+
+Your feedback shapes Portkit's future!
+
+**What to share:**
+- Features you'd like to see
+- UX improvements and suggestions
+- Conversion quality feedback
+- Integration ideas
+
+**What converts well (beta):**
+- Items, blocks, armor, tools: 80%+ automated
+- Basic entities: 60-80% automated
+- Recipes, loot tables: 80%+ automated
+
+We read every piece of feedback.
+Top suggestions get priority on our roadmap.
+
+---
+
+## Integration with Existing Server
+
+Add these channels to the existing server structure documented in `docs/DISCORD-SETUP.md`:
+
+```
+🔧 BETA-TESTERS ONLY (existing)
+├── #beta-feedback          ← already exists
+├── #preview-features       ← already exists
+└── #direct-dev-access      ← already exists
+
+🆕 BETA-SPECIFIC (new)
+├── #beta-general           ← NEW
+├── #beta-bugs              ← NEW
+└── #beta-feedback          ← already exists, update topic
+```
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-05-05*
+*Related Issue: #1166*

--- a/docs/beta-tally-form.md
+++ b/docs/beta-tally-form.md
@@ -1,0 +1,191 @@
+# Beta Signup Form Setup (Tally)
+
+**Purpose:** Create and configure the Tally form for beta signup at portkit.ai/beta
+**Related:** docs/beta-signup-page.md (content source)
+
+---
+
+## Tally Form Setup
+
+### Step 1: Create New Form
+
+1. Log in to [Tally](https://tally.so)
+2. Click "Create form" → "Start from scratch"
+3. Name the form: "Portkit Beta Application"
+
+### Step 2: Configure Form Fields
+
+#### Section 1: About You
+
+**Field 1:** Your name
+- Type: Short text
+- Required: Yes
+
+**Field 2:** Email address
+- Type: Email
+- Required: Yes
+
+**Field 3:** Discord username
+- Type: Short text
+- Required: Yes
+- Placeholder: username#0000
+
+#### Section 2: Your Mods
+
+**Field 4:** Link to your mod(s) on CurseForge, Modrinth, or GitHub
+- Type: Long text
+- Required: Yes
+- Placeholder: https://...
+- Helper text: Share at least one mod so we can understand your work
+
+**Field 5:** What mod(s) would you most want to convert?
+- Type: Long text
+- Required: Yes
+- Placeholder: "My inventory mod 'X' has 50K downloads..."
+- Helper text: The more specific, the better we can test for you
+
+**Field 6:** How long have you been modding Minecraft Java Edition?
+- Type: Single select
+- Required: Yes
+- Options:
+  - Less than 6 months
+  - 6 months to 1 year
+  - 1-3 years
+  - 3-5 years
+  - 5+ years
+
+#### Section 3: Your Goals
+
+**Field 7:** Why do you want to join the beta?
+- Type: Long text
+- Required: Yes
+- Placeholder: "I want to port my mod to Bedrock to..."
+- Helper text: This helps us understand your use case
+
+**Field 8:** What would "success" look like for you with Portkit?
+- Type: Long text
+- Required: No
+- Placeholder: "Being able to take my Java mod and run it on Bedrock within..."
+- Helper text: Optional but helps us prioritize features
+
+#### Section 4: Agreement
+
+**Field 9:** I agree to provide feedback and bug reports during the beta period
+- Type: Checkbox
+- Required: Yes
+- Label: "I'm willing to spend 2-4 hours/week testing and reporting issues"
+
+**Field 10:** I agree to the beta terms of service
+- Type: Checkbox
+- Required: Yes
+- Label: "I accept the Beta Terms and Privacy Policy"
+
+### Step 3: Form Settings
+
+**Thank you page:** Custom message
+```
+Thanks for applying!
+
+We're reviewing applications on a rolling basis. If you're accepted, you'll receive an invite email within 3-5 business days.
+
+In the meantime, join our Discord: https://discord.gg/portkit
+```
+
+**Notifications:**
+- Email notifications to: beta@portkit.cloud
+- Discord channel webhook for new submissions (optional)
+
+**Closing:** Leave open until 50 beta testers are recruited
+
+### Step 4: Embed Form
+
+Add to portkit.ai/beta using Tally's embed code:
+
+```html
+<iframe data-tally-src="https://tally.so/embed/YOUR_FORM_ID?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1" loading="lazy" width="100%" height="500" frameborder="0" marginheight="0" marginwidth="0"></iframe>
+```
+
+Or use the Tally popup button option for a less intrusive CTA.
+
+---
+
+## Landing Page Setup (portkit.ai/beta)
+
+### Hero Section
+
+**Headline:** Become a Beta Tester
+
+**Subheadline:** Help shape the future of cross-platform Minecraft modding
+
+**Body Text:**
+Portkit is the first AI-powered tool that converts Java mods to Bedrock add-ons. We're recruiting 25-50 mod creators for our beta program. Join now and get free access in exchange for feedback.
+
+**CTA Button:** Apply for Beta Access (links to Tally form)
+
+### Social Proof Section
+
+**Stats:**
+- 60-80% automated conversion for common mod types
+- 3x larger player base on Bedrock
+- Free access during beta (valued at $9.99/month)
+
+### Value Proposition Cards
+
+#### Card 1: Save Time
+- **Title:** Skip the Manual Work
+- **Description:** Our AI handles 60-80% of the conversion automatically. What used to take weeks now takes minutes.
+
+#### Card 2: Reach More Players
+- **Title:** Access Bedrock's 3x Player Base
+- **Description:** Java has ~30M players. Bedrock has ~100M. Your mods can reach them all.
+
+#### Card 3: Shape the Future
+- **Title:** Direct Influence on the Product
+- **Description:** Your bug reports and feedback directly shape our roadmap. Get credited at launch.
+
+### Beta Program Details
+
+**What's Included:**
+- Free Creator tier during beta (unlimited conversions)
+- Direct bug report channel to dev team
+- Early access to new features
+- Recognition in launch credits
+
+**Who We're Looking For:**
+- Active Minecraft Java mod creators
+- At least one published mod (.jar file)
+- Willing to provide feedback and bug reports
+- Interested in cross-platform modding
+
+### FAQ Section
+
+**Q: How long is the beta?**
+A: The beta period is 8 weeks. Your free access continues throughout this period.
+
+**Q: Is the Creator tier really free during beta?**
+A: Yes! The Creator tier ($9.99/month value) is completely free for beta testers.
+
+**Q: What if my mod doesn't convert well?**
+A: That's valuable feedback! Our AI is improving constantly. We'll help you understand what works and what doesn't.
+
+**Q: Can I convert multiple mods?**
+A: Yes, unlimited conversions during beta.
+
+**Q: What happens to my data?**
+A: Your mod files are processed and deleted after conversion. See our Privacy Policy for details.
+
+**Q: How do I report bugs?**
+A: Accepted beta testers get access to a private Discord channel for direct bug reports to the dev team.
+
+---
+
+## Tally Form Link
+
+**Form URL:** https://tally.so/r/YOUR_FORM_ID
+**Landing Page URL:** https://portkit.ai/beta
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-05-05*
+*Related Issue: #1166*

--- a/docs/templates/discord-dm-modrinth.md
+++ b/docs/templates/discord-dm-modrinth.md
@@ -1,0 +1,168 @@
+# Discord DM Template for Modrinth Mod Authors
+
+**Purpose:** Direct message template for reaching out to mod authors on Modrinth's Discord server
+**Related:** docs/beta-recruitment.md (strategy document)
+
+---
+
+## Overview
+
+**Platform:** Modrinth Discord (https://discord.gg/modrinth)
+**Target:** Active mod creators with published mods on Modrinth
+**Approach:** Personal DM, professional tone, brief introduction
+
+---
+
+## Initial DM Template
+
+**Subject:** N/A (Discord DM)
+
+**Message:**
+
+```
+Hi [mod_author_name]!
+
+I'm reaching out because I noticed you're an active mod creator on Modrinth. I wanted to let you know about a beta opportunity that might interest you.
+
+Portkit is an AI-powered tool that converts Java mods to Bedrock add-ons. We're recruiting 25-50 mod creators for our beta program.
+
+**Beta offer:**
+- Free unlimited conversions (8 weeks)
+- Direct access to our dev team
+- Your name in our launch credits
+
+**What converts well:**
+- Items, blocks, armor, tools: 80%+ automated
+- Basic entities: 60-80% automated
+- Recipes, loot tables: 80%+ automated
+
+If you have mods you'd like to see on Bedrock, we'd love to have you try it.
+
+Apply: portkit.ai/beta
+
+Happy to answer any questions!
+```
+
+---
+
+## Alternative (Shorter) Version
+
+Use this if the mod author seems busy or has a shorter bio:
+
+```
+Hi! I saw your mods on Modrinth and thought this might interest you.
+
+Portkit converts Java mods to Bedrock add-ons using AI. We're recruiting beta testers - free access for 8 weeks + direct dev access.
+
+Interested? Apply at portkit.ai/beta
+```
+
+---
+
+## Finding Mod Authors to DM
+
+### Via Modrinth Website
+
+1. Go to [modrinth.com](https://modrinth.com)
+2. Search for mods in popular categories
+3. Click on mod page → check author profile for Discord handle
+4. Look for authors with "Open for commissions" or active social links
+
+### Via Modrinth Discord
+
+1. Join the Modrinth Discord server
+2. Look in #showcase and #mods channels for active creators
+3. Check profiles for "mod author" or similar badges
+4. Look for users active in modding discussion channels
+
+### Prioritization
+
+| Priority | Mod Type | Why |
+|----------|----------|-----|
+| High | Items/blocks/armor mods | 80%+ conversion rate |
+| High | Recipe/loot table mods | 80%+ conversion rate |
+| Medium | Basic entity mods | 60-80% conversion rate |
+| Low | Complex rendering mods | May need manual work |
+
+---
+
+## DM Best Practices
+
+### Do:
+- Personalize with reference to their specific mod(s)
+- Keep it brief (under 200 words)
+- Be professional and friendly
+- Mention the free aspect upfront
+- Provide a clear CTA
+
+### Don't:
+- Mass DM without personalization
+- Be pushy or salesy
+- Use wall of text format
+- Message people who explicitly say "no DMs"
+- Follow up more than once
+
+---
+
+## Follow-up Message (If No Response)
+
+Wait 5-7 days before following up, and only follow up once:
+
+```
+Hi! Just wanted to bump this in case you missed it. No pressure if it's not for you!
+
+Portkit beta is still open - we have about [X] spots left. Apply at portkit.ai/beta if you're curious.
+```
+
+---
+
+## Handling Responses
+
+### If they're interested:
+- Direct them to apply at portkit.ai/beta
+- Answer any questions they have
+- If they mention specific mod, note it for follow-up
+
+### If they're not interested:
+- Thank them for their time
+- Don't push further
+- Could they share with someone who might be interested?
+
+### If they have technical questions:
+- Answer honestly about conversion capabilities
+- Acknowledge limitations
+- Suggest they apply to test with their specific mods
+
+---
+
+## Discord Server Announcement (Alternative to DM)
+
+If DM approach is not preferred, use this server announcement in Modrinth Discord:
+
+```
+🎉 Portkit Beta Recruitment
+
+We're looking for 25-50 Minecraft mod creators to join our beta program!
+
+What is Portkit?
+An AI-powered tool that converts Java mods to Bedrock add-ons.
+
+Beta benefits:
+- ✨ Free unlimited conversions
+- ✨ Direct bug report channel
+- ✨ Recognition in launch credits
+- ✨ Shape the product roadmap
+
+Who we're looking for:
+- Active Java mod creators
+- Mods you'd like to see on Bedrock
+- Willing to provide feedback
+
+Apply: portkit.ai/beta
+```
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-05-05*
+*Related Issue: #1166*

--- a/docs/templates/reddit-posts.md
+++ b/docs/templates/reddit-posts.md
@@ -1,0 +1,174 @@
+# Reddit Post Templates for Beta Recruitment
+
+**Purpose:** Templates for posting to r/feedthebeast and r/MinecraftBedrock
+**Related:** docs/beta-recruitment.md (strategy document)
+
+---
+
+## r/feedthebeast Post
+
+**Subreddit:** r/feedthebeast
+**Reach:** 400K+ members, most active Java modding community
+**Best Timing:** Tuesday-Thursday, 6-9 AM PST
+**Guidelines:** Must disclose affiliation, no direct promotion
+
+### Post Template
+
+```
+**Title:** [Beta] Portkit - AI Tool to Convert Java Mods to Bedrock (25-50 Testers)
+
+Hey everyone,
+
+I've been building Portkit, an AI-powered tool that converts Java mods to Bedrock add-ons. We're opening beta and looking for 25-50 mod creators to help us test.
+
+**What it does:**
+- Upload your Java mod (.jar)
+- AI analyzes and converts to Bedrock format (.mcaddon)
+- Download ready-to-use add-on
+
+**Conversion rates:**
+- Items, blocks, recipes: 80%+ automated
+- Basic entities: 60-80% automated
+- Complex features: May need manual work
+
+**Beta offer:**
+- Free unlimited conversions
+- Direct bug report channel
+- Recognition in launch credits
+
+**Apply:** portkit.ai/beta
+
+Happy to answer questions about the tech!
+```
+
+### Tips for Posting
+
+1. **Flair:** Use the "News" or "Mods" flare (not "Showcase" or "Discussion" which may get removed as self-promotion)
+
+2. **Disclosure:** You are the developer. The post already mentions "I've been building" which is good disclosure.
+
+3. **Monitor comments:** Respond to questions within the first hour. Higher engagement = higher visibility.
+
+4. **Don't:**
+   - Ask people to upvote
+   - Post the same thing multiple times
+   - Engage with criticism defensively
+
+5. **Do:**
+   - Answer technical questions honestly
+   - Acknowledge limitations
+   - Share screenshots if you have them
+   - Be responsive to community feedback
+
+---
+
+## r/MinecraftBedrock Post
+
+**Subreddit:** r/MinecraftBedrock
+**Reach:** Bedrock community interested in content from Java side
+**Best Timing:** Wednesday-Saturday, 8-11 AM PST
+**Guidelines:** Cross-community post, emphasize bridge between Java and Bedrock
+
+### Post Template
+
+```
+**Title:** [Beta] Java modders - want to reach Bedrock players? Join our beta
+
+If you're a Java modder looking to expand to Bedrock, we need your help!
+
+Portkit is an AI-powered converter that translates Java mods to Bedrock add-ons. We're recruiting 25-50 beta testers.
+
+**Why this matters:**
+- Bedrock has 3x the players of Java
+- Most mods never get ported due to effort
+- We're making cross-platform modding easier
+
+**Beta perks:**
+- Free Creator tier during beta
+- Direct access to dev team
+- Your name in our credits
+
+**What converts well in beta:**
+- Items, blocks, armor, tools: 80%+ automated
+- Basic entities: 60-80% automated
+- Recipes, loot tables: 80%+ automated
+
+**Apply:** portkit.ai/beta
+```
+
+### Tips for Posting
+
+1. **Flair:** Use "News" or "Discussion" flair
+
+2. **Opening:** Frame this as helping Java modders reach Bedrock players (benefit to the Bedrock community by bringing more content)
+
+3. **Don't:**
+   - Dismiss Bedrock as "lesser" - Frame as "reaching more players"
+   - Compare Java vs Bedrock negatively
+
+4. **Do:**
+   - Emphasize the player base growth opportunity
+   - Acknowledge that porting is currently difficult
+
+---
+
+## Post Analytics Tracking
+
+| Metric | r/feedthebeast | r/MinecraftBedrock |
+|--------|---------------|-------------------|
+| Post URL | | |
+| Posted Date | | |
+| Upvotes | | |
+| Comments | | |
+| Awards | | |
+| Applications from post | | |
+
+---
+
+## Posting Schedule
+
+| Day | Best Time | Platform | Notes |
+|-----|-----------|----------|-------|
+| Tuesday | 6-9 AM PST | r/feedthebeast | High engagement early week |
+| Wednesday | 8-11 AM PST | r/MinecraftBedrock | Mid-week, good visibility |
+| Thursday | 6-9 AM PST | r/feedthebeast | Alternative day if missed Tuesday |
+| Saturday | 8-11 AM PST | r/MinecraftBedrock | Weekend traffic |
+
+---
+
+## Comment Response Templates
+
+### If asked "Does this work on [specific mod type]?"
+
+```
+Our AI currently converts:
+- Items, blocks, armor, tools: 80%+ automated
+- Basic entities: 60-80% automated
+- Recipes, loot tables: 80%+ automated
+
+Complex features like custom rendering or network packet handlers may need manual work. We can't guarantee 100% conversion, but we're improving based on beta feedback. Give it a try and let us know!
+```
+
+### If asked "Is this safe for my mod files?"
+
+```
+Your mod files are processed and deleted after conversion. We don't store or distribute your code. Check our privacy policy for details: portkit.ai/privacy
+```
+
+### If asked "Why Bedrock?"
+
+```
+Bedrock has ~3x the players of Java Edition. Many great mods never get ported because it's too much work. We're making cross-platform modding more accessible.
+```
+
+### If asked "What's the catch?"
+
+```
+No catch! Beta is free. We need testers who are willing to provide feedback and bug reports. In return, you get free access during the 8-week beta and your name in our launch credits.
+```
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-05-05*
+*Related Issue: #1166*

--- a/docs/templates/twitter-thread.md
+++ b/docs/templates/twitter-thread.md
@@ -1,0 +1,161 @@
+# Twitter Thread Template for Beta Recruitment
+
+**Purpose:** Thread format for announcing beta recruitment on Twitter/X
+**Related:** docs/beta-recruitment.md (strategy document)
+
+---
+
+## Thread Overview
+
+**Platform:** Twitter/X
+**Format:** Thread (series of connected tweets)
+**Length:** 5-7 tweets
+**Goal:** Recruit 25-50 beta testers, drive applications to portkit.ai/beta
+
+---
+
+## Thread Template
+
+### Tweet 1 (Opening Hook)
+
+🎮 Beta testers wanted!
+
+Want to bring your Java mods to Bedrock? @portkit is recruiting 25-50 mod creators for beta.
+
+✨ 60-80% automated conversion
+✨ Free Creator tier during beta
+✨ Direct line to dev team
+✨ Named in our launch credits
+
+Apply: portkit.ai/beta
+
+#Minecraft #Modding #GameDev
+
+### Tweet 2 (Problem Statement)
+
+Most Java mods never make it to Bedrock.
+
+Why? Because manual porting takes weeks of work for features that could be automated.
+
+That's why we built Portkit.
+
+A thread on what we do and why we're recruiting beta testers 👇
+
+### Tweet 3 (What Portkit Does)
+
+Portkit is an AI-powered tool that converts Java mods (.jar) to Bedrock add-ons (.mcaddon).
+
+Upload your mod → AI converts it → Download ready-to-use add-on
+
+What's been taking weeks now takes minutes.
+
+### Tweet 4 (Conversion Capabilities)
+
+**What converts well in beta:**
+
+- Items, blocks, armor, tools: 80%+ automated
+- Recipes, loot tables: 80%+ automated
+- Basic entities: 60-80% automated
+
+Complex features (custom rendering, network packets) may need manual work.
+
+We can't promise 100% automation - but we're always improving based on your feedback.
+
+### Tweet 5 (Beta Offer)
+
+**Why join our beta?**
+
+🎁 Free Creator tier during beta (8 weeks)
+🎁 Direct bug report channel to our dev team
+🎁 Early access to new features
+🎁 Your name in our launch credits
+
+We're looking for mod creators who want to help shape cross-platform modding.
+
+### Tweet 6 (Who We're Looking For)
+
+Currently recruiting:
+- Java mod creators with published mods
+- Modders interested in reaching Bedrock's 3x larger player base
+- People willing to spend 2-4 hours/week testing and providing feedback
+
+No experience with Bedrock needed - just curiosity about bringing your mods to more players.
+
+### Tweet 7 (Call to Action)
+
+**Ready to apply?**
+
+👉 portkit.ai/beta
+
+Spaces are limited (25-50 testers). We're reviewing applications on a rolling basis.
+
+Questions? Drop them below 👇 or reach out to @portkit
+
+---
+
+## Alternative Short Version (Single Tweet)
+
+If thread is too long, use this single tweet:
+
+🎮 Minecraft mod creators: we're recruiting 25-50 beta testers for Portkit - an AI tool that converts Java mods to Bedrock add-ons.
+
+Free Creator tier during beta • 60-80% automated • Direct dev access
+
+Apply: portkit.ai/beta
+
+#MinecraftModding #Bedrock #Java
+
+---
+
+## Best Practices
+
+### Do:
+- Tweet during weekdays, 8-11 AM or 5-7 PM PST for best engagement
+- Include relevant hashtags (but don't spam)
+- Add visuals if available (screenshots of conversion process)
+- Respond to replies to boost engagement
+
+### Don't:
+- Post multiple times in one day
+- Use aggressive sales language
+- Promise 100% conversion (not accurate)
+
+---
+
+## Engagement Tracking
+
+| Metric | Target | Actual |
+|--------|--------|--------|
+| Impressions | | |
+| Engagements | | |
+| Link clicks | | |
+| Applications | 25-50 total | |
+
+---
+
+## Thread Images (Optional)
+
+If you have screenshots or visuals:
+
+1. **Tweet 1:** Could attach screenshot of conversion UI
+2. **Tweet 3:** Before/after of converted mod
+3. **Tweet 5:** Could show beta Discord access
+
+---
+
+## Hashtag Suggestions
+
+- #Minecraft
+- #MinecraftModding
+- #Bedrock
+- #Java
+- #Modding
+- #GameDev
+- #IndieDev
+- #MinecraftBedrock
+
+---
+
+*Document Version: 1.0*
+*Created: 2026-05-05*
+*Related Issue: #1166*


### PR DESCRIPTION
## Summary
- Add Tally form setup guide for portkit.ai/beta signup page
- Add Discord channel setup guide for #beta-general, #beta-bugs, #beta-feedback
- Add Reddit post templates for r/feedthebeast and r/MinecraftBedrock
- Add Discord DM template for Modrinth mod authors
- Add Twitter thread template for beta announcement

## Related Issue
Fixes #1166 - Beta user recruitment: recruit 25-50 mod creators

## Files Changed
- `docs/beta-tally-form.md` - Tally form setup guide
- `docs/beta-discord-channels.md` - Discord channel setup
- `docs/templates/reddit-posts.md` - Reddit post templates
- `docs/templates/discord-dm-modrinth.md` - Discord DM template
- `docs/templates/twitter-thread.md` - Twitter thread template