### PR TITLE
fix: align ai-engine FastAPI version to 0.136.1 with backend

### DIFF
--- a/ai-engine/requirements.txt
+++ b/ai-engine/requirements.txt
@@ -1,6 +1,6 @@
 # Core FastAPI for AI Engine API - align with backend version
-fastapi==0.136.0
-uvicorn[standard]==0.44.0
+fastapi==0.136.1
+uvicorn[standard]==0.46.0
 python-multipart==0.0.27
 
 # AI Framework - add upper bounds to avoid dependency conflicts
@@ -54,7 +54,7 @@ async-timeout>=5.0.1
 
 # Configuration Management - align with backend version
 pydantic~=2.13.3
-pydantic-settings~=2.11.0
+pydantic-settings~=2.14.0
 
 # Monitoring - align with backend version
 prometheus_client>=0.25.0


### PR DESCRIPTION
## Summary

Aligns `ai-engine/requirements.txt` versions to match `backend/requirements.txt` for packages that the Docker base image installs together. The base image combines all Python requirements from both `backend/` and `ai-engine/` into a single image — conflicting exact/semantic pins cause pip to fail.

## Changes

| Package | ai-engine (before) | ai-engine (after) | backend (reference) |
|---------|-------------------|-------------------|-------------------|
| `fastapi` | `0.136.0` | `0.136.1` | `0.136.1` |
| `uvicorn[standard]` | `0.44.0` | `0.46.0` | `0.46.0` |
| `pydantic-settings` | `~=2.11.0` | `~=2.14.0` | `~=2.14.0` |

## Root Cause

The Dockerfile installs all three requirements files simultaneously:
```dockerfile
RUN python -m pip install --no-cache-dir \
    -r /tmp/ai-engine-requirements.txt \
    -r /tmp/ai-engine-requirements-dev.txt \
    -r /tmp/backend-requirements.txt
```

Conflicting exact pins (`fastapi==0.136.0` vs `==0.136.1`) and incompatible semver ranges (`~=2.11.0` vs `~=2.14.0`) made pip's dependency resolution impossible.

## Testing

- [x] `pip install --dry-run -r ai-engine/requirements.txt -r ai-engine/requirements-dev.txt -r backend/requirements.txt` — dependency resolution succeeds
- [ ] CI: Build Base Images workflow should pass

Closes #1386