### PR TITLE
feat(security): rehash legacy SHA-256/scrypt API keys to bcrypt on first use (#1428)

### DIFF
--- a/backend/src/core/auth.py
+++ b/backend/src/core/auth.py
@@ -6,8 +6,12 @@ Provides high-level authentication functionality including:
 - Password hashing with bcrypt
 - Token generation and validation
 - AuthManager class for easy integration
+- Rehash-on-next-use migration path for legacy SHA-256/scrypt API keys (#1428)
 """
 
+import hashlib
+import hmac
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -17,6 +21,8 @@ import jwt
 
 from core.secrets import get_secret
 
+logger = logging.getLogger(__name__)
+
 # JWT settings
 SECRET_KEY = get_secret("SECRET_KEY")
 if not SECRET_KEY:
@@ -24,6 +30,91 @@ if not SECRET_KEY:
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 15
 REFRESH_TOKEN_EXPIRE_DAYS = 7
+
+# ---------------------------------------------------------------------------
+# Legacy API-key migration support (issue #1428)
+# ---------------------------------------------------------------------------
+# bcrypt's modular-crypt format always begins with one of these tags. Anything
+# else stored in ``api_keys.key_hash`` is assumed to be a pre-#1414 hash
+# (SHA-256 hex from this module or scrypt hex from ``security.auth``) and is
+# eligible for rehash-on-next-use via :meth:`AuthManager.verify_api_key_with_rehash`.
+BCRYPT_HASH_PREFIXES = ("$2a$", "$2b$", "$2y$")
+
+# Pre-#1414 scrypt parameters used by ``security.auth.hash_api_key``. Kept
+# here too so the verification primitive in this module can fall back to
+# scrypt when an API key was issued via the security path. See PR #1425
+# parent commit for the original constants.
+_LEGACY_SCRYPT_N = 16384
+_LEGACY_SCRYPT_R = 8
+_LEGACY_SCRYPT_P = 1
+_LEGACY_SCRYPT_DKLEN = 32
+
+# SHA-256 / scrypt-with-dklen=32 hex digest length. Used as the dummy
+# placeholder so constant-time comparisons against malformed stored hashes
+# touch the same number of bytes as the real path.
+_LEGACY_HEX_LEN = 64
+
+
+def _is_bcrypt_hash(stored_hash: object) -> bool:
+    """Return True if ``stored_hash`` looks like a bcrypt modular-crypt string."""
+    return isinstance(stored_hash, str) and stored_hash.startswith(BCRYPT_HASH_PREFIXES)
+
+
+# TODO(security): remove legacy SHA-256/scrypt fallback after 2026-08-13
+# (90 days post-deploy of #1428). Tracked in #1428 follow-up. After removal,
+# any remaining legacy keys force re-issue (PR #1425 behaviour).
+def _matches_legacy_sha256(plain_key: str, stored: object) -> bool:
+    """Constant-time SHA-256 hex comparison against a pre-#1414 hash.
+
+    Pre-#1414 ``core.auth.hash_api_key`` was
+    ``hashlib.sha256(api_key.encode()).hexdigest()``. This helper always
+    computes the digest and always invokes :func:`hmac.compare_digest`, so a
+    timing attacker cannot distinguish "stored hash had wrong length" from
+    "stored hash had right length but different value".
+    """
+    try:
+        computed = hashlib.sha256(plain_key.encode("utf-8")).hexdigest()
+    except (AttributeError, UnicodeError, TypeError):
+        computed = "0" * _LEGACY_HEX_LEN
+
+    if not isinstance(stored, str):
+        hmac.compare_digest(computed, "0" * _LEGACY_HEX_LEN)
+        return False
+
+    return hmac.compare_digest(computed, stored)
+
+
+# TODO(security): remove legacy SHA-256/scrypt fallback after 2026-08-13
+# (90 days post-deploy of #1428). Tracked in #1428 follow-up.
+def _matches_legacy_scrypt(plain_key: str, stored: object) -> bool:
+    """Constant-time scrypt hex comparison against a pre-#1414 hash.
+
+    Pre-#1414 ``security.auth.hash_api_key`` was::
+
+        hashlib.scrypt(api_key.encode(), salt=SECRET_KEY.encode(),
+                       n=16384, r=8, p=1, dklen=32).hex()
+
+    The static-SECRET_KEY salt was one of the reasons we migrated away from
+    this scheme. We replicate the parameters here only to drain remaining
+    legacy keys.
+    """
+    try:
+        computed = hashlib.scrypt(
+            plain_key.encode("utf-8"),
+            salt=SECRET_KEY.encode("utf-8"),
+            n=_LEGACY_SCRYPT_N,
+            r=_LEGACY_SCRYPT_R,
+            p=_LEGACY_SCRYPT_P,
+            dklen=_LEGACY_SCRYPT_DKLEN,
+        ).hex()
+    except (AttributeError, UnicodeError, TypeError, ValueError):
+        computed = "0" * _LEGACY_HEX_LEN
+
+    if not isinstance(stored, str):
+        hmac.compare_digest(computed, "0" * _LEGACY_HEX_LEN)
+        return False
+
+    return hmac.compare_digest(computed, stored)
 
 
 class AuthManager:
@@ -261,6 +352,11 @@ class AuthManager:
         callers can use this as a constant-time comparison primitive without
         leaking information about the hash format via exceptions.
 
+        This method is bcrypt-only and remains byte-identical to the
+        behaviour introduced by PR #1425. Use
+        :meth:`verify_api_key_with_rehash` if you need to also accept legacy
+        SHA-256/scrypt hashes (issue #1428).
+
         Args:
             plain_key: Plain text API key submitted by the caller.
             hashed_key: Bcrypt hash previously produced by ``hash_api_key``.
@@ -277,6 +373,57 @@ class AuthManager:
             # — treat as a failed verification without leaking why.
             return False
 
+    def needs_rehash(self, stored_hash: object) -> bool:
+        """Return True if ``stored_hash`` is in a deprecated legacy format.
+
+        Callers can use this as a cheap pre-check before invoking
+        :meth:`verify_api_key_with_rehash`. Returns False for bcrypt hashes
+        and True for everything else (including malformed strings — those
+        also need replacement).
+        """
+        return not _is_bcrypt_hash(stored_hash)
+
+    def verify_api_key_with_rehash(
+        self, plain_key: str, hashed_key: str
+    ) -> tuple[bool, Optional[str]]:
+        """Verify an API key, accepting legacy SHA-256/scrypt hashes (#1428).
+
+        This is the legacy-tolerant sibling of :meth:`verify_api_key`. It
+        does NOT touch the database; the caller is responsible for
+        persisting ``new_hash`` when it is non-None.
+
+        Args:
+            plain_key: Plain text API key submitted by the caller.
+            hashed_key: Stored hash — may be bcrypt (modern) or legacy
+                SHA-256/scrypt hex (pre-#1414).
+
+        Returns:
+            ``(matched, new_hash)`` where:
+
+            - ``(True, None)`` — bcrypt hash matched; no rehash needed.
+              Byte-identical to :meth:`verify_api_key` returning True.
+            - ``(True, "<bcrypt hash>")`` — legacy hash matched; the caller
+              MUST persist ``new_hash`` to ``api_keys.key_hash`` and SHOULD
+              emit the ``legacy_api_key_rehashed`` log/metric.
+            - ``(False, None)`` — no match. Do **not** persist anything.
+        """
+        if plain_key is None or hashed_key is None:
+            return (False, None)
+
+        if _is_bcrypt_hash(hashed_key):
+            # Modern path — byte-identical to verify_api_key().
+            return (self.verify_api_key(plain_key, hashed_key), None)
+
+        # Legacy path: try SHA-256, then scrypt. Both helpers are
+        # constant-time even on malformed input.
+        if _matches_legacy_sha256(plain_key, hashed_key) or _matches_legacy_scrypt(
+            plain_key, hashed_key
+        ):
+            new_hash = self.hash_api_key(plain_key)
+            return (True, new_hash)
+
+        return (False, None)
+
 
 # Default instance for easy import
 default_auth = AuthManager()
@@ -292,3 +439,5 @@ generate_reset_token = default_auth.generate_reset_token
 generate_api_key = default_auth.generate_api_key
 hash_api_key = default_auth.hash_api_key
 verify_api_key = default_auth.verify_api_key
+verify_api_key_with_rehash = default_auth.verify_api_key_with_rehash
+needs_rehash = default_auth.needs_rehash

--- a/backend/src/security/auth.py
+++ b/backend/src/security/auth.py
@@ -5,17 +5,23 @@ Provides:
 - Password hashing and verification using bcrypt
 - JWT token creation and verification
 - Token type constants
+- Rehash-on-next-use migration path for legacy SHA-256/scrypt API keys (#1428)
 """
 
+import hashlib
+import hmac
+import logging
 import os
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Optional
 
-import jwt
 import bcrypt
+import jwt
 
 from core.secrets import get_secret
+
+logger = logging.getLogger(__name__)
 
 # bcrypt cost factor (12 = ~250ms per hash on modern hardware)
 BCRYPT_COST = 12
@@ -31,6 +37,31 @@ ALGORITHM = "HS256"
 # Development: 15 minutes access, 7 days refresh (more convenient)
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "5"))
 REFRESH_TOKEN_EXPIRE_DAYS = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "1"))
