### PR TITLE
fix(security): clear 24 CodeQL path/log-injection alerts (#1429)

### DIFF
--- a/backend/src/api/behavioral_testing.py
+++ b/backend/src/api/behavioral_testing.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 
 from db.models import User
 from api._authz import get_current_user  # issue #1417
+from security.path_sanitization import sanitize_for_log  # issue #1429
 
 # Import behavioral testing framework components
 try:
@@ -134,8 +135,11 @@ async def create_behavioral_test(
             test_request.test_config,
         )
 
+        # Issue #1429: sanitize identifiers before logging.
         logger.info(
-            f"Created behavioral test {test_id} for conversion {test_request.conversion_id}"
+            "Created behavioral test %s for conversion %s",
+            sanitize_for_log(test_id),
+            sanitize_for_log(test_request.conversion_id),
         )
 
         return BehavioralTestResponse(
@@ -150,8 +154,9 @@ async def create_behavioral_test(
         )
 
     except Exception as e:
-        logger.error(f"Error creating behavioral test: {e}")
-        logger.error(f"Failed to create test: {str(e)}", exc_info=True)
+        # Issue #1429: exception messages can contain user input; sanitize.
+        logger.error("Error creating behavioral test: %s", sanitize_for_log(e))
+        logger.error("Failed to create test: %s", sanitize_for_log(e), exc_info=True)
 
         raise HTTPException(status_code=500, detail="Failed to create test: Please try again.")
 
@@ -186,7 +191,11 @@ async def get_behavioral_test(
         )
 
     except Exception as e:
-        logger.error(f"Error retrieving test {test_id}: {e}")
+        logger.error(
+            "Error retrieving test %s: %s",
+            sanitize_for_log(test_id),
+            sanitize_for_log(e),
+        )
         raise HTTPException(status_code=404, detail=f"Test {test_id} not found")
 
 
@@ -228,8 +237,12 @@ async def get_test_scenarios(
         ]
 
     except Exception as e:
-        logger.error(f"Error retrieving scenarios for test {test_id}: {e}")
-        logger.error(f"Failed to retrieve scenarios: {str(e)}", exc_info=True)
+        logger.error(
+            "Error retrieving scenarios for test %s: %s",
+            sanitize_for_log(test_id),
+            sanitize_for_log(e),
+        )
+        logger.error("Failed to retrieve scenarios: %s", sanitize_for_log(e), exc_info=True)
 
         raise HTTPException(
             status_code=500, detail="Failed to retrieve scenarios: Please try again."
@@ -272,8 +285,12 @@ async def get_test_report(
         return mock_report
 
     except Exception as e:
-        logger.error(f"Error generating report for test {test_id}: {e}")
-        logger.error(f"Failed to generate report: {str(e)}", exc_info=True)
+        logger.error(
+            "Error generating report for test %s: %s",
+            sanitize_for_log(test_id),
+            sanitize_for_log(e),
+        )
+        logger.error("Failed to generate report: %s", sanitize_for_log(e), exc_info=True)
 
         raise HTTPException(status_code=500, detail="Failed to generate report: Please try again.")
 
@@ -295,12 +312,16 @@ async def delete_behavioral_test(
     """
     try:
         # In a real implementation, this would delete from database
-        logger.info(f"Deleted behavioral test {test_id}")
+        logger.info("Deleted behavioral test %s", sanitize_for_log(test_id))
         return {"message": f"Test {test_id} deleted successfully"}
 
     except Exception as e:
-        logger.error(f"Error deleting test {test_id}: {e}")
-        logger.error(f"Failed to delete test: {str(e)}", exc_info=True)
+        logger.error(
+            "Error deleting test %s: %s",
+            sanitize_for_log(test_id),
+            sanitize_for_log(e),
+        )
+        logger.error("Failed to delete test: %s", sanitize_for_log(e), exc_info=True)
 
         raise HTTPException(status_code=500, detail="Failed to delete test: Please try again.")
 
@@ -319,7 +340,7 @@ async def execute_behavioral_test_async(
     and stores results in the database.
     """
     try:
-        logger.info(f"Starting async execution of behavioral test {test_id}")
+        logger.info("Starting async execution of behavioral test %s", sanitize_for_log(test_id))
 
         # Initialize testing framework
         framework = BehavioralTestingFramework(test_config)
@@ -328,8 +349,17 @@ async def execute_behavioral_test_async(
         results = framework.run_behavioral_test(scenarios, expected_behaviors)
 
         # Store results in database (implementation needed)
-        logger.info(f"Behavioral test {test_id} completed with status: {results.get('status')}")
+        logger.info(
+            "Behavioral test %s completed with status: %s",
+            sanitize_for_log(test_id),
+            sanitize_for_log(results.get("status")),
+        )
 
     except Exception as e:
-        logger.error(f"Error in async behavioral test execution {test_id}: {e}", exc_info=True)
+        logger.error(
+            "Error in async behavioral test execution %s: %s",
+            sanitize_for_log(test_id),
+            sanitize_for_log(e),
+            exc_info=True,
+        )
         # Store error status in database (implementation needed)

--- a/backend/src/api/conversions.py
+++ b/backend/src/api/conversions.py
@@ -64,6 +64,11 @@ from security.file_security import (
     SecurityScanResult,
 )
 from security.auth import verify_token, verify_api_key
+from security.path_sanitization import (  # issue #1429
+    PathSanitizationError,
+    safe_join,
+    sanitize_for_log,
+)
 from api._authz import get_current_user, assert_owner  # issue #1417
 
 logger = logging.getLogger(__name__)
@@ -408,6 +413,32 @@ def validate_path_safe(path: str, base_dir: Path) -> bool:
         return False
 
 
+def _chunks_dir_for_upload(upload_id_str: str) -> Path:
+    """
+    Issue #1429: return ``<TEMP_UPLOADS_DIR>/chunks/<upload_id_str>`` after
+    routing the join through :func:`security.path_sanitization.safe_join`.
+
+    Centralises path construction for every chunked-upload endpoint so each
+    sink (``os.makedirs``, ``open``, ``shutil.rmtree``, ``os.listdir``, ...)
+    sees a path that has been allow-list validated and proven contained
+    in ``TEMP_UPLOADS_DIR``. Recognised by CodeQL as a sanitizer because
+    ``safe_join`` rejects any segment that does not match
+    ``[A-Za-z0-9._-]+`` and verifies containment via ``Path.resolve()``
+    + ``relative_to``.
+
+    Raises:
+        HTTPException(400): if ``upload_id_str`` is malformed.
+    """
+    try:
+        # Path is created on demand by callers that need it.
+        return safe_join(Path(TEMP_UPLOADS_DIR).resolve(), "chunks", upload_id_str)
+    except PathSanitizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid upload session",
+        ) from exc
+
+
 def validate_file_type(filename: str) -> tuple[bool, str]:
     """
     Validate file type is allowed.
@@ -586,13 +617,28 @@ async def websocket_conversion_progress(websocket: WebSocket, conversion_id: str
                         continue
                 except (json.JSONDecodeError, AttributeError):
                     pass
-                logger.debug(f"Received WebSocket message for {conversion_id}: {data}")
+                # Issue #1429: conversion_id (URL str) and data (WS frame)
+                # are both untrusted; sanitize before logging to prevent
+                # CWE-117 log forgery (CodeQL py/log-injection).
+                _safe_conv_id = sanitize_for_log(conversion_id)
+                logger.debug(
+                    "Received WebSocket message for %s: %s",
+                    _safe_conv_id,
+                    sanitize_for_log(data),
+                )
             except WebSocketDisconnect:
-                logger.info(f"WebSocket disconnected for conversion {conversion_id}")
+                logger.info(
+                    "WebSocket disconnected for conversion %s",
+                    sanitize_for_log(conversion_id),
+                )
                 break
 
     except Exception as e:
-        logger.error(f"WebSocket error for conversion {conversion_id}: {e}")
+        logger.error(
+            "WebSocket error for conversion %s: %s",
+            sanitize_for_log(conversion_id),
+            sanitize_for_log(e),
+        )
     finally:
         manager.disconnect(websocket, conversion_id)
 
@@ -803,35 +849,42 @@ async def create_conversion(
     file_id = str(uuid.uuid4())
     file_ext = os.path.splitext(safe_filename)[1]
     saved_filename = f"{file_id}{file_ext}"
-    file_path = os.path.join(TEMP_UPLOADS_DIR, saved_filename)
-
-    # Ensure upload directory exists
-    os.makedirs(TEMP_UPLOADS_DIR, exist_ok=True)
+    uploads_root = Path(TEMP_UPLOADS_DIR).resolve()
+    uploads_root.mkdir(parents=True, exist_ok=True)
+    try:
+        file_path = safe_join(uploads_root, saved_filename)
+    except PathSanitizationError as exc:  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid upload filename",
+        ) from exc
 
     # Save uploaded file
     try:
         with open(file_path, "wb") as buffer:
             for chunk in file.file:
                 buffer.write(chunk)
-        logger.info(f"File saved: {file_path}")
+        logger.info("File saved: %s", sanitize_for_log(file_path))
 
         # SECURITY: Scan the uploaded file for ZIP bombs, path traversal, etc.
         try:
-            security_result = await scan_uploaded_file(Path(file_path))
+            security_result = await scan_uploaded_file(file_path)
             logger.info(
-                f"Security scan completed for {file_path}: "
-                f"safe={security_result.is_safe}, threats={len(security_result.threats)}"
+                "Security scan completed for %s: safe=%s, threats=%d",
+                sanitize_for_log(file_path),
+                security_result.is_safe,
+                len(security_result.threats),
             )
         except HTTPException:
             # Re-raise HTTP exceptions from security scan (file rejected)
-            if os.path.exists(file_path):
-                os.remove(file_path)
+            if file_path.exists():
+                file_path.unlink()
             raise
         except Exception as e:
             # Log but don't fail on security scan errors
-            logger.error(f"Security scan error (continuing): {e}")
+            logger.error("Security scan error (continuing): %s", sanitize_for_log(e))
     except Exception as e:
-        logger.error(f"Failed to save file: {e}")
+        logger.error("Failed to save file: %s", sanitize_for_log(e))
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to save uploaded file",
@@ -1184,32 +1237,49 @@ async def download_conversion(
             detail=f"Conversion is not completed. Current status: {job.status}",
         )
 
-    # Determine file path
-    # Check for both .mcaddon and .zip extensions
-    base_path = os.path.join(CONVERSION_OUTPUTS_DIR, f"{conversion_id}_converted")
+    # Issue #1429: derive on-disk filenames from the *server-side*
+    # job.id (a uuid.UUID, not the raw URL string) and route every join
+    # through safe_join so the resolved path is provably contained in
+    # CONVERSION_OUTPUTS_DIR. Defends against path-injection
+    # (CWE-22/-23/-36/-73/-99).
+    job_uuid_str = str(job.id)
+    outputs_root = Path(CONVERSION_OUTPUTS_DIR).resolve()
+    outputs_root.mkdir(parents=True, exist_ok=True)
+    try:
+        mcaddon_path = safe_join(outputs_root, f"{job_uuid_str}_converted.mcaddon")
+        zip_path = safe_join(outputs_root, f"{job_uuid_str}_converted.zip")
+    except PathSanitizationError as exc:
+        logger.error(
+            "Refusing to serve conversion artifact for job %s: %s",
+            sanitize_for_log(job_uuid_str),
+            sanitize_for_log(exc),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Result file not found on server",
+        ) from exc
 
-    mcaddon_path = base_path + ".mcaddon"
-    zip_path = base_path + ".zip"
-
-    file_path = None
-    if os.path.exists(mcaddon_path):
+    file_path: Optional[Path] = None
+    if mcaddon_path.exists():
         file_path = mcaddon_path
-    elif os.path.exists(zip_path):
+    elif zip_path.exists():
         file_path = zip_path
 
-    if not file_path or not os.path.exists(file_path):
+    if file_path is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Result file not found on server",
         )
 
-    # Generate download filename
+    # Generate download filename - sanitize against path components from
+    # the user-supplied original_filename stored in input_data.
     original_filename = job.input_data.get("original_filename", "mod")
-    base_name = os.path.splitext(original_filename)[0]
+    base_name = os.path.splitext(os.path.basename(original_filename))[0]
+    base_name = sanitize_filename(base_name) or "mod"
     download_filename = f"{base_name}_converted.mcaddon"
 
     return FileResponse(
-        path=file_path,
+        path=str(file_path),  # safe: file_path is guaranteed inside outputs_root via safe_join
         media_type="application/zip",
         filename=download_filename,
     )
@@ -1430,9 +1500,11 @@ async def init_chunked_upload(
 
     await cache.set_job_status(f"upload:{upload_id}", upload_metadata)
 
-    # Create temporary directory for chunks
-    chunks_dir = os.path.join(TEMP_UPLOADS_DIR, "chunks", upload_id)
-    os.makedirs(chunks_dir, exist_ok=True)
+    # Create temporary directory for chunks. upload_id is a server-generated
+    # uuid4 string; routing through _chunks_dir_for_upload keeps every chunk
+    # path under TEMP_UPLOADS_DIR and silences CodeQL py/path-injection.
+    chunks_dir = _chunks_dir_for_upload(upload_id)
+    chunks_dir.mkdir(parents=True, exist_ok=True)
 
     return ChunkUploadInitResponse(
         upload_id=upload_id,
@@ -1502,22 +1574,23 @@ async def upload_chunk(
     if chunk_number < 1 or chunk_number > 10000:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid chunk number")
 
-    # Save chunk to disk - use safe path construction to prevent path traversal
-    chunks_dir = os.path.join(TEMP_UPLOADS_DIR, "chunks", upload_id_str)
-
-    # SECURITY: Validate the chunks_dir is within allowed directory
-    base_dir = Path(TEMP_UPLOADS_DIR).resolve()
-    if not validate_path_safe(os.path.join("chunks", upload_id_str), base_dir):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid upload session"
-        )
+    # Issue #1429: build chunks_dir + chunk_path via safe_join. The helper
+    # rejects any segment that isn't ``[A-Za-z0-9._-]+`` and verifies the
+    # final resolved path is contained in TEMP_UPLOADS_DIR, neutralising
+    # CWE-22/-23/-36/-73/-99 (CodeQL py/path-injection).
+    chunks_dir = _chunks_dir_for_upload(upload_id_str)
 
     # Ensure chunks directory exists
-    os.makedirs(chunks_dir, exist_ok=True)
+    chunks_dir.mkdir(parents=True, exist_ok=True)
 
     # SECURITY: Construct chunk filename safely - only allow numeric extension
     safe_chunk_name = f"chunk_{chunk_number:04d}"
-    chunk_path = os.path.join(chunks_dir, safe_chunk_name)
+    try:
+        chunk_path = safe_join(chunks_dir, safe_chunk_name)
+    except PathSanitizationError as exc:  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid chunk name"
+        ) from exc
 
     with open(chunk_path, "wb") as f:
         f.write(chunk_data)
@@ -1571,14 +1644,22 @@ async def get_upload_progress(
             status_code=status.HTTP_404_NOT_FOUND, detail="Upload session not found"
         )
 
-    chunks_dir = os.path.join(TEMP_UPLOADS_DIR, "chunks", upload_id_str)
+    # Issue #1429: chunks_dir is built via safe_join; chunk files were
+    # written by the server with names matching ``chunk_NNNN``, so each
+    # listdir result is allow-list re-validated to keep the sink inside
+    # CONVERSION_OUTPUTS_DIR.
+    chunks_dir = _chunks_dir_for_upload(upload_id_str)
     received_bytes = 0
 
-    if os.path.exists(chunks_dir):
+    if chunks_dir.exists():
         for chunk_file in os.listdir(chunks_dir):
-            chunk_path = os.path.join(chunks_dir, chunk_file)
-            if os.path.isfile(chunk_path):
-                received_bytes += os.path.getsize(chunk_path)
+            try:
+                chunk_path = safe_join(chunks_dir, chunk_file)
+            except PathSanitizationError:
+                # Skip stray/oddly-named files we did not create.
+                continue
+            if chunk_path.is_file():
+                received_bytes += chunk_path.stat().st_size
 
     total_bytes = upload_metadata.get("total_size", 0)
     progress = (received_bytes / total_bytes * 100) if total_bytes > 0 else 0
@@ -1624,30 +1705,50 @@ async def complete_chunked_upload(
             detail=f"Upload session is {upload_metadata.get('status')}",
         )
 
-    chunks_dir = os.path.join(TEMP_UPLOADS_DIR, "chunks", upload_id_str)
+    # Issue #1429: build chunks_dir + final file_path through safe_join.
+    chunks_dir = _chunks_dir_for_upload(upload_id_str)
     safe_filename = upload_metadata["filename"]
     total_size = upload_metadata["total_size"]
 
     # Combine chunks
     file_id = str(uuid.uuid4())
     file_ext = os.path.splitext(safe_filename)[1]
-    saved_filename = f"{file_id}{file_ext}"
-    file_path = os.path.join(TEMP_UPLOADS_DIR, saved_filename)
+    # Re-sanitize the extension defensively: ``filename`` originally came
+    # from the user and ``sanitize_filename`` was applied at init, but the
+    # extension is reconstructed here from cached metadata, so we strip
+    # anything other than safe characters.
+    file_ext_safe = "".join(c for c in file_ext if c.isalnum() or c == ".")
+    saved_filename = f"{file_id}{file_ext_safe}"
+    uploads_root = Path(TEMP_UPLOADS_DIR).resolve()
+    uploads_root.mkdir(parents=True, exist_ok=True)
+    try:
+        file_path = safe_join(uploads_root, saved_filename)
+    except PathSanitizationError as exc:  # pragma: no cover - defensive
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid upload filename",
+        ) from exc
 
     try:
         with open(file_path, "wb") as outfile:
             # Read chunks in order
             chunk_number = 1
             while True:
-                chunk_path = os.path.join(chunks_dir, f"chunk_{chunk_number:04d}")
-                if not os.path.exists(chunk_path):
+                # safe_join validates the chunk segment against the
+                # ``[A-Za-z0-9._-]+`` allow-list, so an attacker cannot
+                # influence this path even if they could mutate metadata.
+                try:
+                    chunk_path = safe_join(chunks_dir, f"chunk_{chunk_number:04d}")
+                except PathSanitizationError:  # pragma: no cover - defensive
+                    break
+                if not chunk_path.exists():
                     break
                 with open(chunk_path, "rb") as infile:
                     outfile.write(infile.read())
                 chunk_number += 1
 
         # Verify file size
-        actual_size = os.path.getsize(file_path)
+        actual_size = file_path.stat().st_size
         if actual_size != total_size:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1656,19 +1757,21 @@ async def complete_chunked_upload(
 
         # SECURITY: Scan the uploaded file for ZIP bombs, path traversal, etc.
         try:
-            security_result = await scan_uploaded_file(Path(file_path))
+            security_result = await scan_uploaded_file(file_path)
             logger.info(
-                f"Security scan completed for {file_path}: "
-                f"safe={security_result.is_safe}, threats={len(security_result.threats)}"
+                "Security scan completed for %s: safe=%s, threats=%d",
+                sanitize_for_log(file_path),
+                security_result.is_safe,
+                len(security_result.threats),
             )
         except HTTPException:
             # Re-raise HTTP exceptions from security scan (file rejected)
-            if os.path.exists(file_path):
-                os.remove(file_path)
+            if file_path.exists():
+                file_path.unlink()
             raise
         except Exception as e:
             # Log but don't fail on security scan errors
-            logger.error(f"Security scan error (continuing): {e}")
+            logger.error("Security scan error (continuing): %s", sanitize_for_log(e))
 
         # Update upload status
         upload_metadata["status"] = "completed"
@@ -1710,10 +1813,13 @@ async def complete_chunked_upload(
         )
 
     except Exception as e:
-        logger.error(f"Failed to complete chunked upload: {e}")
-        # Clean up on failure
-        if os.path.exists(file_path):
-            os.remove(file_path)
+        logger.error("Failed to complete chunked upload: %s", sanitize_for_log(e))
+        # Clean up on failure - file_path/chunks_dir are safe_join outputs
+        try:
+            if file_path.exists():
+                file_path.unlink()
+        except OSError:  # pragma: no cover - best-effort cleanup
+            pass
         shutil.rmtree(chunks_dir, ignore_errors=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -1748,8 +1854,9 @@ async def cancel_upload(
     upload_metadata["status"] = "cancelled"
     await cache.set_job_status(f"upload:{upload_id_str}", upload_metadata)
 
-    # Clean up chunks
-    chunks_dir = os.path.join(TEMP_UPLOADS_DIR, "chunks", upload_id_str)
+    # Issue #1429: chunks_dir resolved via safe_join → guaranteed inside
+    # TEMP_UPLOADS_DIR.
+    chunks_dir = _chunks_dir_for_upload(upload_id_str)
     shutil.rmtree(chunks_dir, ignore_errors=True)
 
     return None

--- a/backend/src/security/path_sanitization.py
+++ b/backend/src/security/path_sanitization.py
@@ -1,0 +1,199 @@
+"""
+Path and log sanitization helpers.
+
+Provides defense-in-depth against:
+- ``py/path-injection`` (CWE-22, CWE-23, CWE-36, CWE-73, CWE-99)
+- ``py/log-injection`` (CWE-117)
+
+These helpers use **allow-list** validation (regex-restricted character sets)
+so that downstream CodeQL flow analysis recognises them as effective
+sanitizers when called between a user-controlled source and a filesystem or
+logging sink.
+
+Issue #1429: triage CodeQL alerts in ``conversions.py`` and
+``behavioral_testing.py`` after the auth changes in PR #1426 added new
+taint sources.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Maximum length of a sanitised log value. Defends against log-flooding from
+#: oversized user inputs that pass other checks.
+MAX_LOG_VALUE_LEN = 256
+
+#: Marker appended when a log value is truncated.
+LOG_TRUNCATION_MARKER = "...[truncated]"
+
+# Allow-list for individual filesystem-path segments accepted by ``safe_join``.
+# Allows letters, digits, underscore, dot, hyphen. Forbids '/', '\\', ':',
+# whitespace and every control character. The standalone tokens '.' and '..'
+# are rejected separately by ``safe_path_segment``.
+_SAFE_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# Whitespace + control characters (0x00-0x1F, 0x7F) replaced inside log
+# values. ``\r`` and ``\n`` are escaped earlier so this regex never sees
+# them in the form that would create a forged log line.
+_LOG_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class PathSanitizationError(ValueError):
+    """Raised when input cannot be safely used as a filesystem path."""
+
+
+# ---------------------------------------------------------------------------
+# UUID validation
+# ---------------------------------------------------------------------------
+
+
+def validate_uuid(value: object) -> uuid.UUID:
+    """Validate that ``value`` is a UUID and return it as :class:`uuid.UUID`.
+
+    Accepts an existing :class:`uuid.UUID` or any string that
+    :class:`uuid.UUID` can parse (canonical, hex, urn, braced).
+
+    Raises:
+        PathSanitizationError: if ``value`` is None / empty / not a UUID.
+    """
+    if value is None:
+        raise PathSanitizationError("UUID value is required")
+    if isinstance(value, uuid.UUID):
+        return value
+    text = str(value).strip()
+    if not text:
+        raise PathSanitizationError("UUID value is required")
+    try:
+        return uuid.UUID(text)
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise PathSanitizationError("Value is not a valid UUID") from exc
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def safe_path_segment(segment: object) -> str:
+    r"""Return ``segment`` unchanged if it is a safe single path component.
+
+    A "safe segment" matches ``[A-Za-z0-9._-]+`` and is not the reserved
+    relative-traversal token ``.`` or ``..``. This excludes path separators
+    (``/`` and ``\\``), drive prefixes (``C:``), null bytes, newlines and
+    every other ASCII control character.
+
+    Raises:
+        PathSanitizationError: if ``segment`` is None / empty / not a string
+            / contains disallowed characters / is a reserved token.
+    """
+    if segment is None:
+        raise PathSanitizationError("Path segment is required")
+    if not isinstance(segment, str):
+        raise PathSanitizationError(f"Path segment must be a string, got {type(segment).__name__}")
+    if not segment:
+        raise PathSanitizationError("Path segment must be non-empty")
+    if segment in (".", ".."):
+        raise PathSanitizationError(f"Reserved path segment: {segment!r}")
+    if not _SAFE_PATH_SEGMENT_RE.match(segment):
+        raise PathSanitizationError(f"Path segment contains disallowed characters: {segment!r}")
+    return segment
+
+
+def safe_join(base: str | Path, *parts: str) -> Path:
+    """Securely join ``parts`` onto ``base`` and verify containment.
+
+    Each part must individually satisfy :func:`safe_path_segment`. The
+    final resolved path is then checked to be located inside the resolved
+    ``base`` directory; any escape (via symlink, ``..``, absolute prefix
+    or other trick) raises :class:`PathSanitizationError`.
+
+    The base directory is resolved with ``Path.resolve()`` (which follows
+    symlinks). The result is **not** required to exist on disk -- callers
+    typically write to or create the returned path -- so ``strict=False``
+    is used.
+
+    Args:
+        base: The allow-listed root directory. Must be an existing directory
+            for symlink resolution to be meaningful, but this is not
+            enforced here.
+        *parts: One or more path segments. Each is validated independently.
+
+    Returns:
+        The resolved :class:`pathlib.Path`, guaranteed to be inside ``base``.
+
+    Raises:
+        PathSanitizationError: if any part is unsafe or the resolved path
+            escapes ``base``.
+    """
+    if not parts:
+        raise PathSanitizationError("safe_join requires at least one path part")
+    base_path = Path(base).resolve()
+    cleaned = [safe_path_segment(part) for part in parts]
+    candidate = base_path.joinpath(*cleaned).resolve()
+    try:
+        candidate.relative_to(base_path)
+    except ValueError as exc:  # pragma: no cover - exercised by tests
+        raise PathSanitizationError(
+            f"Resolved path escapes base directory: {candidate!r} not under {base_path!r}"
+        ) from exc
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Log helpers
+# ---------------------------------------------------------------------------
+
+
+def sanitize_for_log(value: object, *, max_len: int = MAX_LOG_VALUE_LEN) -> str:
+    r"""Return a string representation of ``value`` safe to embed in a log line.
+
+    Specifically:
+
+    * ``None`` becomes the literal ``"<none>"``.
+    * Carriage return / newline are escaped as the two-char sequences
+      ``\\r`` / ``\\n`` so an attacker cannot forge new log lines.
+    * Other ASCII control characters (NUL, BEL, ESC, DEL, ...) are replaced
+      with ``?``.
+    * Values longer than ``max_len`` characters are truncated and marked
+      with :data:`LOG_TRUNCATION_MARKER`.
+
+    The output is always a ``str`` and never raises.
+
+    Args:
+        value: Any object; ``str(value)`` is used as the starting point.
+        max_len: Maximum length of the returned string (excluding marker).
+            Defaults to :data:`MAX_LOG_VALUE_LEN`.
+    """
+    if value is None:
+        return "<none>"
+    try:
+        text = str(value)
+    except Exception:  # noqa: BLE001 - defensive: never raise from logging
+        text = f"<unrepresentable {type(value).__name__}>"
+    text = text.replace("\r", "\\r").replace("\n", "\\n")
+    text = _LOG_CONTROL_CHARS_RE.sub("?", text)
+    if len(text) > max_len:
+        text = text[:max_len] + LOG_TRUNCATION_MARKER
+    return text
+
+
+__all__ = [
+    "LOG_TRUNCATION_MARKER",
+    "MAX_LOG_VALUE_LEN",
+    "PathSanitizationError",
+    "safe_join",
+    "safe_path_segment",
+    "sanitize_for_log",
+    "validate_uuid",
+]

--- a/backend/src/tests/unit/test_path_sanitization.py
+++ b/backend/src/tests/unit/test_path_sanitization.py
@@ -1,0 +1,346 @@
+"""Unit tests for ``security.path_sanitization``.
+
+Issue #1429.
+
+Coverage areas:
+
+- ``safe_path_segment``: traversal tokens, separators, control chars,
+  non-strings, empty/None inputs, accepted patterns.
+- ``safe_join``: containment guarantees, traversal attempts via ``..``,
+  absolute paths outside allow-list, symlink escape, empty parts.
+- ``validate_uuid``: valid UUID-strings, ``uuid.UUID`` instances, malformed
+  strings, ``None``, non-string objects.
+- ``sanitize_for_log``: CR/LF escaping, ASCII control chars, ``None``,
+  truncation of oversized values, idempotent behaviour for safe values.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+from security.path_sanitization import (
+    LOG_TRUNCATION_MARKER,
+    MAX_LOG_VALUE_LEN,
+    PathSanitizationError,
+    safe_join,
+    safe_path_segment,
+    sanitize_for_log,
+    validate_uuid,
+)
+
+
+# ---------------------------------------------------------------------------
+# safe_path_segment
+# ---------------------------------------------------------------------------
+
+
+class TestSafePathSegment:
+    """Allow-list validation for individual path segments."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "file.txt",
+            "abc-DEF_123",
+            "1234abcd-5678-90ef-1234-567890abcdef",
+            "chunk_0001",
+            "report.html",
+            "a",
+        ],
+    )
+    def test_accepts_safe_segments(self, value):
+        assert safe_path_segment(value) == value
+
+    @pytest.mark.parametrize("value", ["", None])
+    def test_rejects_empty_or_none(self, value):
+        with pytest.raises(PathSanitizationError):
+            safe_path_segment(value)
+
+    @pytest.mark.parametrize("value", [".", ".."])
+    def test_rejects_reserved_traversal_tokens(self, value):
+        with pytest.raises(PathSanitizationError, match="Reserved"):
+            safe_path_segment(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "../etc/passwd",
+            "..\\windows",
+            "..",
+            "foo/bar",
+            "foo\\bar",
+            "/abs/path",
+            "C:\\Users",
+            "with space",
+            "with\ttab",
+            "new\nline",
+            "carriage\rreturn",
+            "null\x00byte",
+            "esc\x1bseq",
+            "del\x7fchar",
+            "URL%2eencoded",
+            "smart‐dash",  # non-ASCII
+            "emoji😀",
+        ],
+    )
+    def test_rejects_unsafe_segments(self, value):
+        with pytest.raises(PathSanitizationError):
+            safe_path_segment(value)
+
+    def test_rejects_non_string_input(self):
+        with pytest.raises(PathSanitizationError, match="must be a string"):
+            safe_path_segment(123)
+        with pytest.raises(PathSanitizationError, match="must be a string"):
+            safe_path_segment(b"file.txt")
+        with pytest.raises(PathSanitizationError, match="must be a string"):
+            safe_path_segment(Path("file.txt"))
+
+
+# ---------------------------------------------------------------------------
+# safe_join
+# ---------------------------------------------------------------------------
+
+
+class TestSafeJoin:
+    """End-to-end containment tests for ``safe_join``."""
+
+    def test_joins_simple_segments(self, tmp_path):
+        result = safe_join(tmp_path, "chunks", "chunk_0001")
+        assert result == (tmp_path / "chunks" / "chunk_0001").resolve()
+        assert str(result).startswith(str(tmp_path.resolve()))
+
+    def test_returns_absolute_resolved_path(self, tmp_path):
+        result = safe_join(tmp_path, "a")
+        assert result.is_absolute()
+
+    def test_does_not_require_path_to_exist(self, tmp_path):
+        # Defines the canonical location for a future write; the file does
+        # not yet exist on disk.
+        result = safe_join(tmp_path, "future_file.zip")
+        assert not result.exists()
+        assert result.parent == tmp_path.resolve()
+
+    def test_rejects_traversal_segment(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, "..", "etc")
+
+    def test_rejects_dot_dot_in_segment(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, "..\\..\\etc\\passwd")
+
+    def test_rejects_absolute_path_in_segment(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, "/etc/passwd")
+
+    def test_rejects_path_separators_in_segment(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, "chunks/chunk_0001")
+
+    def test_rejects_empty_parts_list(self, tmp_path):
+        with pytest.raises(PathSanitizationError, match="at least one"):
+            safe_join(tmp_path)
+
+    def test_rejects_empty_segment(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, "")
+
+    def test_rejects_none_segment(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, None)
+
+    def test_rejects_control_char_segment(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, "chunk\x00.bin")
+
+    def test_rejects_symlink_escape(self, tmp_path):
+        # Create a legitimate base dir and a symlink that points outside it.
+        # safe_join should refuse to follow the symlink to escape the root.
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = base / "link"
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("Symlink creation not permitted on this platform")
+
+        with pytest.raises(PathSanitizationError):
+            # The segment "link" is allow-listed by name, but resolve()
+            # follows it, and the resulting absolute path is outside ``base``.
+            safe_join(base, "link", "secret")
+
+    def test_accepts_string_base(self, tmp_path):
+        result = safe_join(str(tmp_path), "ok")
+        assert result == (tmp_path / "ok").resolve()
+
+    def test_uuid_str_is_accepted_segment(self, tmp_path):
+        # The most common real-world usage: the UUID-string from a Pydantic
+        # ``UUID`` parameter.
+        upload_id = "1234abcd-5678-90ef-1234-567890abcdef"
+        result = safe_join(tmp_path, "chunks", upload_id)
+        assert result.parent.name == "chunks"
+
+
+# ---------------------------------------------------------------------------
+# validate_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUuid:
+    def test_accepts_canonical_uuid_string(self):
+        s = "12345678-1234-5678-1234-567812345678"
+        result = validate_uuid(s)
+        assert isinstance(result, uuid.UUID)
+        assert str(result) == s
+
+    def test_accepts_uuid_instance(self):
+        u = uuid.uuid4()
+        assert validate_uuid(u) is u
+
+    def test_accepts_hex_uuid(self):
+        # uuid.UUID accepts the 32-char hex form too.
+        assert isinstance(validate_uuid("12345678123456781234567812345678"), uuid.UUID)
+
+    def test_rejects_none(self):
+        with pytest.raises(PathSanitizationError, match="required"):
+            validate_uuid(None)
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(PathSanitizationError, match="required"):
+            validate_uuid("")
+        with pytest.raises(PathSanitizationError, match="required"):
+            validate_uuid("   ")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "not-a-uuid",
+            "12345678-1234-5678-1234",  # too short
+            "../../etc/passwd",
+            "abcdefgh-1234-5678-1234-567812345678",  # non-hex
+            123,
+            object(),
+        ],
+    )
+    def test_rejects_invalid_inputs(self, value):
+        with pytest.raises(PathSanitizationError):
+            validate_uuid(value)
+
+
+# ---------------------------------------------------------------------------
+# sanitize_for_log
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeForLog:
+    def test_simple_string_passes_through(self):
+        assert sanitize_for_log("hello") == "hello"
+
+    def test_uuid_passes_through(self):
+        u = uuid.uuid4()
+        assert sanitize_for_log(u) == str(u)
+
+    def test_none_becomes_marker(self):
+        assert sanitize_for_log(None) == "<none>"
+
+    def test_escapes_newline(self):
+        out = sanitize_for_log("line1\nline2")
+        assert "\n" not in out
+        assert "\\n" in out
+
+    def test_escapes_carriage_return(self):
+        out = sanitize_for_log("a\rb")
+        assert "\r" not in out
+        assert "\\r" in out
+
+    def test_log_forgery_attempt_is_neutralised(self):
+        # Classic CWE-117 payload: terminate the legitimate line and forge
+        # a new one with a fake "INFO" level.
+        attack = "Guest\r\nINFO: User name: Admin"
+        out = sanitize_for_log(attack)
+        assert "\r\n" not in out
+        assert "\\r\\n" in out
+
+    @pytest.mark.parametrize("ch", ["\x00", "\x07", "\x1b", "\x7f"])
+    def test_replaces_other_control_chars(self, ch):
+        out = sanitize_for_log(f"a{ch}b")
+        assert ch not in out
+        assert "?" in out
+
+    def test_truncates_oversize_values(self):
+        long = "x" * (MAX_LOG_VALUE_LEN + 50)
+        out = sanitize_for_log(long)
+        assert out.endswith(LOG_TRUNCATION_MARKER)
+        assert len(out) == MAX_LOG_VALUE_LEN + len(LOG_TRUNCATION_MARKER)
+
+    def test_respects_custom_max_len(self):
+        out = sanitize_for_log("0123456789", max_len=4)
+        assert out == "0123" + LOG_TRUNCATION_MARKER
+
+    def test_handles_non_string_value(self):
+        assert sanitize_for_log(42) == "42"
+        assert sanitize_for_log(3.14) == "3.14"
+
+    def test_handles_unrepresentable_object(self):
+        class Boom:
+            def __str__(self):
+                raise RuntimeError("nope")
+
+        out = sanitize_for_log(Boom())
+        assert "<unrepresentable" in out
+        assert "Boom" in out
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: realistic end-to-end usage matching the api/ call sites
+# ---------------------------------------------------------------------------
+
+
+class TestRealisticUsage:
+    """Smoke tests that mirror how ``conversions.py`` invokes the helpers."""
+
+    def test_upload_chunks_dir_pattern(self, tmp_path):
+        upload_id = uuid.uuid4()
+        chunks_dir = safe_join(tmp_path, "chunks", str(upload_id))
+        chunks_dir.mkdir(parents=True)
+        chunk_path = safe_join(chunks_dir, f"chunk_{1:04d}")
+        chunk_path.write_bytes(b"data")
+        assert chunk_path.exists()
+        assert chunk_path.parent == chunks_dir
+
+    def test_download_path_pattern(self, tmp_path):
+        # Caller already validated the conversion_id as UUID and confirmed
+        # ownership.
+        conv_id = "00000000-0000-4000-8000-000000000001"
+        validated = validate_uuid(conv_id)
+        artifact = safe_join(tmp_path, f"{validated}_converted.mcaddon")
+        artifact.write_bytes(b"x")
+        assert artifact.exists()
+
+    def test_download_rejects_path_separator_in_id(self, tmp_path):
+        with pytest.raises(PathSanitizationError):
+            safe_join(tmp_path, "../etc/passwd_converted.mcaddon")
+
+    def test_log_line_with_tainted_websocket_text(self):
+        attacker = "ping\r\nERROR: forged"
+        line = (
+            f"WS message for conv {sanitize_for_log('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')}: "
+            f"{sanitize_for_log(attacker)}"
+        )
+        assert "\n" not in line
+        assert "ERROR:" in line  # text retained, but on a single line
+        assert "\\r\\n" in line
+
+
+# Sanity check that the module path is importable with the project's
+# ``pythonpath = src`` pytest config (declared in backend/pytest.ini).
+def test_module_is_importable_via_src_layout():
+    import security.path_sanitization as mod
+
+    assert mod.__name__ == "security.path_sanitization"
+    assert os.path.isfile(mod.__file__)


