### PR TITLE
test(integration): repair 5 mock shapes for ConversionJob/ConversionFeedback (#1431)

### DIFF
--- a/backend/src/tests/integration/test_validation_api_integration.py
+++ b/backend/src/tests/integration/test_validation_api_integration.py
@@ -22,9 +22,34 @@ from api.validation_constants import ValidationJobStatus, ValidationMessages
 
 @pytest.fixture
 def client():
-    """Test client fixture (issue #1417: bypass new auth + ownership requirements)."""
+    """Test client fixture (issue #1417: bypass new auth + ownership requirements).
+
+    Issue #1431: previously this fixture replaced ``_val_mod.crud.get_job``
+    with an ``AsyncMock`` and never restored the original. Because
+    ``_val_mod.crud`` *is* the ``db.crud`` module object, the rebinding
+    leaked across the rest of the integration suite — every later test that
+    hit a code path calling ``crud.get_job`` (e.g.
+    ``GET /api/v1/convert/<id>/status`` or
+    ``POST /api/v1/feedback``) received a bare ``MagicMock`` instead of
+    ``None`` for unknown job ids, then exploded while building the
+    ``ConversionJob`` / ``FeedbackResponse`` Pydantic response models
+    (``4 validation errors for ConversionJob``,
+    ``AttributeError: 'ConversionFeedback' object has no attribute
+    'quality_rating'``).
+
+    The fix has two parts:
+
+    1.  Snapshot the original ``crud.get_job`` and restore it on teardown
+        so the patch is fully scoped to the validation tests.
+    2.  Shape ``owned_job`` as a ``MagicMock(spec=ConversionJob)`` with
+        Pydantic-compatible attribute values so that, even if a future
+        regression re-introduces the leak, downstream serializers in
+        ``src/main.py`` won't crash with cryptic validation errors.
+    """
     from api._authz import get_current_user
     from api import validation as _val_mod
+    from db import models as _db_models
+    from datetime import datetime, timezone
     from unittest.mock import MagicMock, AsyncMock
 
     _TEST_USER_ID = "11111111-1111-4111-a111-111111111111"  # noqa: N806
@@ -32,13 +57,30 @@ def client():
     user = MagicMock()
     user.id = _TEST_USER_ID
 
-    owned_job = MagicMock()
+    # Pydantic-compatible mock — every attribute pulled by main.py's
+    # ConversionJob mirror has a real, JSON-serialisable value.
+    owned_job = MagicMock(spec=_db_models.ConversionJob)
+    owned_job.id = uuid.uuid4()
     owned_job.user_id = _TEST_USER_ID
+    owned_job.status = "queued"
+    owned_job.input_data = {
+        "file_id": str(uuid.uuid4()),
+        "original_filename": "validation_test.jar",
+        "target_version": "1.20.0",
+        "options": {},
+    }
+    owned_job.progress = None
+    owned_job.created_at = datetime.now(timezone.utc)
+    owned_job.updated_at = datetime.now(timezone.utc)
 
-    app.dependency_overrides[get_current_user] = lambda: user
+    original_get_job = _val_mod.crud.get_job
     _val_mod.crud.get_job = AsyncMock(return_value=owned_job)
-    yield TestClient(app)
-    app.dependency_overrides.clear()
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        yield TestClient(app)
+    finally:
+        _val_mod.crud.get_job = original_get_job
+        app.dependency_overrides.clear()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fix the 5 integration-test failures that flipped from green to red on PR #1426
(issue #1417 — `Depends(get_current_user)` + ownership checks). The new auth
gating works correctly; it just exercises end-to-end response-model
serialisation paths that previously short-circuited, exposing a long-standing
bug in **one** integration fixture.

## Root cause

`backend/src/tests/integration/test_validation_api_integration.py::client`
rebinds `_val_mod.crud.get_job = AsyncMock(return_value=owned_job)` at module
level and never restores it. Because `_val_mod.crud` *is* the `db.crud` module
object, the patch leaks for the rest of the xdist worker session. Subsequent
tests then receive a bare `MagicMock` (where they expected `None` for unknown
job ids) and explode while the FastAPI handler builds the `ConversionJob` /
`FeedbackResponse` response models from `job.input_data.get(...)` etc., e.g.

```
pydantic_core._pydantic_core.ValidationError: 4 validation errors for ConversionJob
original_filename  Input should be a valid string ... input_type=MagicMock
status             Input should be a valid string ... input_type=MagicMock
target_version     Input should be a valid string ... input_type=MagicMock
options            Input should be a valid dictionary ... input_type=MagicMock
```

The `owned_job` mock was a shape mismatch on **every** field that response
models need (`id`, `user_id`, `status`, `input_data`, `progress`,
`created_at`, `updated_at`).

## The 5 fixed tests

| # | Test | Failure on PR #1426 head | Why this PR fixes it |
|---|------|--------------------------|----------------------|
| 1 | `test_end_to_end_integration.py::TestEndToEndIntegration::test_nonexistent_job_status` | `4 validation errors for ConversionJob` (mirror builder in `src/main.py:get_conversion_status`) | `crud.get_job` is restored on teardown → fake UUID round-trips to `None` → endpoint correctly returns 404 as the test asserts |
| 2 | `test_api_feedback.py::test_submit_feedback_invalid_job_id` | `AttributeError: 'ConversionFeedback' object has no attribute 'quality_rating'` | Same: the leaked mock made `if not job:` pass for a fake UUID, reaching production code that touches columns the ORM model does not expose. With the patch restored, the endpoint returns 404 first |
| 3 | `test_api_feedback.py::test_get_training_data_empty` | `assert [{... 'job_id': \"<MagicMock ...>\", ...}] == []` | The leaked mock made every job lookup short-circuit to a MagicMock; training-data scan returned synthetic feedback rows |
| 4 | `test_api_integration.py::TestConversionIntegration::test_check_conversion_status` | `4 validation errors for ConversionJob` | Same root cause as #1 |
| 5 | `test_api_integration.py::TestErrorHandlingIntegration::test_check_status_nonexistent_job` | `4 validation errors for ConversionJob` (was supposed to 404) | Same root cause as #1 |

Locally reproduced exactly (5 failed) and resolved (12 passed, 1 skipped) by
running:

```bash
pytest src/tests/integration/test_validation_api_integration.py \
       src/tests/integration/test_end_to_end_integration.py::TestEndToEndIntegration::test_nonexistent_job_status \
       src/tests/integration/test_api_feedback.py \
       src/tests/integration/test_api_integration.py::TestConversionIntegration::test_check_conversion_status \
       src/tests/integration/test_api_integration.py::TestErrorHandlingIntegration::test_check_status_nonexistent_job
```

## The fix (test-only, single file)

`backend/src/tests/integration/test_validation_api_integration.py` — `client` fixture:

1. **Restore the patch.** Snapshot `_val_mod.crud.get_job` before the rebind and
   restore it in a `finally:` block so the patch is fully scoped to the
   validation tests.
2. **Reshape the mock.** Replace `owned_job = MagicMock()` with
   `MagicMock(spec=db.models.ConversionJob)` and set every attribute the
   downstream Pydantic constructors need to JSON-serialisable values:
   `id` (UUID), `user_id` (str), `status` (`"queued"`), `input_data` (a real
   dict with `file_id`, `original_filename`, `target_version`, `options`),
   `progress` (`None`), `created_at` / `updated_at` (`datetime`).

Defence-in-depth: even if a future regression re-introduces the leak, the
`ConversionJob(...)` mirror builder in `src/main.py:get_conversion_status`
will now round-trip cleanly through Pydantic instead of raising
`4 validation errors for ConversionJob`.

## Verification

- **Integration suite (local, no Docker):**
  - Serial: `132 passed, 100 skipped` (was `5 failed, 127 passed, 100 skipped` on PR #1426 head).
  - `-n auto --dist=loadscope`: `132 passed, 100 skipped`.
- **Unit suite:** unchanged — no production code touched, no unit fixtures
  touched. The 3 unit failures observed locally
  (`test_export_zip_sanitization`, `test_get_job_success`,
  `test_get_job_invalid_uuid`) reproduce on `origin/fix/1417-endpoint-auth-audit`
  *without* this patch and are unrelated to this scope.
- **Lint:** `ruff format` / `ruff check` clean on the touched file.
- **Out-of-scope LFS noise** (`scripts/phase5_output/stage1/*/tokenizer.json`)
  is left untouched (issue #1427, Worker D's scope).

## Contract bug — recommended for a separate issue (NOT fixed here)

`src/api/feedback.py:155` returns `FeedbackResponse(...)` with
`quality_rating=db_feedback.quality_rating` (and `specific_issues`,
`suggested_improvements`, `conversion_accuracy`, `visual_quality`,
`performance_rating`, `ease_of_use`, `agent_specific_feedback`), but the
SQLAlchemy ORM model `db.models.ConversionFeedback` only declares `id`,
`job_id`, `user_id`, `feedback_type`, `comment`, `created_at`. Likewise
`db.crud.create_enhanced_feedback` accepts those rating kwargs but silently
drops them when constructing the model. So:

- The API claims a richer feedback contract than the schema stores.
- For a *valid* `job_id`, `POST /api/v1/feedback` would today raise
  `AttributeError` while building the response (the unit tests sidestep this
  with `MagicMock()` returns).

This is real production logic and is **out of scope per #1431's task brief**
("If you find that a mock failure reveals a real API contract bug in
production code, **DO NOT FIX IT** — instead document it in the PR body and
recommend a separate issue."). Recommended follow-up: open a `bug(api)` issue
to either (a) drop the extended fields from `FeedbackResponse` or (b) add
the missing columns + persistence in `create_enhanced_feedback`.

Closes #1431
Unblocks #1417 (PR #1426 Integration Tests gate)