### PR TITLE
fix(backend): replace SHA-256 with bcrypt for API key hashing (#1414)

### DIFF
--- a/backend/src/core/auth.py
+++ b/backend/src/core/auth.py
@@ -239,17 +239,43 @@ class AuthManager:
 
     def hash_api_key(self, api_key: str) -> str:
         """
-        Hash an API key for storage.
+        Hash an API key using bcrypt for secure storage.
+
+        bcrypt is intentionally slow (configurable cost factor) which makes
+        offline brute-force attacks against a leaked database significantly
+        more expensive than fast hashes such as SHA-256.
 
         Args:
             api_key: Plain text API key
 
         Returns:
-            Hashed API key using SHA-256
+            Bcrypt-hashed API key (UTF-8 string suitable for varchar storage).
         """
-        import hashlib
+        return bcrypt.hashpw(api_key.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
-        return hashlib.sha256(api_key.encode()).hexdigest()
+    def verify_api_key(self, plain_key: str, hashed_key: str) -> bool:
+        """
+        Verify an API key against its bcrypt hash.
+
+        Returns False (rather than raising) for malformed or missing input so
+        callers can use this as a constant-time comparison primitive without
+        leaking information about the hash format via exceptions.
+
+        Args:
+            plain_key: Plain text API key submitted by the caller.
+            hashed_key: Bcrypt hash previously produced by ``hash_api_key``.
+
+        Returns:
+            True if the plain key matches the stored hash, False otherwise.
+        """
+        if plain_key is None or hashed_key is None:
+            return False
+        try:
+            return bcrypt.checkpw(plain_key.encode("utf-8"), hashed_key.encode("utf-8"))
+        except (ValueError, TypeError):
+            # Invalid hash format (e.g. legacy SHA-256 hex) or encoding error
+            # — treat as a failed verification without leaking why.
+            return False
 
 
 # Default instance for easy import
@@ -265,3 +291,4 @@ generate_verification_token = default_auth.generate_verification_token
 generate_reset_token = default_auth.generate_reset_token
 generate_api_key = default_auth.generate_api_key
 hash_api_key = default_auth.hash_api_key
+verify_api_key = default_auth.verify_api_key

--- a/backend/src/security/auth.py
+++ b/backend/src/security/auth.py
@@ -208,46 +208,76 @@ def generate_api_key() -> tuple[str, str]:
 
 def hash_api_key(api_key: str) -> str:
     """
-    Hash an API key for storage.
+    Hash an API key using bcrypt for secure storage.
+
+    bcrypt uses a random per-call salt, so two calls with the same input
+    produce different output. This means callers cannot look the hash up
+    directly in the database — use :func:`verify_api_key` to authenticate
+    a submitted key against stored hashes.
 
     Args:
         api_key: Plain text API key
 
     Returns:
-        Hashed API key using scrypt (memory-hard KDF)
+        Bcrypt-hashed API key as a UTF-8 string suitable for varchar storage.
     """
-    import hashlib
+    return bcrypt.hashpw(api_key.encode("utf-8"), bcrypt.gensalt(rounds=BCRYPT_COST)).decode(
+        "utf-8"
+    )
 
-    return hashlib.scrypt(
-        api_key.encode(), salt=SECRET_KEY.encode(), n=16384, r=8, p=1, dklen=32
-    ).hex()
+
+def _check_api_key(plain_key: str, hashed_key: str) -> bool:
+    """Constant-time bcrypt comparison that swallows malformed-hash errors."""
+    try:
+        return bcrypt.checkpw(plain_key.encode("utf-8"), hashed_key.encode("utf-8"))
+    except (ValueError, TypeError):
+        # Invalid hash format (e.g. legacy SHA-256/scrypt hex) or bad encoding —
+        # treat as a verification failure without leaking why.
+        return False
 
 
 async def verify_api_key(db, api_key: str) -> "Optional[User]":
     """
     Verify an API key and return the associated user.
 
+    Because :func:`hash_api_key` uses bcrypt with a random per-call salt,
+    we cannot look the row up by hash directly. Instead we narrow the
+    candidate set using the public prefix (the first 8 characters of every
+    issued key, persisted on :class:`APIKey.prefix`) and then run
+    :func:`bcrypt.checkpw` against each candidate.
+
+    Tradeoff: we may run bcrypt up to N times, where N is the number of
+    active keys sharing the same 8-character prefix. The prefix
+    (``mpk_`` + 4 base64url chars) gives ~24 bits of entropy, so in
+    practice N is almost always 1. If many users ever shared a prefix
+    we would need to add an indexed lookup column (e.g. an HMAC
+    fingerprint of the key) — out of scope for this change.
+
     Args:
-        db: Database session
-        api_key: Plain text API key
+        db: Async database session
+        api_key: Plain text API key submitted by the caller
 
     Returns:
-        User if API key is valid, None otherwise
+        User if API key is valid and active, None otherwise.
     """
     from sqlalchemy import select
     from db.models import APIKey, User
 
-    key_hash = hash_api_key(api_key)
-    result = await db.execute(
-        select(APIKey).where(
-            APIKey.key_hash == key_hash,
-            APIKey.is_active == True,
-        )
-    )
-    api_key_record = result.scalar_one_or_none()
-
-    if not api_key_record:
+    if not api_key or len(api_key) < 8:
         return None
 
-    result = await db.execute(select(User).where(User.id == api_key_record.user_id))
-    return result.scalar_one_or_none()
+    prefix = api_key[:8]
+    result = await db.execute(
+        select(APIKey).where(
+            APIKey.prefix == prefix,
+            APIKey.is_active == True,  # noqa: E712 — SQLAlchemy needs `==` here
+        )
+    )
+    candidates = result.scalars().all()
+
+    for record in candidates:
+        if _check_api_key(api_key, record.key_hash):
+            user_result = await db.execute(select(User).where(User.id == record.user_id))
+            return user_result.scalar_one_or_none()
+
+    return None

--- a/backend/src/tests/unit/test_core_auth_api_key.py
+++ b/backend/src/tests/unit/test_core_auth_api_key.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for the bcrypt-based API key hashing/verification helpers
+introduced for issue #1414 on ``core.auth.AuthManager``.
+"""
+
+import bcrypt
+import pytest
+
+from core.auth import AuthManager, default_auth, hash_api_key, verify_api_key
+
+
+@pytest.mark.unit
+class TestAuthManagerApiKeyBcrypt:
+    """Behavioural tests for AuthManager.hash_api_key / verify_api_key."""
+
+    def test_hash_api_key_uses_bcrypt_format(self):
+        manager = AuthManager()
+        full_key, _ = manager.generate_api_key()
+
+        hashed = manager.hash_api_key(full_key)
+
+        # bcrypt modular crypt format: $2[abxy]$<cost>$<22-char-salt><31-char-hash>
+        assert isinstance(hashed, str)
+        assert len(hashed) == 60
+        assert hashed.startswith("$2")
+
+    def test_hash_api_key_is_non_deterministic(self):
+        """Each hash uses a fresh salt — calls must not collide."""
+        manager = AuthManager()
+        full_key, _ = manager.generate_api_key()
+
+        first = manager.hash_api_key(full_key)
+        second = manager.hash_api_key(full_key)
+
+        assert first != second
+        # …but both must verify against the same plaintext.
+        assert bcrypt.checkpw(full_key.encode("utf-8"), first.encode("utf-8"))
+        assert bcrypt.checkpw(full_key.encode("utf-8"), second.encode("utf-8"))
+
+    def test_verify_api_key_accepts_correct_key(self):
+        manager = AuthManager()
+        full_key, _ = manager.generate_api_key()
+        hashed = manager.hash_api_key(full_key)
+
+        assert manager.verify_api_key(full_key, hashed) is True
+
+    def test_verify_api_key_rejects_wrong_key(self):
+        manager = AuthManager()
+        full_key, _ = manager.generate_api_key()
+        hashed = manager.hash_api_key(full_key)
+
+        assert manager.verify_api_key("mpk_obviously-wrong-key", hashed) is False
+
+    def test_verify_api_key_rejects_malformed_hash(self):
+        manager = AuthManager()
+        full_key, _ = manager.generate_api_key()
+
+        # legacy SHA-256 hex hash format (64 chars, not bcrypt)
+        legacy_hash = "a" * 64
+        assert manager.verify_api_key(full_key, legacy_hash) is False
+
+        # complete garbage
+        assert manager.verify_api_key(full_key, "not-a-hash") is False
+
+    def test_verify_api_key_rejects_none_inputs(self):
+        manager = AuthManager()
+
+        assert manager.verify_api_key(None, "$2b$12$" + "a" * 53) is False
+        assert manager.verify_api_key("mpk_anything", None) is False
+        assert manager.verify_api_key(None, None) is False
+
+    def test_module_level_aliases_use_default_auth(self):
+        """The module-level ``hash_api_key`` / ``verify_api_key`` are convenience
+        wrappers around ``default_auth`` — exercise them end-to-end.
+        """
+        full_key, _ = default_auth.generate_api_key()
+
+        hashed = hash_api_key(full_key)
+        assert verify_api_key(full_key, hashed) is True
+        assert verify_api_key("mpk_other", hashed) is False

--- a/backend/src/tests/unit/test_security_auth_coverage.py
+++ b/backend/src/tests/unit/test_security_auth_coverage.py
@@ -140,6 +140,8 @@ class TestSecurityAuth:
 
     def test_api_key_generation(self):
         """Test API key generation and hashing."""
+        import bcrypt
+
         full_key, prefix = generate_api_key()
 
         assert full_key.startswith("mpk_")
@@ -147,5 +149,15 @@ class TestSecurityAuth:
         assert len(full_key) > 20
 
         hashed = hash_api_key(full_key)
-        assert len(hashed) == 64  # SHA-256 hex
-        assert hashed == hash_api_key(full_key)  # Deterministic
+        # bcrypt hashes are always 60 chars and start with $2 (modular crypt format)
+        assert isinstance(hashed, str)
+        assert len(hashed) == 60
+        assert hashed.startswith("$2")
+        # bcrypt is non-deterministic — each call uses a fresh salt — but the
+        # produced hash must still verify against the original plaintext.
+        second_hash = hash_api_key(full_key)
+        assert second_hash != hashed
+        assert bcrypt.checkpw(full_key.encode("utf-8"), hashed.encode("utf-8"))
+        assert bcrypt.checkpw(full_key.encode("utf-8"), second_hash.encode("utf-8"))
+        # A wrong key must not verify.
+        assert not bcrypt.checkpw(b"mpk_wrong-key-payload", hashed.encode("utf-8"))

--- a/backend/src/tests/unit/test_security_auth_verify_api_key.py
+++ b/backend/src/tests/unit/test_security_auth_verify_api_key.py
@@ -1,0 +1,123 @@
+"""
+Regression tests for ``security.auth.verify_api_key`` after the bcrypt
+migration in issue #1414.
+
+These tests use a fake async DB that yields canned ``execute`` results,
+so we can exercise the prefix-narrow + ``bcrypt.checkpw`` candidate loop
+without spinning up a real database.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from security.auth import hash_api_key, verify_api_key
+
+
+class _ScalarResult:
+    """Mimic the slice of the SQLAlchemy ``Result`` API used by verify_api_key."""
+
+    def __init__(self, rows: list[Any]):
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return list(self._rows)
+
+    def scalar_one_or_none(self) -> Any | None:
+        return self._rows[0] if self._rows else None
+
+    def scalars(self) -> "_ScalarResult":
+        return self
+
+
+class _FakeAsyncSession:
+    """
+    Two-call fake: the first ``execute`` returns API-key candidates,
+    the second returns the User row matched against the winning candidate.
+    """
+
+    def __init__(self, candidates: list[Any], users: list[Any]):
+        self._candidates = candidates
+        self._users = users
+        self.execute_calls = 0
+
+    async def execute(self, _stmt: Any) -> _ScalarResult:
+        self.execute_calls += 1
+        if self.execute_calls == 1:
+            return _ScalarResult(self._candidates)
+        return _ScalarResult(self._users)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSecurityAuthVerifyApiKey:
+    """Behavioural tests for ``security.auth.verify_api_key`` candidate loop."""
+
+    async def test_returns_user_for_correct_key_single_candidate(self):
+        plain = "mpk_test-key-single-candidate"
+        candidate = SimpleNamespace(key_hash=hash_api_key(plain), user_id="user-1")
+        user = SimpleNamespace(id="user-1")
+        db = _FakeAsyncSession([candidate], [user])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user
+        # one query for candidates, one for the user
+        assert db.execute_calls == 2
+
+    async def test_returns_user_when_correct_key_is_not_first_candidate(self):
+        """If multiple keys share a prefix, the loop must keep checking."""
+        plain = "mpk_real-key-second-in-list"
+        wrong = SimpleNamespace(key_hash=hash_api_key("mpk_some-other-key"), user_id="user-x")
+        right = SimpleNamespace(key_hash=hash_api_key(plain), user_id="user-1")
+        user = SimpleNamespace(id="user-1")
+        db = _FakeAsyncSession([wrong, right], [user])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user
+
+    async def test_returns_none_when_no_candidate_matches(self):
+        plain = "mpk_a-key-that-no-row-stores"
+        wrong = SimpleNamespace(key_hash=hash_api_key("mpk_completely-different"), user_id="x")
+        db = _FakeAsyncSession([wrong], [])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is None
+        # Only the candidate query runs; we never look the user up.
+        assert db.execute_calls == 1
+
+    async def test_returns_none_when_no_candidates_for_prefix(self):
+        plain = "mpk_no-rows-at-all"
+        db = _FakeAsyncSession([], [])
+
+        assert await verify_api_key(db, plain) is None
+        assert db.execute_calls == 1
+
+    async def test_returns_none_for_empty_or_short_input(self):
+        db = _FakeAsyncSession([], [])
+
+        assert await verify_api_key(db, "") is None
+        assert await verify_api_key(db, "abc") is None
+        # Short-circuit: no DB calls at all.
+        assert db.execute_calls == 0
+
+    async def test_returns_none_for_none_input(self):
+        db = _FakeAsyncSession([], [])
+
+        assert await verify_api_key(db, None) is None
+        assert db.execute_calls == 0
+
+    async def test_skips_candidate_with_legacy_hash_format(self):
+        """A legacy SHA-256 / scrypt hex hash must not raise, just be skipped."""
+        plain = "mpk_real-key-after-legacy-row"
+        legacy = SimpleNamespace(key_hash="a" * 64, user_id="legacy")
+        good = SimpleNamespace(key_hash=hash_api_key(plain), user_id="user-1")
+        user = SimpleNamespace(id="user-1")
+        db = _FakeAsyncSession([legacy, good], [user])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user


### PR DESCRIPTION
Closes #1414

## Why
SHA-256 is too fast (~millions of hashes/sec) for password-class secrets and is brute-forceable if the database is compromised. Passwords already use bcrypt; API keys should match.

> **Side note:** the module-level helper in `backend/src/security/auth.py` was actually using `hashlib.scrypt` (with a static salt = `SECRET_KEY`) rather than SHA-256, but the same critique applies — a static-salt scrypt is still vulnerable to precomputation against the per-deployment salt. This PR consolidates both call-sites onto bcrypt with per-call random salts.

## What
- `backend/src/core/auth.py` — `AuthManager.hash_api_key` now uses `bcrypt.hashpw` + `bcrypt.gensalt`; new `AuthManager.verify_api_key(plain, hashed) -> bool` uses `bcrypt.checkpw` with `ValueError`/`TypeError`/`None` guards. The new method is also exported at module level (`verify_api_key = default_auth.verify_api_key`) to mirror the existing `hash_api_key` alias.
- `backend/src/security/auth.py`
  - module-level `hash_api_key` switched to bcrypt (replacing the previous static-salt scrypt)
  - `verify_api_key(db, api_key)` rewritten to: (a) reject empty/short tokens early, (b) narrow candidates by the public `APIKey.prefix` column (first 8 chars of the issued key — already persisted), and (c) run `bcrypt.checkpw` against each candidate. The signature is unchanged, so `api/conversions.py` and `api/premium_conversion.py` continue to work without modification.
  - Tradeoff documented inline: we may run bcrypt up to N times per verification, where N = active keys sharing the same 8-char prefix. Prefix entropy is ~24 bits, so N is almost always 1 in practice. If collisions ever become common we can add an indexed HMAC fingerprint column — out of scope here.

## Tests
- Updated `backend/src/tests/unit/test_security_auth_coverage.py::test_api_key_generation` to no longer assert deterministic hash equality (`hashed == hash_api_key(full_key)` is false under bcrypt). Now asserts bcrypt format (`$2…`, 60 chars), non-determinism across calls, and successful `bcrypt.checkpw` round-trips for both hashes plus rejection of a wrong key.
- New `backend/src/tests/unit/test_core_auth_api_key.py` covers `AuthManager.verify_api_key` end-to-end:
  - correct key → True
  - wrong key → False
  - malformed (legacy SHA-256 hex, garbage) hash → False (no exception)
  - `None` inputs → False
  - module-level convenience aliases (`hash_api_key`, `verify_api_key`) work via `default_auth`
- Existing API auth / OAuth tests (`test_api_auth_simple.py`, `test_api_oauth.py`, `test_api_auth_coverage.py`) continue to pass — they patch `api.auth.hash_api_key`, so the new return format is transparent.

Local run (89 collected, 0 failed):

```
$ python3 -m pytest src/tests/unit/test_security_auth_coverage.py \
    src/tests/unit/test_core_auth_api_key.py \
    src/tests/unit/test_api_auth_simple.py \
    src/tests/unit/test_api_oauth.py \
    src/tests/unit/test_api_auth_coverage.py
============================== 89 passed in 10.72s ==============================
```

## Migration
Any API keys currently stored with SHA-256 (or static-salt scrypt) hashes in the database will fail verification after this deploy and must be re-issued. There is no in-place data migration; users with existing keys should rotate them via the standard `POST /auth/api-keys` flow. The `APIKey.key_hash` column is `String(255)`, so it has plenty of room for the 60-char bcrypt output — no schema migration needed. If a one-shot rehash-on-next-use path is desired (re-hash transparently on the first successful authentication), it can be added in a follow-up; intentionally out of scope here to keep the change focused on the security fix.

## Acceptance checklist
- [x] `hash_api_key` in `backend/src/core/auth.py` uses bcrypt
- [x] `verify_api_key` method added to the auth helper class in `backend/src/core/auth.py` and exported at module level
- [x] `backend/src/security/auth.py` `hash_api_key` and `verify_api_key` updated to use bcrypt correctly (iterate-and-checkpw; narrowed by `APIKey.prefix`)
- [x] No remaining `hashlib.sha256` / `hashlib.scrypt` calls for API key hashing in the touched files
- [x] Migration path documented (above)
- [x] All targeted unit tests pass