### PR DESCRIPTION
## Summary

PR #1426 added `Depends(get_current_user)` to `conversions.py` and `behavioral_testing.py`, which expanded the taint-source surface CodeQL tracks. CodeQL then reported **24 open `py/path-injection` and `py/log-injection` alerts** across these two files (issue lists ~15; the actual count today is 24 after de-duping the `state=fixed` alert #91). Every alert was either:

- **Fixed** by routing the value through a recognised sanitiser (`safe_join` for paths, `sanitize_for_log` for log calls), **or**
- **Re-routed** so the user-controlled identifier no longer reaches the sink (e.g. paths in `download_conversion` are now derived from the server-side `job.id`, not the URL string).

No blanket file-level suppressions, no `# nosec`, no per-line CodeQL suppression comments were used. Every change is a real defence-in-depth improvement.

## Changes

| File | Purpose |
| --- | --- |
| `backend/src/security/path_sanitization.py` | **New** helper module: `safe_join`, `safe_path_segment`, `validate_uuid`, `sanitize_for_log`, `PathSanitizationError`. |
| `backend/src/tests/unit/test_path_sanitization.py` | **New** 72 unit tests covering traversal, absolute-path escape, symlink escape, control chars, empty/None, log forgery payloads, truncation. |
| `backend/src/api/conversions.py` | Routes every upload/download filesystem path through `safe_join` where touched: direct upload save path, chunked-upload paths via `_chunks_dir_for_upload()`, chunk-completion output path, and download artifact path from `str(job.id)` (server-side UUID) instead of the URL string. WebSocket logs sanitised. |
| `backend/src/api/behavioral_testing.py` | Every f-string log call rewritten to parametrised `logger.<lvl>(fmt, sanitize_for_log(value), ...)`. |

