### PR TITLE
docs(operations): document post-merge manual follow-ups for 2026-05-14 parallel-issue-workflow batch

### DIFF
--- a/docs/operations/post-merge-followups-2026-05-14.md
+++ b/docs/operations/post-merge-followups-2026-05-14.md
@@ -1,0 +1,166 @@
+# Post-Merge Manual Follow-Ups — 2026-05-14 Parallel-Issue-Workflow Batch
+
+This document records the manual actions a maintainer must perform **after**
+the three PRs from the 2026-05-14 parallel-issue-workflow batch are merged. It
+is point-in-time; future batches should add their own dated file rather than
+overwriting this one.
+
+## Batch summary
+
+| Issue | PR | Branch | Scope | Auto-closes issue? |
+| --- | --- | --- | --- | --- |
+| [#1437](https://github.com/anchapin/portkit/issues/1437) | [#1440](https://github.com/anchapin/portkit/pull/1440) | `fix/1437-trivy-sarif-permission` | `.github/workflows/ai-quality-gates.yml` (+3 / −0) | ✅ Closes #1437 |
+| [#1438](https://github.com/anchapin/portkit/issues/1438) | [#1441](https://github.com/anchapin/portkit/pull/1441) | `ops/1438-fly-token-rotation-runbook` | `docs/operations/fly-token-rotation.md` (+277 / −0) | ⚠️ Refs #1438 only — manual rotation still required to fully close |
+| [#1439](https://github.com/anchapin/portkit/issues/1439) | [#1442](https://github.com/anchapin/portkit/pull/1442) | `fix/1439-crewai-langchain-openai-conflict` | `ai-engine/requirements.txt` (+7 / −3) | ✅ Closes #1439 |
+
+All three branches were forked from `main @ accf7329` and have disjoint write
+sets, so they could be merged in any order without conflicts. The order below
+is chosen for safety, not for technical dependency.
+
+## Recommended merge order (with rationale)
+
+1. **#1440 first** — fully green at submission; small (+3 / −0), additive,
+   and reverses the only pre-existing failure on `ai-quality-gates.yml`. Lowest
+   blast radius of the three.
+2. **#1441 next** — documentation-only (+277 / −0). Only one CI job
+   (`ai-engine-test`) was outstanding at submission; that job exercises the
+   ai-engine test image which is unaffected by a docs-only diff. Merging this
+   second makes the runbook canonically available before the maintainer needs
+   it to act on the items in this file.
+3. **#1442 last and only when all 9 originally-pending CI jobs report green**.
+   The critical gates are `build-python-base`, `ai-engine-test`,
+   `Tests + Coverage (70% min)`, `Integration Tests (ai-engine|backend|integration)`,
+   `Mutation Testing - Python (ai-engine)`, `Mutation Testing - Frontend`, and
+   `Trivy Dependency Scan`. The `crewai 0.11.x → 0.193.x` jump crosses an API
+   boundary; `pip` resolver convergence (proven locally) does not prove
+   runtime compatibility. Do **not** admin-bypass these checks.
+
+## Manual ops follow-ups still required after merges
+
+These actions could not be automated by the workflow worker because they
+require live production credentials and have irreversible side effects.
+
+### From PR #1441 (Fly.io token rotation, blocks #1438 closure)
+
+A maintainer with **Fly.io org access** AND **`anchapin/portkit` repo-secret
+write access** must:
+
+1. **Mint a new token.** Per-app deploy tokens are preferred for least
+   privilege:
+   ```bash
+   fly tokens create deploy --app portkit-backend-staging --expiry 168h
+   fly tokens create deploy --app portkit-backend         --expiry 168h
+   ```
+   Or, if the workflow refactor (see "Deferred follow-ups" below) hasn't
+   landed yet, mint a single org token instead:
+   ```bash
+   fly tokens create org <org-slug>
+   ```
+2. **Verify the new token works** before storing it:
+   ```bash
+   read -s -p "Paste new token: " NEW_TOKEN; echo
+   FLY_API_TOKEN="$NEW_TOKEN" fly auth whoami
+   ```
+3. **Store it in GitHub Actions secrets** (do not echo the token to shell
+   history):
+   ```bash
+   gh secret set FLY_API_TOKEN --repo anchapin/portkit --body "$NEW_TOKEN"
+   unset NEW_TOKEN
+   ```
+   If using per-app tokens AND the workflow refactor has landed:
+   ```bash
+   gh secret set FLY_API_TOKEN_STAGING --repo anchapin/portkit --body "$STAGING_TOKEN"
+   gh secret set FLY_API_TOKEN_PROD    --repo anchapin/portkit --body "$PROD_TOKEN"
+   ```
+4. **Re-trigger the deploy workflow** and confirm `Deploy to Fly.io` gets past
+   auth:
+   ```bash
+   gh workflow run fly-deploy.yml --repo anchapin/portkit --ref main
+   gh run watch --repo anchapin/portkit
+   ```
+5. **Close [#1438](https://github.com/anchapin/portkit/issues/1438)** once the
+   first post-rotation run reaches the deploy step. PR #1441 uses
+   `Refs #1438`, not `Closes #1438`, so the issue stays open until step 5 is
+   done by hand.
+6. **Update the runbook's `Last rotated:` line** in a small follow-up PR. The
+   current value in `docs/operations/fly-token-rotation.md` is
+   `_never (initial runbook)_`.
+
+The full procedure is in `docs/operations/fly-token-rotation.md` (lands with
+PR #1441); this section is a check-the-box checklist.
+
+> Note: production deploys may still fail for a different reason
+> (`ai-engine` dependency resolution) until PR #1442 / issue #1439 also
+> merges. That is the expected interaction documented in both PRs.
+
+## Deferred follow-ups (separate future PRs)
+
+These were intentionally scoped out of the batch above to keep each PR small
+and reviewable. They should be tracked as new issues if not already.
+
+### A. `fly-deploy.yml` per-app secret refactor
+
+Currently `.github/workflows/fly-deploy.yml` reads only `secrets.FLY_API_TOKEN`,
+so per-app deploy tokens cannot be used until the workflow is refactored to
+select a different secret per matrix entry. The intended shape (sketched in
+the runbook) is:
+
+```yaml
+matrix:
+  include:
+    - environment: staging
+      app_name: portkit-backend-staging
+      token_secret_name: FLY_API_TOKEN_STAGING
+    - environment: production
+      app_name: portkit-backend
+      token_secret_name: FLY_API_TOKEN_PROD
+
+- name: Deploy to Fly.io
+  uses: superfly/flyctl-actions@master
+  env:
+    # Prefer per-app token; fall back to legacy single token for backward compat.
+    FLY_API_TOKEN: ${{ secrets[matrix.token_secret_name] || secrets.FLY_API_TOKEN }}
+  with:
+    args: "deploy --app ${{ matrix.app_name }} --remote-only"
+```
+
+The `secrets[matrix.x]` dynamic-indexing syntax is not guaranteed to evaluate
+in every GitHub Actions context; the refactor must be validated on a
+short-lived branch in a real runner before being landed on `main`. If
+dynamic indexing fails in practice, fall back to two explicit `Deploy to
+Fly.io` steps with `if:` matrix-environment guards and static secret names.
+
+### B. `chromadb` bump to unlock `crewai 1.x`
+
+`ai-engine/requirements.txt` currently pins `crewai>=0.140.0,<0.201.0` because
+`crewai 0.201+` (and all `1.x`) declares `chromadb~=1.1.0`, which is mutually
+exclusive with the existing `chromadb==1.5.8` hard pin. To pick up bug fixes
+and features in `crewai 1.x`:
+
+1. Audit the codebase for `chromadb` API usage that may have changed between
+   `1.5.8` and the current `crewai 1.x` constraint band.
+2. Lower-bound `chromadb` to whatever `crewai 1.x` declares (currently
+   `~=1.1.0` per PyPI metadata for `crewai 1.14.4`).
+3. Re-run `pip install --dry-run -r ai-engine/requirements.txt` and the
+   ai-engine test suite to confirm no second-order conflicts (e.g. with
+   `embedchain`, `langchain-*`, or the `opentelemetry-exporter-*` stack the
+   file already calls out).
+4. Bump `crewai` to `1.x` in the same PR.
+
+### C. Update the `crewai` major-line — codebase audit
+
+PR #1442 jumps `crewai` from `0.11.x` to `0.193.2`. The Agent / Task / Crew
+constructor surface that `ai-engine/crew/conversion_crew.py` and
+`ai-engine/agents/rag_agents.py` rely on is structurally compatible based on
+the `crewai 0.193.2` wheel inspection that informed the version pick, but CI
+is the authoritative validation. If any of the pending CI jobs on PR #1442
+fail with an `Agent.__init__()`, `Task.__init__()`, `Crew.__init__()`, or
+`Process` import error, the fix likely belongs in a **follow-up PR** that
+adapts the call sites — do not amend PR #1442 with code changes that expand
+its scope beyond the requirements pin.
+
+## Source
+
+- Generated by: 2026-05-14 parallel-issue-workflow run, post-merge follow-up summary.
+- Worker agents: Dewey (#1437), Lorentz (#1438), Franklin (#1439).
+- Base commit for all three branches: `accf7329`.


### PR DESCRIPTION
## What

Adds a dated post-merge follow-ups document at `docs/operations/post-merge-followups-2026-05-14.md` recording every manual action a maintainer must perform after the three PRs from the 2026-05-14 parallel-issue-workflow batch land:

- Recommended merge order for #1440, #1441, #1442 with safety rationale.
- Step-by-step Fly.io token rotation checklist (the manual tail of #1438 that PR #1441 deliberately did not perform).
- Deferred follow-ups intentionally scoped out of the batch: the per-app `FLY_API_TOKEN_{STAGING,PROD}` workflow refactor, the `chromadb` bump that would unlock `crewai 1.x`, and the codebase-audit angle on the `crewai 0.11.x → 0.193.x` major-line jump.

## Why

The parallel-issue-workflow run on 2026-05-14 fixed three CI/build failures, but two of them have manual tails that an automated agent could not safely perform (Fly.io token rotation requires production credentials; per-app workflow refactor needs validation in a real Actions runner). This file is the canonical, dated checklist of what's left for a human, so the next person doesn't have to reconstruct it from PR descriptions.

It is intentionally date-suffixed (`-2026-05-14`) so future workflow batches add their own file rather than overwriting this one.

## Scope

Documentation-only:

- 1 file added: `docs/operations/post-merge-followups-2026-05-14.md` (+166 lines)
- No code changes
- No workflow changes

## Validation

- `python3` markdown structural check: 14 code fences (balanced), 10 headings, max heading level 3, min 1.
- All cross-PR and cross-issue links use full URLs so they render correctly even before #1441 lands and creates the sibling `docs/operations/fly-token-rotation.md`.

## Out of scope

- Performing the Fly.io token rotation itself (still a maintainer action — see Section "Manual ops follow-ups" in the new file).
- Closing #1438 (manual rotation in step 5 of that section).
- The deferred follow-ups themselves; they're documented here so they can be filed as follow-up issues if not already.