+
+# ---------------------------------------------------------------------------
+# Legacy API-key migration support (issue #1428)
+# ---------------------------------------------------------------------------
+# bcrypt's modular-crypt format always begins with one of these tags. Anything
+# else stored in ``api_keys.key_hash`` is assumed to be a pre-#1414 hash
+# (SHA-256 hex from ``core.auth`` or scrypt hex from ``security.auth``) and is
+# eligible for rehash-on-next-use. The list mirrors what passlib accepts so we
+# don't accidentally treat a valid bcrypt variant as legacy.
+BCRYPT_HASH_PREFIXES = ("$2a$", "$2b$", "$2y$")
+
+# Pre-#1414 scrypt parameters used by ``security.auth.hash_api_key``.
+# Source of truth: parent commit of PR #1425 — ``hashlib.scrypt(api_key.encode(),
+# salt=SECRET_KEY.encode(), n=16384, r=8, p=1, dklen=32).hex()``. The static
+# SECRET_KEY salt is one of the reasons we migrated away from this scheme; we
+# only replicate it here so existing keys can still authenticate during drain.
+_LEGACY_SCRYPT_N = 16384
+_LEGACY_SCRYPT_R = 8
+_LEGACY_SCRYPT_P = 1
+_LEGACY_SCRYPT_DKLEN = 32
+
+# Length of a SHA-256 / scrypt-with-dklen=32 hex digest. Used as the dummy
+# placeholder so constant-time comparisons against malformed stored hashes
+# still touch the same number of bytes as the real path.
+_LEGACY_HEX_LEN = 64
 
 
 def hash_password(password: str) -> str:
@@ -227,13 +258,141 @@ def hash_api_key(api_key: str) -> str:
 
 
 def _check_api_key(plain_key: str, hashed_key: str) -> bool:
-    """Constant-time bcrypt comparison that swallows malformed-hash errors."""
+    """Constant-time bcrypt comparison that swallows malformed-hash errors.
+
+    NOTE: This helper remains bcrypt-only and byte-identical to the behaviour
+    introduced by PR #1425. The legacy SHA-256/scrypt fallback lives in
+    :func:`verify_api_key` because the rehash + DB write must happen alongside
+    the candidate row, not in a pure verification primitive.
+    """
     try:
         return bcrypt.checkpw(plain_key.encode("utf-8"), hashed_key.encode("utf-8"))
     except (ValueError, TypeError):
         # Invalid hash format (e.g. legacy SHA-256/scrypt hex) or bad encoding —
         # treat as a verification failure without leaking why.
         return False