## Helper API at a glance

```python
from security.path_sanitization import (
    safe_join,            # base + parts → resolved Path inside base, or PathSanitizationError
    safe_path_segment,    # allow-list: [A-Za-z0-9._-]+, rejects '.', '..', '/', '\\', control chars
    validate_uuid,        # str/UUID → uuid.UUID, or PathSanitizationError
    sanitize_for_log,     # any → str with \r\n escaped, control chars stripped, len-capped
    PathSanitizationError,
)
```

`safe_join` is the primary path sink replacement: it (a) allow-list validates each segment with a restrictive regex, (b) resolves the result via `Path.resolve()`, then (c) verifies the resolved path is `relative_to(base)`. CodeQL recognises restrictive-regex validation as a sanitiser, so flagged sinks downstream of `safe_join` are cleared.

`sanitize_for_log` escapes `\r\n` to literal `\r` / `\n`, replaces other ASCII control chars with `?`, caps length at 256 chars, and never raises (handles `None`, unrepresentable objects). Use as `logger.info("event %s", sanitize_for_log(value))` — parametrised logging form, matching the project's parametrised-logger convention.

## Verdict table

| Alert # | Rule | File | Line (alert commit) | Verdict | Action |
| --- | --- | --- | --- | --- | --- |
| 87 | py/path-injection | `conversions.py` | 399 | fix (indirect) | `validate_path_safe`'s only user-controlled caller (`upload_chunk`) now uses `safe_join`; the helper is no longer reached by tainted data. |
| 88 | py/path-injection | `conversions.py` | 1175 (`os.path.exists(mcaddon_path)`) | **fix** | `download_conversion` now derives `mcaddon_path` from `safe_join(outputs_root, f"{str(job.id)}_converted.mcaddon")`. |
| 89 | py/path-injection | `conversions.py` | 1177 (`os.path.exists(zip_path)`) | **fix** | Same `safe_join` rewrite, `.zip` variant. |
| 90 | py/path-injection | `conversions.py` | 1180 (`os.path.exists(file_path)`) | **fix** | `file_path` is now `Optional[Path]` set to a `safe_join` result; uses `.exists()`. |
| 92 | py/path-injection | `conversions.py` | 1490 (`os.makedirs(chunks_dir)`) | **fix** | `chunks_dir = _chunks_dir_for_upload(upload_id_str)` → `chunks_dir.mkdir(...)`. |
| 93 | py/path-injection | `conversions.py` | 1496 (`open(chunk_path, "wb")`) | **fix** | `chunk_path = safe_join(chunks_dir, safe_chunk_name)`. |
| 94 | py/path-injection | `conversions.py` | 1547 (`os.path.exists(chunks_dir)`) | **fix** | `chunks_dir.exists()` on `safe_join` output. |
| 95 | py/path-injection | `conversions.py` | 1548 (`os.listdir(chunks_dir)`) | **fix** | `chunks_dir` is `safe_join` output; listdir results re-validated with `safe_join(chunks_dir, name)`. |
| 96 | py/path-injection | `conversions.py` | 1550 (`os.path.isfile(chunk_path)`) | **fix** | Replaced with `chunk_path.is_file()` after `safe_join`. |
| 97 | py/path-injection | `conversions.py` | 1551 (`os.path.getsize(chunk_path)`) | **fix** | Replaced with `chunk_path.stat().st_size`. |
| 98 | py/path-injection | `conversions.py` | 1611 (`os.path.exists(chunk_path)`) | **fix** | `chunk_path = safe_join(chunks_dir, f"chunk_{n:04d}")`; uses `.exists()`. |
| 99 | py/path-injection | `conversions.py` | 1613 (`open(chunk_path, "rb")`) | **fix** | Same. |
| 100 | py/path-injection | `conversions.py` | 1670 (`shutil.rmtree(chunks_dir)`) | **fix** | `chunks_dir` is `safe_join` output. |
| 101 | py/path-injection | `conversions.py` | 1684 (`shutil.rmtree(chunks_dir)`) | **fix** | Same. |
| 102 | py/path-injection | `conversions.py` | 1716 (`shutil.rmtree(chunks_dir)`) | **fix** | `cancel_upload` now uses `_chunks_dir_for_upload()`. |
| 295 | py/path-injection | `conversions.py` | 1192 (`FileResponse(path=file_path)`) | **fix** | `file_path` is now a `safe_join` Path under `CONVERSION_OUTPUTS_DIR`. |
| 128 | py/log-injection | `conversions.py` | 588 (`logger.debug(... data ...)`) | **fix** | `sanitize_for_log(conversion_id)` + `sanitize_for_log(data)`, parametrised log. |
| 129 | py/log-injection | `conversions.py` | 590 (`logger.info(... conversion_id ...)`) | **fix** | `sanitize_for_log(conversion_id)`. |
| 130 | py/log-injection | `conversions.py` | 594 (`logger.error(... e ...)`) | **fix** | `sanitize_for_log(conversion_id)` + `sanitize_for_log(e)`. |
| 122 | py/log-injection | `behavioral_testing.py` | 132 | **fix** | `sanitize_for_log(test_id)` + `sanitize_for_log(test_request.conversion_id)`. |
| 123 | py/log-injection | `behavioral_testing.py` | 179 | **fix** | `sanitize_for_log(test_id)` + `sanitize_for_log(e)`. |
| 124 | py/log-injection | `behavioral_testing.py` | 217 | **fix** | Same pattern. |
| 125 | py/log-injection | `behavioral_testing.py` | 256 | **fix** | Same pattern. |
| 126 | py/log-injection | `behavioral_testing.py` | 275 | **fix** | `sanitize_for_log(test_id)` in info log. |
| 127 | py/log-injection | `behavioral_testing.py` | 279 | **fix** | `sanitize_for_log(test_id)` + `sanitize_for_log(e)`. |

