### PR TITLE
fix(ai-engine): bump crewai to >=0.140.0,<0.201.0 to resolve langchain-openai>=0.3.35 conflict (#1439)

### DIFF
--- a/ai-engine/requirements.txt
+++ b/ai-engine/requirements.txt
@@ -6,12 +6,16 @@ python-multipart==0.0.28
 # AI Framework - add upper bounds to avoid dependency conflicts
 # Note: crewai requires Python 3.10-3.13. Use Docker container for development (Python 3.12).
 # If running locally, use Python 3.12 virtual environment.
-# Let crewai manage langchain package versions to avoid conflicts
-crewai>=0.11.0,<1.0.0
+# crewai >=0.95 no longer depends on langchain-openai; it is pinned independently below
+# (used by ai-engine/crew/rag_crew.py and ai-engine/utils/rate_limiter.py).
+# Upper bound <0.201 keeps crewai compatible with the chromadb==1.5.8 pin below
+# (crewai 0.201+ pins chromadb~=1.1.0, which would conflict). See #1439.
+# Lower bound >=0.140 is required for Python 3.13 (used by the ai-engine-builder stage in Dockerfile).
+crewai>=0.140.0,<0.201.0
 openai>=1.0.0,<3.0.0
 langgraph>=1.1.0
 sentence-transformers>=5.1.2,<6.0.0
-langchain-openai>=0.3.35  # Required by crewai for OpenAI integration
+langchain-openai>=0.3.35,<2.0  # See #1439
 
 # Vector Database (pin version for embedchain compatibility)
 # Note: chromadb may require Python <3.13


### PR DESCRIPTION
## What
Bumps `crewai` in `ai-engine/requirements.txt` from `>=0.11.0,<1.0.0` to `>=0.140.0,<0.201.0` so that the existing `langchain-openai>=0.3.35` pin can resolve. Also adds a `<2.0` upper bound to `langchain-openai` and removes the now-stale trailing comment on that line. The four-line block of comments above the `crewai` line is updated to record the rationale (and to drop the obsolete "Let crewai manage langchain package versions" note, which has been false since crewai 0.95).

## Why
Closes #1439. `crewai 0.11.x` requires `langchain-openai (>=0.0.2,<0.0.3)`, which is mutually exclusive with `langchain-openai>=0.3.35`. This caused `pip install -r ai-engine/requirements.txt` to fail with `ResolutionImpossible` on every Docker build, blocking production deploys (`Dockerfile` `ai-engine-builder` stage → `pip install`).

## Version selection rationale

### `crewai>=0.140.0,<0.201.0`
- **Why not `<2.0` or `>=1.0` (per the issue's preferred suggestion)?** crewai 1.x (and crewai 0.201+) declares `chromadb~=1.1.0` (i.e., `>=1.1.0,<1.2.0`). That is mutually exclusive with the existing `chromadb==1.5.8` hard pin in this same file. Bumping chromadb is a separate concern (it would itself require validation against any code that talks to chromadb's wire format), so it is intentionally out of scope for this fix. With the `<0.201` cap, the resolver picks **crewai 0.193.2**, which only requires `chromadb>=0.5.23` — satisfied by `chromadb==1.5.8`.
- **Why `>=0.140.0`?** crewai 0.95 – 0.139 declare `requires_python = "<3.13,>=3.10"`, so they cannot be installed under Python 3.13 — but the `ai-engine-builder` stage in the repo's `Dockerfile` uses `python:3.13-slim`. From crewai 0.140 onward `requires_python` is `<3.14,>=3.10`, which works on both Python 3.12 (local dev/`ai-engine/Dockerfile`) and Python 3.13 (`Dockerfile` `ai-engine-builder`).
- **`langchain-openai` no longer pulled by crewai.** PyPI metadata for crewai 0.193.2 has zero `langchain*` requirements (it switched to `litellm` + `instructor` + raw `openai`). So the `langchain-openai` pin in this file now stands on its own — it is consumed directly by `ai-engine/crew/rag_crew.py` and `ai-engine/utils/rate_limiter.py` (`from langchain_openai import ChatOpenAI`). The "Required by crewai for OpenAI integration" comment was wrong and has been removed.

### `langchain-openai>=0.3.35,<2.0`
- Lower bound preserved from the previous pin (no behavioural change for the codebase).
- Upper bound chosen as **current major + 1**: PyPI's latest `langchain-openai` is `1.2.1`, so `<1.0` would have locked the project out of the current major while every other line in this file uses a `<NEXT_MAJOR` ceiling. `<2.0` matches that convention. The two API surfaces the codebase actually uses (`from langchain_openai import ChatOpenAI` and `from langchain_core.messages import AIMessage`) were smoke-checked against the resolved versions.

### Resolved versions (key ones)
- `crewai-0.193.2` (highest in the configured range)
- `langchain-openai-1.2.1` (highest in the configured range)
- `langchain-core-1.4.0` (transitive)
- `chromadb-1.5.8` (preserved — pin held)
- `openai-2.36.0` (within the existing `>=1.0.0,<3.0.0` pin)
- `langgraph-1.2.0`

## Validation
- `pip install --dry-run -r ai-engine/requirements.txt` resolves successfully under **Python 3.12** in a fresh venv (host) **and** under **Python 3.13** in `python:3.13-slim` (which is exactly what the `ai-engine-builder` stage in `Dockerfile` uses). Output below.
- Smoke-tested that `from langchain_openai import ChatOpenAI` and `from langchain_core.messages import AIMessage` still import cleanly against the resolved `langchain-openai 1.2.1` / `langchain-core 1.4.0`.
- Full Docker image build was **not** run locally — building the `ai-engine-builder` stage end-to-end downloads ~5 GB of CUDA wheels via `torch>=1.11.0`, which is slow enough that the dry-run on the matching Python version is a better signal in this environment. CI will run the full build.
- ai-engine test suite was **not** run locally for the same reason (the dependency tree includes torch + transformers + onnxruntime + the full CUDA toolkit, which is impractical to install just to run pytest in a worktree). CI will run the suite.

```
$ /tmp/portkit-1439-venv/bin/pip install --dry-run -r ai-engine/requirements.txt 2>&1 | tail -1
Would install Jinja2-3.1.6 MarkupSafe-3.0.3 PyJWT-2.12.1 PyPika-0.51.1 PyYAML-6.0.3 Pygments-2.20.0 SQLAlchemy-2.0.49 aiofiles-25.1.0 ... chromadb-1.5.8 ... crewai-0.193.2 ... langchain-core-1.4.0 langchain-openai-1.2.1 ... openai-2.36.0 ... pydantic-2.13.4 pydantic-settings-2.14.1 ... sentence-transformers-5.5.0 ... torch-2.12.0 ...
```

(Full "Would install" line lists ~180 packages; key ones excerpted above. Exit code: 0. No `ERROR`, no `WARNING`, no `ResolutionImpossible`.)

## Out of scope
- The Fly auth failure is tracked separately in #1438; with this PR the `Deploy production` step will get past the build but will still fail on auth until #1438's manual rotation is performed.
- Bumping `chromadb` past 1.5.8 (which would unlock crewai 0.201+/1.x) is left as a follow-up — it is independent of this resolver fix and warrants its own validation.

Closes #1439
