### PR TITLE
ci(ai-quality-gates): grant security-events: write to security-scan job (#1437)

### DIFF
--- a/.github/workflows/ai-quality-gates.yml
+++ b/.github/workflows/ai-quality-gates.yml
@@ -280,6 +280,9 @@ jobs:
   security-scan:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## What
Adds the `security-events: write` permission to the `security-scan` job in `ai-quality-gates.yml` so that `github/codeql-action/upload-sarif@v4` can push Trivy results to GitHub Code Scanning.

## Why
Closes #1437. The workflow currently inherits the default token, which does not include `security-events: write`, causing the Trivy upload step to fail with `Resource not accessible by integration` on every push to `main`. The Trivy scan itself succeeds; only the upload fails — but it makes the entire workflow report `failure`. Sibling workflows (`ci.yml`, `deploy.yml`, `security.yml`) already configure this correctly; `ai-quality-gates.yml` was the lone exception.

## Changes
- `.github/workflows/ai-quality-gates.yml`: add `permissions: { contents: read, security-events: write }` to the `security-scan` job.

## Validation
- YAML syntax check: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ai-quality-gates.yml'))"` → OK
- (Post-merge) `AI Quality Gates` workflow on `main` should be green and Trivy SARIF should appear under Security → Code scanning, filtered by `tool:Trivy`.

Closes #1437