**Totals:** 24 alerts fixed, 0 suppressed.

(Alert #91 was already in `state=fixed` on `main` and is excluded.)

## Test results

- **New tests:** `backend/src/tests/unit/test_path_sanitization.py` — **72 passed** locally (`pytest -q`).
- **Regression check:** `pytest src/tests/unit/ -q --tb=no --no-cov` reports `114 failed, 2349 passed, 97 skipped, 131 errors` on this branch — **identical** to the baseline (`origin/fix/1417-endpoint-auth-audit`) before any change. No previously-passing test broke.
- **Lint:** `ruff check` clean on all four touched files.
- **Format:** `ruff format` applied; clean.

## Notes / assumptions

1. **`validate_path_safe` left in place.** It is the only existing helper that callers may import. After this PR, the only production caller (`upload_chunk`) routes through `safe_join` instead, but the function is still exported and exercised by `test_conversions_helpers.py`. Removing it is out-of-scope for this security PR.
2. **`file_path` type change in `create_conversion`, `complete_chunked_upload`, and `download_conversion`.** Previously `str` from `os.path.join`, now `Path` from `safe_join` wherever the patch calls Path methods. Touched call sites (`open()`, `scan_uploaded_file()`, `FileResponse(path=str(file_path))`, `.unlink()`, `.exists()`, `.stat()`) updated accordingly. No public API change — these are local variables.
3. **Chunked-upload `file_ext` defensively re-sanitised** (`complete_chunked_upload`) by stripping any chars other than alnum + `.`. The original extension came from a user-supplied filename and was cached in Redis between init and complete; treating it as still-tainted on read costs us nothing.
4. **Symlink escape attempts** are caught by `safe_join` because `Path.resolve()` follows symlinks before the `relative_to` containment check (covered by `TestSafeJoin::test_rejects_symlink_escape`).
5. The pre-existing in-isolation import errors in `test_conversions_helpers.py`, `test_conversions_authorization.py`, `test_api_conversions_targeted.py` (`ModuleNotFoundError: No module named 'db.base'`) reproduce identically on the base branch and are unrelated to this PR.

Closes #1429
Unblocks #1417 (PR #1426 CodeQL gate)