+
+
+def _is_bcrypt_hash(stored_hash: object) -> bool:
+    """Return True if ``stored_hash`` looks like a bcrypt modular-crypt string.
+
+    Format-only (``$2a$`` / ``$2b$`` / ``$2y$`` prefix). We do *not* try to
+    parse the body — bcrypt itself will validate the structure during
+    :func:`bcrypt.checkpw`. Any non-string input is rejected so the legacy
+    fallback path can take over.
+    """
+    return isinstance(stored_hash, str) and stored_hash.startswith(BCRYPT_HASH_PREFIXES)
+
+
+# TODO(security): remove legacy SHA-256/scrypt fallback after 2026-08-13
+# (90 days post-deploy of #1428). Tracked in #1428 follow-up. After removal,
+# any remaining legacy keys force re-issue (the original PR #1425 behaviour).
+def _matches_legacy_sha256(plain_key: str, stored: object) -> bool:
+    """Constant-time SHA-256 hex comparison against a pre-#1414 hash.
+
+    Pre-#1414 ``core.auth.hash_api_key`` was::
+
+        hashlib.sha256(api_key.encode()).hexdigest()
+
+    The function is constant-time even when ``stored`` is malformed: we
+    always compute the SHA-256 digest of ``plain_key`` and always invoke
+    :func:`hmac.compare_digest`, so a timing attacker cannot distinguish
+    "stored hash had wrong length" from "stored hash had right length but
+    different value".
+    """
+    try:
+        computed = hashlib.sha256(plain_key.encode("utf-8")).hexdigest()
+    except (AttributeError, UnicodeError, TypeError):
+        # Plain key was not a usable string; still keep timing flat by
+        # comparing a placeholder of the expected length.
+        computed = "0" * _LEGACY_HEX_LEN
+
+    if not isinstance(stored, str):
+        # Always perform the dummy comparison so this branch costs the same
+        # number of bytes as the real path.
+        hmac.compare_digest(computed, "0" * _LEGACY_HEX_LEN)
+        return False
+
+    return hmac.compare_digest(computed, stored)
+
+
+# TODO(security): remove legacy SHA-256/scrypt fallback after 2026-08-13
+# (90 days post-deploy of #1428). Tracked in #1428 follow-up.
+def _matches_legacy_scrypt(plain_key: str, stored: object) -> bool:
+    """Constant-time scrypt hex comparison against a pre-#1414 hash.
+
+    Pre-#1414 ``security.auth.hash_api_key`` was::
+
+        hashlib.scrypt(
+            api_key.encode(),
+            salt=SECRET_KEY.encode(),
+            n=16384, r=8, p=1, dklen=32,
+        ).hex()
+
+    The static-SECRET_KEY salt was one of the reasons we migrated away from
+    this scheme (it allows precomputed rainbow tables once the secret leaks).
+    We replicate the parameters here only to drain remaining legacy keys.
+    Like :func:`_matches_legacy_sha256` this is constant-time even when
+    ``stored`` is malformed.
+    """
+    try:
+        computed = hashlib.scrypt(
+            plain_key.encode("utf-8"),
+            salt=SECRET_KEY.encode("utf-8"),
+            n=_LEGACY_SCRYPT_N,
+            r=_LEGACY_SCRYPT_R,
+            p=_LEGACY_SCRYPT_P,
+            dklen=_LEGACY_SCRYPT_DKLEN,
+        ).hex()
+    except (AttributeError, UnicodeError, TypeError, ValueError):
+        computed = "0" * _LEGACY_HEX_LEN
+
+    if not isinstance(stored, str):
+        hmac.compare_digest(computed, "0" * _LEGACY_HEX_LEN)
+        return False
+
+    return hmac.compare_digest(computed, stored)
+
+
+async def _rehash_legacy_key(db, record, plain_key: str, legacy_format: str) -> bool:
+    """Rehash a legacy API-key row to bcrypt and persist it.
+
+    Returns ``True`` on a successful commit, ``False`` if persistence failed
+    (in which case the session is rolled back). The caller authenticates the
+    user either way — a transient DB hiccup must not lock a valid key out;
+    the next call simply retries the upgrade.
+    """
+    new_hash = bcrypt.hashpw(plain_key.encode("utf-8"), bcrypt.gensalt(rounds=BCRYPT_COST)).decode(
+        "utf-8"
+    )
+
+    try:
+        record.key_hash = new_hash
+        await db.commit()
+    except Exception:
+        try:
+            await db.rollback()
+        except Exception:
+            # Rollback failures are themselves logged; don't mask the original.
+            pass
+        logger.exception(
+            "legacy_api_key_rehash_persist_failed",
+            extra={"user_id": str(record.user_id), "old_format": legacy_format},
+        )
+        return False
+
+    logger.info(
+        "legacy_api_key_rehashed",
+        extra={"user_id": str(record.user_id), "old_format": legacy_format},
+    )
+    # Best-effort metric — services.metrics is optional in some test contexts.
+    try:
+        from services.metrics import record_legacy_api_key_rehashed
+
+        record_legacy_api_key_rehashed(legacy_format)
+    except ImportError:
+        pass
+    return True
 
 
 async def verify_api_key(db, api_key: str) -> "Optional[User]":
@@ -253,6 +412,13 @@ async def verify_api_key(db, api_key: str) -> "Optional[User]":
     we would need to add an indexed lookup column (e.g. an HMAC
     fingerprint of the key) — out of scope for this change.
 
