### PR TITLE
chore(backend): add __init__.py to namespace packages (#1430)

### DIFF
--- a/backend/src/db/__init__.py
+++ b/backend/src/db/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker — added in #1430 to prevent sibling editable-install shadowing."""

--- a/backend/src/db/migrations/__init__.py
+++ b/backend/src/db/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker — added in #1430 to prevent sibling editable-install shadowing."""

--- a/backend/src/db/migrations/versions/__init__.py
+++ b/backend/src/db/migrations/versions/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker — added in #1430 to prevent sibling editable-install shadowing."""

--- a/backend/src/worker/__init__.py
+++ b/backend/src/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker — added in #1430 to prevent sibling editable-install shadowing."""


### PR DESCRIPTION
## Summary

Adds package marker files to backend source directories that still contained Python modules without `__init__.py`, preventing implicit namespace package merging during editable installs.

## Added `__init__.py` directories

- `backend/src/worker/`
- `backend/src/db/`
- `backend/src/db/migrations/`
- `backend/src/db/migrations/versions/`

## Verification

- `cd backend && ruff check src/` — passed
- `cd backend && python3 -m pytest src/tests/unit/ -q --tb=no -x` — passed: 3298 passed, 85 skipped, 7 warnings; coverage 84.00%
- `cd backend && python3 -c "import importlib; [importlib.import_module(f'src.{m}') for m in ['api','services','models','db','security','core','worker']]"` — passed

## Package discovery

- `backend/pyproject.toml` was not changed. It only has pytest/mypy settings here, and `backend/setup.py` already uses regular `find_packages()` rather than namespace package discovery.
- `backend/src/tests/`, `backend/src/tests/unit/`, and `backend/src/tests/integration/` were intentionally left without `__init__.py` so pytest discovery remains unchanged.

Closes #1430
