### PR TITLE
fix: test_celery_tasks.py event loop error (#1304)

### DIFF
--- a/backend/src/services/celery_tasks.py
+++ b/backend/src/services/celery_tasks.py
@@ -371,7 +371,7 @@ def _enqueue_task_sync(
         logger.info(f"Task {task.id} ({name}) enqueued with priority {task.priority.name}")
         return {"task_id": task.id, "status": "queued"}
 
-    return asyncio.get_event_loop().run_until_complete(_enqueue())
+    return asyncio.run(_enqueue())
 
 
 @celery_app.task(name="services.celery_tasks.get_task_status")


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop().run_until_complete()` with `asyncio.run()` in `celery_tasks.py:374`
- Fixes `RuntimeError: There is no current event loop in thread 'MainThread'` when running tests with `pytest-xdist` in parallel mode

## Root Cause
`_enqueue_task_sync()` used `asyncio.get_event_loop().run_until_complete()` which fails when no event loop exists in the MainThread context during parallel test execution with pytest-xdist.

## Solution
`asyncio.run()` creates and manages its own event loop, avoiding the RuntimeError.

## Testing
- All 25 tests in `test_celery_tasks.py` now pass with `-n auto` (parallel mode)
- Previously failing tests (`test_handle_conversion_task`, etc.) now pass

## Files Changed
- `backend/src/services/celery_tasks.py` - Line 374: `asyncio.get_event_loop().run_until_complete(_enqueue())` → `asyncio.run(_enqueue())`

## Summary by Sourcery

Bug Fixes:
- Fix RuntimeError raised when no current asyncio event loop exists in the main thread during Celery task enqueueing, particularly under parallel pytest-xdist execution.