+    Legacy migration (#1428): if a candidate row stores a pre-#1414
+    SHA-256 or scrypt hash and the key matches under the legacy scheme,
+    the row is transparently rehashed with bcrypt and persisted before
+    the user is returned. The bcrypt fast-path is byte-identical to the
+    pre-rehash behaviour: bcrypt-format hashes never touch the legacy
+    helpers and never trigger a DB write.
+
     Args:
         db: Async database session
         api_key: Plain text API key submitted by the caller
@@ -261,6 +427,7 @@ async def verify_api_key(db, api_key: str) -> "Optional[User]":
         User if API key is valid and active, None otherwise.
     """
     from sqlalchemy import select
+
     from db.models import APIKey, User
 
     if not api_key or len(api_key) < 8:
@@ -276,8 +443,35 @@ async def verify_api_key(db, api_key: str) -> "Optional[User]":
     candidates = result.scalars().all()
 
     for record in candidates:
-        if _check_api_key(api_key, record.key_hash):
-            user_result = await db.execute(select(User).where(User.id == record.user_id))
-            return user_result.scalar_one_or_none()
+        stored_hash = record.key_hash
+
+        if _is_bcrypt_hash(stored_hash):
+            # Modern path — byte-identical to PR #1425 behaviour. No DB write,
+            # no metric, no log; this is the common case at steady state.
+            if _check_api_key(api_key, stored_hash):
+                user_result = await db.execute(select(User).where(User.id == record.user_id))
+                return user_result.scalar_one_or_none()
+            continue
+
+        # Legacy path (#1428): try SHA-256 first (cheaper), then scrypt.
+        # Both helpers are constant-time even on malformed stored hashes.
+        legacy_format: Optional[str] = None
+        if _matches_legacy_sha256(api_key, stored_hash):
+            legacy_format = "sha256"
+        elif _matches_legacy_scrypt(api_key, stored_hash):
+            legacy_format = "scrypt"
+
+        if legacy_format is None:
+            # Stored hash isn't bcrypt and isn't a legacy match — could be
+            # corruption or a hash from a future scheme; skip without
+            # writing anything and let the next candidate try.
+            continue
+
+        # Match — rehash with bcrypt, persist, and emit telemetry. Auth
+        # succeeds whether or not the rehash commit succeeds (see helper).
+        await _rehash_legacy_key(db, record, api_key, legacy_format)
+
+        user_result = await db.execute(select(User).where(User.id == record.user_id))
+        return user_result.scalar_one_or_none()
 
     return None

--- a/backend/src/services/metrics.py
+++ b/backend/src/services/metrics.py
@@ -282,6 +282,23 @@ rate_limit_active_clients = Gauge(
 
 
 # ============================================
+# Authentication / Migration Metrics (Issue #1428)
+# ============================================
+
+# Counts API-key rows transparently rehashed from legacy SHA-256 / scrypt
+# storage to bcrypt on first use after the #1414 / #1425 migration.
+# Used to monitor migration drain — when this counter flatlines for several
+# weeks, the legacy fallback in security.auth / core.auth can be removed
+# (sunset target: 2026-08-13, see #1428).
+legacy_api_key_rehashed_total = Counter(
+    "portkit_legacy_api_key_rehashed_total",
+    "API keys upgraded from legacy SHA-256/scrypt storage to bcrypt on use",
+    ["old_format"],
+    registry=registry,
+)
+
+
+# ============================================
 # Internal Tracking (thread-safe)
 # ============================================
 
@@ -557,6 +574,18 @@ def update_active_rate_limit_clients(count: int):
         count: Number of unique clients currently tracked
     """
     rate_limit_active_clients.set(count)
+
+
+def record_legacy_api_key_rehashed(old_format: str) -> None:
+    """
+    Record a legacy API-key hash being upgraded to bcrypt (issue #1428).
+
+    Args:
+        old_format: The pre-migration hash format that matched — one of
+            ``"sha256"`` or ``"scrypt"``. Used as the metric label so ops
+            dashboards can split the migration drain by source format.
+    """
+    legacy_api_key_rehashed_total.labels(old_format=old_format).inc()
 
 
 def get_metrics() -> bytes:

--- a/backend/src/tests/unit/test_auth_legacy_rehash.py
+++ b/backend/src/tests/unit/test_auth_legacy_rehash.py
@@ -1,0 +1,494 @@
+"""
+Unit tests for the rehash-on-next-use migration path for legacy SHA-256 /
+scrypt API keys (issue #1428).
+
+Covers both ``security.auth.verify_api_key`` (async, DB-aware — does the
+actual rehash + commit) and ``core.auth.AuthManager.verify_api_key_with_rehash``
+(pure primitive — returns the new bcrypt hash for the caller to persist).
+
+The bcrypt fast-path must remain byte-identical to the post-#1425 behaviour:
+no extra DB write, no metric increment, no log line.
+"""
+
+import hashlib
+import logging
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import bcrypt
+import pytest
+
+from core.auth import (
+    BCRYPT_HASH_PREFIXES,
+    AuthManager,
+    _is_bcrypt_hash,
+    _matches_legacy_scrypt,
+    _matches_legacy_sha256,
+    needs_rehash,
+    verify_api_key_with_rehash,
+)
+from security.auth import (
+    SECRET_KEY,
+    hash_api_key,
+    verify_api_key,
+)
+from security.auth import (
+    _matches_legacy_scrypt as sec_matches_legacy_scrypt,
+)
+from security.auth import (
+    _matches_legacy_sha256 as sec_matches_legacy_sha256,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _ScalarResult:
+    """Mimic the slice of the SQLAlchemy ``Result`` API used by verify_api_key."""
+
+    def __init__(self, rows: list[Any]):
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return list(self._rows)
+
+    def scalar_one_or_none(self) -> Optional[Any]:
+        return self._rows[0] if self._rows else None
+
+    def scalars(self) -> "_ScalarResult":
+        return self
+
+
+class _FakeAsyncSession:
+    """
+    Async session double that yields canned ``execute`` results in order.
+
+    First call -> APIKey candidates (a list).
+    Second call -> User row(s) for the matched candidate.
+    Third+ calls -> repeats the user-row result (used by the
+    "rehashed key verifies on next call" test which authenticates twice
+    against the same fake).
+    """
+
+    def __init__(self, candidates: list[Any], users: list[Any]):
+        self._candidates = candidates
+        self._users = users
+        self.execute_calls = 0
+        self.commit_calls = 0
+        self.rollback_calls = 0
+        self.commit_should_raise: Optional[Exception] = None
+
+    async def execute(self, _stmt: Any) -> _ScalarResult:
+        self.execute_calls += 1
+        # On every odd call (1st, 3rd, ...) we return candidates so the test
+        # can re-run the verifier; on even calls we return users.
+        if self.execute_calls % 2 == 1:
+            return _ScalarResult(self._candidates)
+        return _ScalarResult(self._users)
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+        if self.commit_should_raise is not None:
+            raise self.commit_should_raise
+
+    async def rollback(self) -> None:
+        self.rollback_calls += 1
+
+
+def _legacy_sha256_hash(plain: str) -> str:
+    """Replicate the pre-#1414 ``core.auth.hash_api_key`` output exactly."""
+    return hashlib.sha256(plain.encode()).hexdigest()
+
+
+def _legacy_scrypt_hash(plain: str) -> str:
+    """Replicate the pre-#1414 ``security.auth.hash_api_key`` output exactly."""
+    return hashlib.scrypt(
+        plain.encode(),
+        salt=SECRET_KEY.encode(),
+        n=16384,
+        r=8,
+        p=1,
+        dklen=32,
+    ).hex()
+
+
+# ===========================================================================
+# security.auth.verify_api_key — async DB-aware verifier (#1428 main flow)
+# ===========================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSecurityAuthLegacyRehash:
+    """End-to-end behaviour of the rehash-on-next-use flow."""
+
+    async def test_legacy_sha256_key_verifies_and_upgrades_to_bcrypt(self):
+        """A pre-#1414 SHA-256 hash matches, gets rehashed, and persists."""
+        plain = "mpk_legacy-sha256-key-payload"
+        record = SimpleNamespace(
+            key_hash=_legacy_sha256_hash(plain),
+            user_id="user-sha",
+        )
+        user = SimpleNamespace(id="user-sha")
+        db = _FakeAsyncSession([record], [user])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user
+        # The row was rehashed and committed exactly once.
+        assert db.commit_calls == 1
+        assert db.rollback_calls == 0
+        # New hash is bcrypt and verifies against the original plaintext.
+        assert record.key_hash.startswith(BCRYPT_HASH_PREFIXES)
+        assert bcrypt.checkpw(plain.encode("utf-8"), record.key_hash.encode("utf-8"))
+
+    async def test_legacy_scrypt_key_verifies_and_upgrades_to_bcrypt(self):
+        """A pre-#1414 scrypt hash matches, gets rehashed, and persists."""
+        plain = "mpk_legacy-scrypt-key-payload"
+        record = SimpleNamespace(
+            key_hash=_legacy_scrypt_hash(plain),
+            user_id="user-scrypt",
+        )
+        user = SimpleNamespace(id="user-scrypt")
+        db = _FakeAsyncSession([record], [user])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user
+        assert db.commit_calls == 1
+        assert db.rollback_calls == 0
+        assert record.key_hash.startswith(BCRYPT_HASH_PREFIXES)
+        assert bcrypt.checkpw(plain.encode("utf-8"), record.key_hash.encode("utf-8"))
+
+    async def test_bcrypt_key_passes_through_unchanged(self):
+        """Bcrypt-format hashes hit the fast-path: no commit, no rollback."""
+        plain = "mpk_modern-bcrypt-key-payload"
+        original_hash = hash_api_key(plain)
+        record = SimpleNamespace(key_hash=original_hash, user_id="user-bcrypt")
+        user = SimpleNamespace(id="user-bcrypt")
+        db = _FakeAsyncSession([record], [user])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user
+        # Byte-identical to pre-#1428 behaviour: no DB writes whatsoever.
+        assert db.commit_calls == 0
+        assert db.rollback_calls == 0
+        # Stored hash is untouched (still the exact original bcrypt string).
+        assert record.key_hash == original_hash
+
+    async def test_wrong_key_against_legacy_hash_returns_false_no_upgrade(self):
+        """A mismatched key against a legacy-format row must NOT trigger a write."""
+        legitimate = "mpk_legitimate-legacy-key"
+        attacker = "mpk_attacker-guessed-this"
+        record = SimpleNamespace(
+            key_hash=_legacy_sha256_hash(legitimate),
+            user_id="user-legit",
+        )
+        db = _FakeAsyncSession([record], [])
+
+        result = await verify_api_key(db, attacker)
+
+        assert result is None
+        # No rehash, no rollback — just a candidate fetch.
+        assert db.commit_calls == 0
+        assert db.rollback_calls == 0
+        assert db.execute_calls == 1
+        # Stored hash is unchanged (still the legacy SHA-256 hex string).
+        assert record.key_hash == _legacy_sha256_hash(legitimate)
+
+    async def test_wrong_key_against_legacy_scrypt_no_upgrade(self):
+        """Same as above but against a scrypt-format row."""
+        legitimate = "mpk_legitimate-scrypt-key"
+        attacker = "mpk_attacker-guessed-this2"
+        record = SimpleNamespace(
+            key_hash=_legacy_scrypt_hash(legitimate),
+            user_id="user-legit",
+        )
+        db = _FakeAsyncSession([record], [])
+
+        result = await verify_api_key(db, attacker)
+
+        assert result is None
+        assert db.commit_calls == 0
+        assert record.key_hash == _legacy_scrypt_hash(legitimate)
+
+    async def test_rehashed_key_verifies_on_next_call(self):
+        """After a successful rehash, the same key authenticates via the bcrypt fast-path."""
+        plain = "mpk_two-call-upgrade-flow"
+        record = SimpleNamespace(
+            key_hash=_legacy_sha256_hash(plain),
+            user_id="user-twice",
+        )
+        user = SimpleNamespace(id="user-twice")
+        db = _FakeAsyncSession([record], [user])
+
+        # First call: legacy match → rehash + commit.
+        first = await verify_api_key(db, plain)
+        assert first is user
+        assert db.commit_calls == 1
+        rehashed = record.key_hash
+        assert rehashed.startswith(BCRYPT_HASH_PREFIXES)
+
+        # Second call: stored hash is now bcrypt → fast-path, no extra commit.
+        second = await verify_api_key(db, plain)
+        assert second is user
+        assert db.commit_calls == 1, "second call must NOT trigger another rehash"
+        assert record.key_hash == rehashed, "stored hash must not change on bcrypt fast-path"
+
+    async def test_legacy_match_succeeds_even_if_persist_fails(self):
+        """If db.commit() raises, auth still succeeds and the session is rolled back.
+
+        Rationale: a transient DB hiccup must not lock a previously-valid
+        legacy key out. The next call simply retries the rehash.
+        """
+        plain = "mpk_legacy-but-broken-db"
+        record = SimpleNamespace(
+            key_hash=_legacy_sha256_hash(plain),
+            user_id="user-broken",
+        )
+        user = SimpleNamespace(id="user-broken")
+        db = _FakeAsyncSession([record], [user])
+        db.commit_should_raise = RuntimeError("simulated commit failure")
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user
+        assert db.commit_calls == 1
+        assert db.rollback_calls == 1
+
+    async def test_legacy_rehash_emits_log_and_metric(self, caplog):
+        """Successful rehash logs ``legacy_api_key_rehashed`` and increments the counter."""
+        from services.metrics import legacy_api_key_rehashed_total
+
+        plain = "mpk_metric-and-log-check"
+        record = SimpleNamespace(
+            key_hash=_legacy_sha256_hash(plain),
+            user_id="user-metric",
+        )
+        user = SimpleNamespace(id="user-metric")
+        db = _FakeAsyncSession([record], [user])
+
+        before = legacy_api_key_rehashed_total.labels(old_format="sha256")._value.get()
+
+        with caplog.at_level(logging.INFO, logger="security.auth"):
+            await verify_api_key(db, plain)
+
+        after = legacy_api_key_rehashed_total.labels(old_format="sha256")._value.get()
+        assert after - before == 1
+
+        log_msgs = [r.getMessage() for r in caplog.records]
+        assert "legacy_api_key_rehashed" in log_msgs
+
+    async def test_unknown_format_candidate_is_skipped(self):
+        """A candidate with garbage in key_hash must not raise and must not match."""
+        plain = "mpk_real-key-after-garbage-row"
+        garbage = SimpleNamespace(key_hash="this-is-definitely-not-a-hash", user_id="garbage")
+        good = SimpleNamespace(key_hash=hash_api_key(plain), user_id="user-good")
+        user = SimpleNamespace(id="user-good")
+        db = _FakeAsyncSession([garbage, good], [user])
+
+        result = await verify_api_key(db, plain)
+
+        assert result is user
+        # The garbage row must not have been "rehashed" — its key_hash is
+        # untouched and no commit fired on its behalf.
+        assert garbage.key_hash == "this-is-definitely-not-a-hash"
+        assert db.commit_calls == 0
+
+
+# ===========================================================================
+# core.auth — pure verification primitive (no DB)
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestCoreAuthLegacyRehash:
+    """``AuthManager.verify_api_key_with_rehash`` returns a (matched, new_hash) tuple."""
+
+    def test_bcrypt_match_returns_no_new_hash(self):
+        manager = AuthManager()
+        plain = "mpk_modern-bcrypt-key"
+        stored = manager.hash_api_key(plain)
+
+        matched, new_hash = manager.verify_api_key_with_rehash(plain, stored)
+
+        assert matched is True
+        assert new_hash is None
+
+    def test_bcrypt_mismatch_returns_false_and_no_new_hash(self):
+        manager = AuthManager()
+        plain = "mpk_modern-bcrypt-key"
+        stored = manager.hash_api_key(plain)
+
+        matched, new_hash = manager.verify_api_key_with_rehash("mpk_wrong-key", stored)
+
+        assert matched is False
+        assert new_hash is None
+
+    def test_legacy_sha256_match_returns_bcrypt_new_hash(self):
+        manager = AuthManager()
+        plain = "mpk_legacy-sha256-payload"
+        stored = _legacy_sha256_hash(plain)
+
+        matched, new_hash = manager.verify_api_key_with_rehash(plain, stored)
+
+        assert matched is True
+        assert new_hash is not None
+        assert new_hash.startswith(BCRYPT_HASH_PREFIXES)
+        assert bcrypt.checkpw(plain.encode("utf-8"), new_hash.encode("utf-8"))
+
+    def test_legacy_scrypt_match_returns_bcrypt_new_hash(self):
+        manager = AuthManager()
+        plain = "mpk_legacy-scrypt-payload"
+        stored = _legacy_scrypt_hash(plain)
+
+        matched, new_hash = manager.verify_api_key_with_rehash(plain, stored)
+
+        assert matched is True
+        assert new_hash is not None
+        assert new_hash.startswith(BCRYPT_HASH_PREFIXES)
+        assert bcrypt.checkpw(plain.encode("utf-8"), new_hash.encode("utf-8"))
+
+    def test_legacy_mismatch_returns_no_new_hash(self):
+        manager = AuthManager()
+        legitimate = "mpk_legitimate-key"
+        attacker = "mpk_guess-attempt"
+        stored = _legacy_sha256_hash(legitimate)
+
+        matched, new_hash = manager.verify_api_key_with_rehash(attacker, stored)
+
+        assert matched is False
+        assert new_hash is None
+
+    def test_garbage_stored_hash_returns_false_no_raise(self):
+        manager = AuthManager()
+        for garbage in ("", "not-a-hash", "x" * 64, "$2b$broken"):
+            matched, new_hash = manager.verify_api_key_with_rehash("mpk_anything", garbage)
+            assert matched is False
+            assert new_hash is None
+
+    def test_none_inputs_return_false_no_raise(self):
+        manager = AuthManager()
+        assert manager.verify_api_key_with_rehash(None, "x") == (False, None)
+        assert manager.verify_api_key_with_rehash("x", None) == (False, None)
+        assert manager.verify_api_key_with_rehash(None, None) == (False, None)
+
+    def test_module_level_alias_works(self):
+        """The module-level ``verify_api_key_with_rehash`` proxies to ``default_auth``."""
+        plain = "mpk_alias-check-payload"
+        stored = _legacy_sha256_hash(plain)
+        matched, new_hash = verify_api_key_with_rehash(plain, stored)
+        assert matched is True
+        assert new_hash is not None
+        assert bcrypt.checkpw(plain.encode("utf-8"), new_hash.encode("utf-8"))
+
+    def test_needs_rehash_flags_legacy_only(self):
+        plain = "mpk_needs-rehash-test"
+        modern = AuthManager().hash_api_key(plain)
+        sha256 = _legacy_sha256_hash(plain)
+        scrypt = _legacy_scrypt_hash(plain)
+
+        assert needs_rehash(modern) is False
+        assert needs_rehash(sha256) is True
+        assert needs_rehash(scrypt) is True
+        # Garbage / non-string inputs are also flagged for replacement.
+        assert needs_rehash("garbage") is True
+        assert needs_rehash(None) is True
+
+
+# ===========================================================================
+# Backwards-compat: the existing bcrypt-only primitive must not change.
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestBcryptPathByteIdentical:
+    """``AuthManager.verify_api_key`` must remain bcrypt-only post-#1428."""
+
+    def test_bcrypt_correct_key_still_true(self):
+        manager = AuthManager()
+        plain = "mpk_bcrypt-truth-table"
+        assert manager.verify_api_key(plain, manager.hash_api_key(plain)) is True
+
+    def test_bcrypt_wrong_key_still_false(self):
+        manager = AuthManager()
+        plain = "mpk_bcrypt-truth-table"
+        assert manager.verify_api_key("mpk_wrong", manager.hash_api_key(plain)) is False
+
+    def test_legacy_sha256_against_old_primitive_still_false(self):
+        """Pre-#1428 callers of ``verify_api_key`` see legacy hashes as failures.
+
+        This is intentional: the rehash-aware flow lives in
+        ``verify_api_key_with_rehash`` so existing callers' contract is
+        unchanged. Any caller that wants legacy support must opt in.
+        """
+        manager = AuthManager()
+        plain = "mpk_was-legacy-payload"
+        stored = _legacy_sha256_hash(plain)
+        assert manager.verify_api_key(plain, stored) is False
+
+    def test_legacy_scrypt_against_old_primitive_still_false(self):
+        manager = AuthManager()
+        plain = "mpk_was-legacy-payload"
+        stored = _legacy_scrypt_hash(plain)
+        assert manager.verify_api_key(plain, stored) is False
+
+    def test_malformed_hash_against_old_primitive_still_false(self):
+        manager = AuthManager()
+        for garbage in ("", "x" * 64, "not-a-hash"):
+            assert manager.verify_api_key("mpk_anything", garbage) is False
+
+
+# ===========================================================================
+# Constant-time legacy helpers — direct unit tests
+# ===========================================================================
+
+
+@pytest.mark.unit
+class TestLegacyHelperPrimitives:
+    """Both modules expose helpers; verify behaviour and constant-time guards."""
+
+    def test_is_bcrypt_hash_recognises_known_prefixes(self):
+        for prefix in BCRYPT_HASH_PREFIXES:
+            assert _is_bcrypt_hash(prefix + "12$" + "a" * 53) is True
+        # Negative cases.
+        assert _is_bcrypt_hash("a" * 64) is False
+        assert _is_bcrypt_hash("") is False
+        assert _is_bcrypt_hash(None) is False
+        assert _is_bcrypt_hash(b"$2b$12$abc") is False  # bytes, not str
+
+    def test_matches_legacy_sha256_correctness(self):
+        plain = "mpk_helper-sha-test"
+        stored = _legacy_sha256_hash(plain)
+        assert _matches_legacy_sha256(plain, stored) is True
+        assert sec_matches_legacy_sha256(plain, stored) is True
+
+        # Wrong key.
+        assert _matches_legacy_sha256("mpk_other", stored) is False
+        # Wrong stored.
+        assert _matches_legacy_sha256(plain, "0" * 64) is False
+
+    def test_matches_legacy_sha256_constant_time_on_garbage(self):
+        """Malformed stored hash must not raise — just return False."""
+        plain = "mpk_helper-sha-garbage"
+        for stored in (None, "", "short", "x" * 13, 12345, b"bytes"):
+            assert _matches_legacy_sha256(plain, stored) is False
+            assert sec_matches_legacy_sha256(plain, stored) is False
+
+    def test_matches_legacy_scrypt_correctness(self):
+        plain = "mpk_helper-scrypt-test"
+        stored = _legacy_scrypt_hash(plain)
+        assert _matches_legacy_scrypt(plain, stored) is True
+        assert sec_matches_legacy_scrypt(plain, stored) is True
+
+        assert _matches_legacy_scrypt("mpk_other", stored) is False
+        assert _matches_legacy_scrypt(plain, "0" * 64) is False
+
+    def test_matches_legacy_scrypt_constant_time_on_garbage(self):
+        plain = "mpk_helper-scrypt-garbage"
+        for stored in (None, "", "short", 12345, b"bytes"):
+            assert _matches_legacy_scrypt(plain, stored) is False
+            assert sec_matches_legacy_scrypt(plain, stored) is False


### PR DESCRIPTION
## Summary

PR #1425 switched `hash_api_key` to bcrypt with an **invalidate-and-reissue** migration: any pre-#1414 SHA-256 (`core.auth`) or scrypt (`security.auth`) hash now fails verification and forces the user to rotate. This PR adds a friendlier **rehash-on-next-use** path so existing keys keep working through a short drain window, then we drop the legacy fallback.

Closes #1428

## Design

### `security.auth.verify_api_key(db, api_key)` — async, DB-aware

For each candidate row matched by `prefix`:

1. **Bcrypt-format hash** (`$2a$` / `$2b$` / `$2y$`) → existing `bcrypt.checkpw` fast-path. **No DB write, no metric, no log line.** This branch is byte-identical to the post-#1425 behaviour.
2. **Otherwise** → try `_matches_legacy_sha256`, then `_matches_legacy_scrypt`. Both helpers always compute the digest and always invoke `hmac.compare_digest`, so they are constant-time even when the stored hash is malformed.
3. **Legacy match** → rehash with `bcrypt.hashpw(plain.encode(), bcrypt.gensalt(rounds=BCRYPT_COST))`, persist via `db.commit()`, log `legacy_api_key_rehashed`, increment the Prometheus counter, and return the user.
4. **Mismatch** → no DB write, no metric, no log; continue to next candidate.
5. **Persist failure** → rollback and log `legacy_api_key_rehash_persist_failed`. Auth still succeeds so a transient DB hiccup does not lock out a previously-valid key; the next call simply retries the upgrade.

### `core.auth.AuthManager` — pure verification primitive (no DB)

- `verify_api_key(plain, hashed)` — **unchanged**, bcrypt-only, byte-identical to the post-#1425 behaviour for every existing caller.
- `verify_api_key_with_rehash(plain, hashed) -> tuple[bool, Optional[str]]` — new, legacy-tolerant. Returns:
  - `(True, None)` for a bcrypt match
  - `(True, "<bcrypt hash>")` for a legacy match — caller MUST persist `new_hash` and SHOULD emit telemetry
  - `(False, None)` for a mismatch
- `needs_rehash(stored_hash) -> bool` — new, cheap pre-check.

### Constants

```python
BCRYPT_HASH_PREFIXES = ("$2a$", "$2b$", "$2y$")
# pre-#1414 scrypt parameters (security.auth):
# n=16384, r=8, p=1, dklen=32, salt=SECRET_KEY.encode()
# pre-#1414 sha256 parameters (core.auth):
# hashlib.sha256(api_key.encode()).hexdigest()
```

The static-`SECRET_KEY` salt was one of the reasons we migrated away from scrypt — replicated here only to drain remaining keys.

## Sunset plan

```python
# TODO(security): remove legacy SHA-256/scrypt fallback after 2026-08-13
# (90 days post-deploy of #1428). Tracked in #1428 follow-up. After removal,
# any remaining legacy keys force re-issue (the original PR #1425 behaviour).
```

The `portkit_legacy_api_key_rehashed_total{old_format}` counter is the signal: when it flatlines for several weeks the fallback can be deleted with a one-liner revert.

## Telemetry emitted on rehash

**Log line** (logger `security.auth`, level `INFO`):

```
legacy_api_key_rehashed
extra: {"user_id": "<uuid>", "old_format": "sha256" | "scrypt"}
```

**Prometheus counter** (in `services.metrics`):

```
portkit_legacy_api_key_rehashed_total{old_format="sha256"|"scrypt"}
```

On commit failure, an additional `legacy_api_key_rehash_persist_failed` exception log is emitted with the same fields.

## Test matrix (28 new tests, all green)

`security.auth.verify_api_key` (DB-aware):

| Scenario | Outcome | Asserts |
| --- | --- | --- |
| Legacy SHA-256 hash + correct key | rehashed → bcrypt + commit | `commit_calls == 1`, `record.key_hash` is bcrypt, verifies against plaintext |
| Legacy scrypt hash + correct key | rehashed → bcrypt + commit | same |
| Bcrypt hash + correct key | passes through unchanged | `commit_calls == 0`, `record.key_hash` byte-identical |
| Legacy SHA-256 hash + wrong key | returns None, no upgrade | `commit_calls == 0`, hash unchanged |
| Legacy scrypt hash + wrong key | returns None, no upgrade | `commit_calls == 0`, hash unchanged |
| Two-call upgrade flow | call 1 rehashes, call 2 fast-paths | `commit_calls == 1` after both calls |
| Legacy match with `commit()` raising | auth still succeeds, session rolled back | `commit_calls == 1`, `rollback_calls == 1` |
| Legacy rehash | log + Prometheus counter incremented | counter delta == 1, log present in `caplog` |
| Garbage hash candidate skipped | falls through to next candidate | garbage row untouched |

`core.auth.AuthManager` (pure primitive):

| Test | Asserts |
| --- | --- |
| `test_bcrypt_match_returns_no_new_hash` | `(True, None)` |
| `test_bcrypt_mismatch_returns_false_and_no_new_hash` | `(False, None)` |
| `test_legacy_sha256_match_returns_bcrypt_new_hash` | `(True, bcrypt_hash)`, verifies plaintext |
| `test_legacy_scrypt_match_returns_bcrypt_new_hash` | same |
| `test_legacy_mismatch_returns_no_new_hash` | `(False, None)` |
| `test_garbage_stored_hash_returns_false_no_raise` | covers `""`, `"not-a-hash"`, `"x"*64`, `"$2b$broken"` |
| `test_none_inputs_return_false_no_raise` | covers all None permutations |
| `test_module_level_alias_works` | `verify_api_key_with_rehash` proxy works end-to-end |
| `test_needs_rehash_flags_legacy_only` | bcrypt → False; sha256/scrypt/garbage/None → True |

Backwards-compat (`verify_api_key` contract unchanged):

- `test_bcrypt_correct_key_still_true`
- `test_bcrypt_wrong_key_still_false`
- `test_legacy_sha256_against_old_primitive_still_false`
- `test_legacy_scrypt_against_old_primitive_still_false`
- `test_malformed_hash_against_old_primitive_still_false`

Constant-time legacy helpers (direct):

- `test_is_bcrypt_hash_recognises_known_prefixes` (covers `$2a$`, `$2b$`, `$2y$`, plus `bytes`/`None`/`""`/`"a"*64` negatives)
- `test_matches_legacy_sha256_correctness`
- `test_matches_legacy_sha256_constant_time_on_garbage` (covers `None`/`""`/`"short"`/`int`/`bytes` — must not raise)
- `test_matches_legacy_scrypt_correctness`
- `test_matches_legacy_scrypt_constant_time_on_garbage`

**Full unit suite:** 3326 passed, 85 skipped, 0 failures.

## Files changed

- `backend/src/security/auth.py` — adds `_is_bcrypt_hash`, `_matches_legacy_sha256`, `_matches_legacy_scrypt`, `_rehash_legacy_key`; rewires `verify_api_key` to attempt legacy fallback + upgrade
- `backend/src/core/auth.py` — adds module-level legacy helpers, plus `AuthManager.verify_api_key_with_rehash` and `AuthManager.needs_rehash` (with module-level aliases)
- `backend/src/services/metrics.py` — adds `legacy_api_key_rehashed_total` Counter and `record_legacy_api_key_rehashed(old_format)` recorder, following the existing `record_*` pattern
- `backend/src/tests/unit/test_auth_legacy_rehash.py` — new test module, 28 cases

## Security notes

- Constant-time comparison via `hmac.compare_digest` for both legacy paths, never `==`.
- Legacy helpers wrap the digest computation in `try/except` and always perform a same-length comparison even on malformed input, so a timing attacker cannot distinguish "malformed stored hash" from "well-formed but mismatched".
- The bcrypt fast-path is dominant in cost (~250 ms at cost factor 12) so legacy-vs-modern branching is observable from the public prefix anyway — the constant-time guards exist to defend the wrong-key vs malformed-hash distinction within the legacy branch.
- `core.auth.AuthManager.verify_api_key` is intentionally **not** broadened to accept legacy hashes — that would let any caller that is not aware of the rehash contract leave a row in legacy storage indefinitely. Callers must opt in via `verify_api_key_with_rehash`.

Closes #1428
