### PR TITLE
refactor(ai-engine): convert SearchTool to typed BaseTool subclasses with args_schema

### DIFF
--- a/ai-engine/services/rag_service.py
+++ b/ai-engine/services/rag_service.py
@@ -80,11 +80,19 @@ def _format_search_results(raw: Any) -> str:
 
 
 def _resolve_search_tool(search_tool: Optional[Any]) -> Any:
+    """Resolve to a search tool; default is the typed ``SemanticSearchTool``.
+
+    After the typed-args-schema migration (Phase 8 A, issue #1201), the default
+    semantic-search tool is itself a LangChain ``BaseTool``. Returning it
+    directly routes the RAG search step through the primary ``BaseTool``
+    branch in ``_make_search_step`` (Path 1) instead of the legacy descriptor
+    branch (Path 2).
+    """
     if search_tool is not None:
         return search_tool
     from tools.search_tool import SearchTool
 
-    return SearchTool.get_instance()
+    return SearchTool.get_instance().semantic_search
 
 
 def _resolve_llm(llm: Optional[Any]) -> Any:
@@ -140,11 +148,15 @@ def _make_search_step(search_tool: Optional[Any]) -> Runnable:
             type(tool), "semantic_search", None
         )
         if isinstance(semantic, _LCBaseTool):
-            try:
-                raw = await semantic.ainvoke({"query_data": query})
-                return _format_search_results(raw)
-            except Exception as e:  # pragma: no cover
-                logger.debug(f"semantic_search.ainvoke failed: {e}")
+            # The typed ``SemanticSearchTool`` accepts ``query``; older
+            # ``query_data``-shaped descriptors (if any remain) are tried as
+            # a final compatibility step.
+            for kwargs in ({"query": query}, {"query_data": query}):
+                try:
+                    raw = await semantic.ainvoke(kwargs)
+                    return _format_search_results(raw)
+                except Exception as e:  # pragma: no cover
+                    logger.debug(f"semantic_search.ainvoke({kwargs}) failed: {e}")
 
         # 3. Sync fallbacks for arbitrary search backends.
         for attr in ("search", "_run"):

--- a/ai-engine/test_integration.py
+++ b/ai-engine/test_integration.py
@@ -212,7 +212,7 @@ def test_search_fallback_mechanism():
     print("=" * 60)
 
     try:
-        from tools.search_tool import SearchTool
+        from tools.search_tool import SearchTool, _attempt_fallback_search
         from utils.config import Config
 
         # Verify fallback is enabled
@@ -220,11 +220,11 @@ def test_search_fallback_mechanism():
         print(f"   Fallback tool: {Config.FALLBACK_SEARCH_TOOL}")
 
         # Test fallback mechanism (may not execute due to no vector DB)
-        search_tool = SearchTool.get_instance()
+        SearchTool.get_instance()
         print("[OK] SearchTool instance created")
 
-        # Test fallback import logic
-        fallback_results = search_tool._attempt_fallback_search("test query", 5)
+        # Test fallback import logic (now a module-level helper after Phase 8 A).
+        fallback_results = _attempt_fallback_search("test query", 5)
         if fallback_results:
             print(f"[OK] Fallback mechanism working: {len(fallback_results)} results")
         else:

--- a/ai-engine/testing/rag_evaluator.py
+++ b/ai-engine/testing/rag_evaluator.py
@@ -74,7 +74,7 @@ class RagEvaluator:
             # Currently, SearchTool returns hardcoded results.
             # In a real scenario, this would involve actual search logic.
             # Using semantic_search method instead of private _run method
-            retrieved_docs_json = await self.search_tool.semantic_search.func(query)
+            retrieved_docs_json = await self.search_tool.semantic_search.ainvoke({"query": query})
             retrieved_docs_data = json.loads(retrieved_docs_json)
             retrieved_docs_text = " ".join(
                 [result.get("content", "") for result in retrieved_docs_data.get("results", [])]

--- a/ai-engine/tests/test_search_tool_comprehensive.py
+++ b/ai-engine/tests/test_search_tool_comprehensive.py
@@ -1,32 +1,55 @@
+"""Comprehensive unit tests for the typed ``SearchTool`` family (issue #1201, Phase 8 A).
+
+This rewrite targets the ``BaseTool`` subclasses introduced when the legacy
+``@tool``-decorated single-string-arg pattern was retired. Each test now
+drives the public ``ainvoke({...})`` surface with structured arguments, and
+mocks the underlying ``VectorDBClient.search_documents`` instead of the
+removed private ``_perform_*`` wrappers.
 """
-Comprehensive unit tests for SearchTool.
-Tests semantic search, document search, similarity search, and fallback mechanisms.
-"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import json
-import asyncio
-from unittest.mock import Mock, AsyncMock, patch, MagicMock
-from typing import List, Dict, Any, Optional
-import logging
+from pydantic import ValidationError
 
-# Set up imports
 try:
-    from tools.search_tool import SearchTool
+    from tools.search_tool import (
+        BedrockApiSearchTool,
+        ComponentLookupTool,
+        ConversionExamplesTool,
+        DocumentSearchTool,
+        SchemaValidationLookupTool,
+        SearchTool,
+        SemanticSearchTool,
+        SimilaritySearchTool,
+        _attempt_fallback_search,
+        _document_search_payload,
+        _semantic_search_payload,
+        _similarity_search_payload,
+    )
     from utils.vector_db_client import VectorDBClient
+
     IMPORTS_AVAILABLE = True
-except ImportError as e:
+except ImportError as exc:  # pragma: no cover - environmental
     IMPORTS_AVAILABLE = False
-    IMPORT_ERROR = str(e)
+    IMPORT_ERROR = str(exc)
 
 
-# Skip all tests if imports fail
-pytestmark = pytest.mark.skipif(not IMPORTS_AVAILABLE, reason=f"Required imports unavailable")
+pytestmark = pytest.mark.skipif(not IMPORTS_AVAILABLE, reason="Required imports unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def mock_vector_client():
-    """Create a mock VectorDBClient for testing."""
+def mock_vector_client() -> AsyncMock:
+    """An async-spec'd ``VectorDBClient`` mock with a default empty result set."""
     client = AsyncMock(spec=VectorDBClient)
     client.search_documents = AsyncMock(return_value=[])
     client.index_document = AsyncMock(return_value=True)
@@ -36,774 +59,573 @@ def mock_vector_client():
 
 
 @pytest.fixture
-def search_tool_instance(mock_vector_client):
-    """Create a SearchTool instance with mocked vector client."""
-    with patch.object(SearchTool, 'vector_client', mock_vector_client, create=True):
-        tool = SearchTool()
-        tool.vector_client = mock_vector_client
-        # Patch get_instance to return this specific instance
-        with patch.object(SearchTool, 'get_instance', return_value=tool):
-            yield tool
-
-
-@pytest.fixture
-def sample_search_results():
-    """Sample search results for mocking."""
+def sample_search_results() -> List[Dict[str, Any]]:
+    """Sample vector-DB results."""
     return [
         {
             "id": "doc_1",
             "content": "Java block entity implementation",
             "source": "java_source",
-            "similarity": 0.95
+            "similarity_score": 0.95,
         },
         {
             "id": "doc_2",
             "content": "Block state management in Bedrock",
             "source": "bedrock_docs",
-            "similarity": 0.87
+            "similarity_score": 0.87,
         },
         {
             "id": "doc_3",
             "content": "Custom block properties",
             "source": "reference",
-            "similarity": 0.72
-        }
+            "similarity_score": 0.72,
+        },
     ]
 
 
-class TestSearchToolInitialization:
-    """Test SearchTool initialization and singleton pattern."""
-    
-    def test_search_tool_instantiation(self, mock_vector_client):
-        """Test that SearchTool can be instantiated."""
-        with patch.object(SearchTool, '__init__', return_value=None):
-            tool = SearchTool()
-            assert tool is not None
-    
-    def test_get_instance_singleton(self):
-        """Test singleton pattern implementation."""
-        # Reset singleton
+@pytest.fixture
+def disable_fallback() -> Any:
+    """Force ``Config.SEARCH_FALLBACK_ENABLED = False`` for the duration of a test."""
+    with patch("tools.search_tool.Config") as mock_config:
+        mock_config.SEARCH_FALLBACK_ENABLED = False
+        yield mock_config
+
+
+@pytest.fixture
+def enable_fallback() -> Any:
+    """Force ``Config.SEARCH_FALLBACK_ENABLED = True`` for the duration of a test."""
+    with patch("tools.search_tool.Config") as mock_config:
+        mock_config.SEARCH_FALLBACK_ENABLED = True
+        mock_config.FALLBACK_SEARCH_TOOL = "web_search_tool"
+        yield mock_config
+
+
+# ---------------------------------------------------------------------------
+# Facade
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolFacade:
+    """Tests for the ``SearchTool`` facade and singleton behaviour."""
+
+    def test_get_tools_returns_seven_basetool_instances(self) -> None:
+        from langchain_core.tools import BaseTool
+
         SearchTool._instance = None
-        
-        with patch('tools.search_tool.VectorDBClient'):
-            instance1 = SearchTool.get_instance()
-            instance2 = SearchTool.get_instance()
-            
-            assert instance1 is instance2
-        
-        # Clean up
+        with patch("tools.search_tool.VectorDBClient"):
+            facade = SearchTool()
+            tools = facade.get_tools()
+
+        assert len(tools) == 7
+        assert all(isinstance(t, BaseTool) for t in tools)
+        names = {t.name for t in tools}
+        assert names == {
+            "semantic_search",
+            "document_search",
+            "similarity_search",
+            "bedrock_api_search",
+            "component_lookup",
+            "conversion_examples",
+            "schema_validation_lookup",
+        }
         SearchTool._instance = None
-    
-    def test_get_tools_returns_list(self, search_tool_instance):
-        """Test that get_tools returns a list of available tools."""
-        tools = search_tool_instance.get_tools()
-        
-        assert isinstance(tools, list)
-        assert len(tools) > 0
-        # Should return callable LangChain tools
-        for tool in tools:
-            assert callable(tool) or hasattr(tool, '__call__') or hasattr(tool, 'func')
+
+    def test_get_instance_singleton(self) -> None:
+        SearchTool._instance = None
+        with patch("tools.search_tool.VectorDBClient"):
+            i1 = SearchTool.get_instance()
+            i2 = SearchTool.get_instance()
+        assert i1 is i2
+        SearchTool._instance = None
+
+    def test_facade_exposes_typed_basetool_properties(self) -> None:
+        SearchTool._instance = None
+        with patch("tools.search_tool.VectorDBClient"):
+            facade = SearchTool()
+        assert isinstance(facade.semantic_search, SemanticSearchTool)
+        assert isinstance(facade.document_search, DocumentSearchTool)
+        assert isinstance(facade.similarity_search, SimilaritySearchTool)
+        assert isinstance(facade.bedrock_api_search, BedrockApiSearchTool)
+        assert isinstance(facade.component_lookup, ComponentLookupTool)
+        assert isinstance(facade.conversion_examples, ConversionExamplesTool)
+        assert isinstance(facade.schema_validation_lookup, SchemaValidationLookupTool)
+        SearchTool._instance = None
 
 
-class TestSemanticSearch:
-    """Test semantic_search tool functionality."""
-    
-    @pytest.mark.asyncio
-    async def test_semantic_search_json_input(self, search_tool_instance, sample_search_results):
-        """Test semantic search with JSON input."""
-        search_tool_instance.vector_client.search_documents = AsyncMock(
-            return_value=sample_search_results
-        )
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=sample_search_results
-        )
-        
-        query_data = json.dumps({
-            "query": "block entity implementation",
-            "limit": 5,
-            "document_source": "java_source"
-        })
-        
-        result = await SearchTool.semantic_search.func(query_data)
-        
-        assert isinstance(result, str)
-        result_data = json.loads(result)
-        assert "query" in result_data
-        assert "results" in result_data or "error" in result_data
-        assert result_data["query"] == "block entity implementation"
-    
-    @pytest.mark.asyncio
-    async def test_semantic_search_string_input(self, search_tool_instance, sample_search_results):
-        """Test semantic search with plain string input."""
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=sample_search_results
-        )
-        
-        result = await SearchTool.semantic_search.func("block implementation")
-        
-        result_data = json.loads(result)
-        assert result_data["query"] == "block implementation"
-        assert len(result_data["results"]) > 0
-    
-    @pytest.mark.asyncio
-    async def test_semantic_search_no_query_error(self, search_tool_instance):
-        """Test semantic search returns error when query is empty."""
-        query_data = json.dumps({"query": "", "limit": 5})
-        
-        result = await SearchTool.semantic_search.func(query_data)
-        result_data = json.loads(result)
-        
-        assert "error" in result_data
-        assert "Query is required" in result_data["error"]
-    
-    @pytest.mark.asyncio
-    async def test_semantic_search_custom_limit(self, search_tool_instance, sample_search_results):
-        """Test semantic search with custom result limit."""
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=sample_search_results[:2]
-        )
-        
-        query_data = json.dumps({
-            "query": "block",
-            "limit": 2
-        })
-        
-        result = await SearchTool.semantic_search.func(query_data)
-        result_data = json.loads(result)
-        
-        assert result_data["total_results"] == 2
-    
-    @pytest.mark.asyncio
-    async def test_semantic_search_exception_handling(self, search_tool_instance):
-        """Test semantic search exception handling."""
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            side_effect=Exception("Vector DB connection failed")
-        )
-        
-        result = await SearchTool.semantic_search.func("test query")
-        result_data = json.loads(result)
-        
-        assert "error" in result_data
+# ---------------------------------------------------------------------------
+# SemanticSearchTool
+# ---------------------------------------------------------------------------
 
 
-class TestDocumentSearch:
-    """Test document_search tool functionality."""
-    
-    @pytest.mark.asyncio
-    async def test_document_search_basic(self, search_tool_instance, sample_search_results):
-        """Test basic document search."""
-        search_tool_instance._search_by_document_source = AsyncMock(
-            return_value=sample_search_results
-        )
-        
-        query_data = json.dumps({
-            "document_source": "java_source",
-            "limit": 3
-        })
-        
-        result = await SearchTool.document_search.func(query_data)
-        
-        assert isinstance(result, str)
-        result_data = json.loads(result)
-        assert len(result_data["results"]) > 0
-    
-    @pytest.mark.asyncio
-    async def test_document_search_no_source_error(self, search_tool_instance):
-        """Test document search returns error when source is empty."""
-        query_data = json.dumps({"document_source": "", "limit": 5})
-        
-        result = await SearchTool.document_search.func(query_data)
-        result_data = json.loads(result)
-        
-        assert "error" in result_data
-        assert "Document source is required" in result_data["error"]
+class TestSemanticSearchTool:
+    """Tests for ``SemanticSearchTool.ainvoke``."""
 
     @pytest.mark.asyncio
-    async def test_document_search_fallback(self, search_tool_instance):
-        """Test document search fallback."""
-        search_tool_instance._search_by_document_source = AsyncMock(return_value=[])
-        search_tool_instance._attempt_fallback_search = Mock(
-            return_value=[{"id": "f1", "content": "fallback"}]
-        )
-        
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = True
-            
-            query_data = json.dumps({"document_source": "test"})
-            result = await SearchTool.document_search.func(query_data)
-            result_data = json.loads(result)
-            
-            assert len(result_data["results"]) == 1
-            assert result_data["results"][0]["content"] == "fallback"
+    async def test_returns_canonical_payload(
+        self, mock_vector_client: AsyncMock, sample_search_results: List[Dict[str, Any]]
+    ) -> None:
+        mock_vector_client.search_documents.return_value = sample_search_results
+        tool = SemanticSearchTool(vector_client=mock_vector_client)
 
-    @pytest.mark.asyncio
-    async def test_document_search_exception(self, search_tool_instance):
-        """Test document search exception handling."""
-        search_tool_instance._search_by_document_source = AsyncMock(
-            side_effect=Exception("Error")
-        )
-        
-        result = await SearchTool.document_search.func("source")
-        result_data = json.loads(result)
-        assert "error" in result_data
-
-
-class TestSimilaritySearch:
-    """Test similarity_search tool functionality."""
-    @pytest.mark.asyncio
-    async def test_similarity_search_basic(self, search_tool_instance, sample_search_results):
-        """Test basic similarity search."""
-        search_tool_instance._find_similar_documents = AsyncMock(
-            return_value=sample_search_results
+        raw = await tool.ainvoke(
+            {"query": "block entity implementation", "limit": 5, "document_source": "java_source"}
         )
 
-        query_data = json.dumps({
-            "content": "entity behavior",
-            "limit": 5,
-            "threshold": 0.7
-        })
-
-        result = await SearchTool.similarity_search.func(query_data)
-
-        result_data = json.loads(result)
-        assert len(result_data["results"]) > 0
-    
-    @pytest.mark.asyncio
-    async def test_similarity_search_no_content_error(self, search_tool_instance):
-        """Test similarity search returns error when content is empty."""
-        query_data = json.dumps({"content": ""})
-        
-        result = await SearchTool.similarity_search.func(query_data)
-        result_data = json.loads(result)
-        
-        assert "error" in result_data
-        assert "Content is required" in result_data["error"]
-
-    @pytest.mark.asyncio
-    async def test_similarity_search_fallback(self, search_tool_instance):
-        """Test similarity search fallback."""
-        search_tool_instance._find_similar_documents = AsyncMock(return_value=[])
-        search_tool_instance._attempt_fallback_search = Mock(
-            return_value=[{"id": "f1", "content": "fallback"}]
+        payload = json.loads(raw)
+        assert payload["query"] == "block entity implementation"
+        assert payload["total_results"] == 3
+        assert payload["results"] == sample_search_results
+        mock_vector_client.search_documents.assert_awaited_once_with(
+            query_text="block entity implementation", top_k=5, document_source_filter="java_source"
         )
-        
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = True
-            
-            result = await SearchTool.similarity_search.func("some content")
-            result_data = json.loads(result)
-            
-            assert len(result_data["results"]) == 1
 
     @pytest.mark.asyncio
-    async def test_similarity_search_exception(self, search_tool_instance):
-        """Test similarity search exception handling."""
-        search_tool_instance._find_similar_documents = AsyncMock(
-            side_effect=Exception("Error")
+    async def test_default_limit_is_ten(self, mock_vector_client: AsyncMock) -> None:
+        tool = SemanticSearchTool(vector_client=mock_vector_client)
+        await tool.ainvoke({"query": "anything"})
+        mock_vector_client.search_documents.assert_awaited_once_with(
+            query_text="anything", top_k=10, document_source_filter=None
         )
-        
-        result = await SearchTool.similarity_search.func("content")
-        result_data = json.loads(result)
-        assert "error" in result_data
 
-
-class TestFallbackMechanism:
-    """Test fallback search mechanism."""
-    
     @pytest.mark.asyncio
-    async def test_fallback_search_on_empty_results(self, search_tool_instance):
-        """Test fallback search triggered on empty primary results."""
-        search_tool_instance._perform_semantic_search = AsyncMock(return_value=[])
-        search_tool_instance._attempt_fallback_search = Mock(
-            return_value=[
-                {"id": "fallback_1", "content": "fallback result", "source": "fallback"}
-            ]
+    async def test_vector_client_exception_returns_error_payload(
+        self, mock_vector_client: AsyncMock
+    ) -> None:
+        mock_vector_client.search_documents.side_effect = Exception("Vector DB connection failed")
+        tool = SemanticSearchTool(vector_client=mock_vector_client)
+
+        raw = await tool.ainvoke({"query": "test"})
+        payload = json.loads(raw)
+
+        assert "error" in payload
+        assert "Vector DB connection failed" in payload["error"]
+        assert payload["query"] == "test"
+
+    @pytest.mark.asyncio
+    async def test_fallback_triggers_when_results_empty(
+        self, mock_vector_client: AsyncMock, enable_fallback: Any
+    ) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = SemanticSearchTool(vector_client=mock_vector_client)
+
+        with patch(
+            "tools.search_tool._attempt_fallback_search",
+            return_value=[{"id": "fb", "content": "fb content"}],
+        ) as mock_fb:
+            raw = await tool.ainvoke({"query": "x", "limit": 4})
+
+        mock_fb.assert_called_once_with("x", 4)
+        payload = json.loads(raw)
+        assert payload["total_results"] == 1
+        assert payload["results"][0]["content"] == "fb content"
+
+    @pytest.mark.asyncio
+    async def test_fallback_skipped_when_disabled(
+        self, mock_vector_client: AsyncMock, disable_fallback: Any
+    ) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = SemanticSearchTool(vector_client=mock_vector_client)
+
+        with patch("tools.search_tool._attempt_fallback_search") as mock_fb:
+            raw = await tool.ainvoke({"query": "x"})
+
+        mock_fb.assert_not_called()
+        assert json.loads(raw)["total_results"] == 0
+
+    def test_sync_invoke_outside_loop(
+        self, mock_vector_client: AsyncMock, sample_search_results: List[Dict[str, Any]]
+    ) -> None:
+        mock_vector_client.search_documents.return_value = sample_search_results
+        tool = SemanticSearchTool(vector_client=mock_vector_client)
+
+        raw = tool.invoke({"query": "block"})
+        assert json.loads(raw)["total_results"] == 3
+
+    @pytest.mark.asyncio
+    async def test_sync_invoke_inside_loop_raises(self, mock_vector_client: AsyncMock) -> None:
+        tool = SemanticSearchTool(vector_client=mock_vector_client)
+        with pytest.raises(RuntimeError, match="event loop"):
+            tool.invoke({"query": "x"})
+
+
+# ---------------------------------------------------------------------------
+# DocumentSearchTool
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentSearchTool:
+    @pytest.mark.asyncio
+    async def test_basic(
+        self, mock_vector_client: AsyncMock, sample_search_results: List[Dict[str, Any]]
+    ) -> None:
+        mock_vector_client.search_documents.return_value = sample_search_results
+        tool = DocumentSearchTool(vector_client=mock_vector_client)
+
+        raw = await tool.ainvoke({"document_source": "java_source", "limit": 3})
+        payload = json.loads(raw)
+
+        assert payload["document_source"] == "java_source"
+        assert payload["total_results"] == 3
+        mock_vector_client.search_documents.assert_awaited_once_with(
+            query_text="java_source", top_k=3, document_source_filter="java_source"
         )
-        
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = True
-            
-            result = await SearchTool.semantic_search.func("test query")
-            result_data = json.loads(result)
-            
-            # Fallback should have been called
-            search_tool_instance._attempt_fallback_search.assert_called()
-            assert len(result_data["results"]) > 0
-    
-    def test_fallback_search_returns_results(self, search_tool_instance):
-        """Test that fallback search returns valid results."""
-        fallback_results = [
-            {"id": "doc_1", "content": "fallback content", "source": "fallback"}
-        ]
-        
-        search_tool_instance._attempt_fallback_search = Mock(return_value=fallback_results)
-        
-        result = search_tool_instance._attempt_fallback_search("test", 5)
-        
-        assert len(result) > 0
-        assert all("id" in r for r in result)
-
-
-class TestComponentLookup:
-    """Test component_lookup tool functionality."""
-    
-    @pytest.mark.asyncio
-    async def test_component_lookup_basic(self, search_tool_instance, sample_search_results):
-        """Test basic component lookup."""
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=sample_search_results
-        )
-        
-        query_data = json.dumps({
-            "component": "BlockEntity",
-            "limit": 5
-        })
-        
-        result = await SearchTool.component_lookup.func(query_data)
-        
-        result_data = json.loads(result)
-        assert isinstance(result_data, dict)
-    
-    @pytest.mark.asyncio
-    async def test_component_lookup_no_component_error(self, search_tool_instance):
-        """Test component lookup returns error when component is empty."""
-        query_data = json.dumps({"component": "", "limit": 5})
-        
-        result = await SearchTool.component_lookup.func(query_data)
-        result_data = json.loads(result)
-        
-        assert "error" in result_data
-
-
-class TestConversionExamples:
-    """Test conversion_examples tool functionality."""
-    
-    @pytest.mark.asyncio
-    async def test_conversion_examples_search(self, search_tool_instance, sample_search_results):
-        """Test conversion examples search."""
-        example_results = [
-            {
-                "id": "example_1",
-                "content": "Example: Convert Java block to Bedrock block",
-                "source": "examples",
-                "similarity": 0.9
-            }
-        ]
-        
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=example_results
-        )
-        
-        query_data = json.dumps({
-            "context": "block conversion",
-            "limit": 5
-        })
-        
-        result = await SearchTool.conversion_examples.func(query_data)
-        
-        result_data = json.loads(result)
-        assert "results" in result_data or "error" in result_data
-
-
-class TestSchemaValidationLookup:
-    """Test schema_validation_lookup tool functionality."""
-    
-    @pytest.mark.asyncio
-    async def test_schema_lookup_basic(self, search_tool_instance, sample_search_results):
-        """Test schema validation lookup."""
-        schema_results = [
-            {
-                "id": "schema_1",
-                "content": "JSON schema for block definition",
-                "source": "schemas",
-                "similarity": 0.88
-            }
-        ]
-        
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=schema_results
-        )
-        
-        query_data = json.dumps({
-            "schema_type": "block_definition",
-            "limit": 5
-        })
-        
-        result = await SearchTool.schema_validation_lookup.func(query_data)
-        
-        result_data = json.loads(result)
-        assert isinstance(result_data, dict)
-
-
-class TestBedrockAPISearch:
-    """Test bedrock_api_search tool functionality."""
-    
-    @pytest.mark.asyncio
-    async def test_bedrock_api_search(self, search_tool_instance, sample_search_results):
-        """Test Bedrock API search."""
-        bedrock_results = [r for r in sample_search_results if "bedrock" in r.get("content", "").lower()]
-        
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=bedrock_results
-        )
-        
-        query_data = json.dumps({
-            "api_endpoint": "blocks",
-            "limit": 5
-        })
-        
-        result = await SearchTool.bedrock_api_search.func(query_data)
-        
-        result_data = json.loads(result)
-        assert isinstance(result_data, dict)
-
-
-class TestSearchToolPrivateMethods:
-    """Test SearchTool private methods."""
-    
-    @pytest.mark.asyncio
-    async def test_perform_semantic_search(self, search_tool_instance, sample_search_results):
-        """Test _perform_semantic_search private method."""
-        search_tool_instance.vector_client.search_documents = AsyncMock(
-            return_value=sample_search_results
-        )
-        
-        results = await search_tool_instance._perform_semantic_search(
-            query="test query",
-            limit=5,
-            document_source=None
-        )
-        
-        assert len(results) > 0
-        assert all(isinstance(r, dict) for r in results)
-
-    def test_attempt_fallback_search_disabled(self, search_tool_instance):
-        """Test _attempt_fallback_search when disabled."""
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = False
-            result = search_tool_instance._attempt_fallback_search("query", 5)
-            assert result == []
-
-    def test_attempt_fallback_search_logic(self, search_tool_instance):
-        """Test _attempt_fallback_search internal logic with successful import."""
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = True
-            mock_config.FALLBACK_SEARCH_TOOL = "web_search_tool"
-            
-            mock_fallback_instance = MagicMock()
-            mock_fallback_instance._run.return_value = "fallback results string"
-            
-            with patch('importlib.import_module') as mock_import:
-                mock_module = MagicMock()
-                mock_import.return_value = mock_module
-                setattr(mock_module, "WebSearchTool", MagicMock(return_value=mock_fallback_instance))
-                
-                result = search_tool_instance._attempt_fallback_search("query", 5)
-                
-                assert len(result) == 1
-                assert result[0]["content"] == "fallback results string"
-
-    def test_attempt_fallback_search_import_error(self, search_tool_instance):
-        """Test _attempt_fallback_search handling of ImportError."""
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = True
-            mock_config.FALLBACK_SEARCH_TOOL = "non_existent_tool"
-            
-            with patch('importlib.import_module', side_effect=ImportError("Module not found")):
-                result = search_tool_instance._attempt_fallback_search("query", 5)
-                assert result == []
-
-    def test_attempt_fallback_search_attribute_error(self, search_tool_instance):
-        """Test _attempt_fallback_search handling of AttributeError."""
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = True
-            mock_config.FALLBACK_SEARCH_TOOL = "web_search_tool"
-            
-            with patch('importlib.import_module') as mock_import:
-                mock_module = MagicMock()
-                # Class not in module
-                delattr(mock_module, "WebSearchTool")
-                mock_import.return_value = mock_module
-                
-                result = search_tool_instance._attempt_fallback_search("query", 5)
-                assert result == []
-
-    def test_attempt_fallback_search_generic_exception(self, search_tool_instance):
-        """Test _attempt_fallback_search handling of generic exceptions."""
-        with patch('tools.search_tool.Config') as mock_config:
-            mock_config.SEARCH_FALLBACK_ENABLED = True
-            mock_config.FALLBACK_SEARCH_TOOL = "web_search_tool"
-            
-            with patch('importlib.import_module', side_effect=Exception("Unexpected error")):
-                result = search_tool_instance._attempt_fallback_search("query", 5)
-                assert result == []
 
     @pytest.mark.asyncio
-    async def test_search_by_document_source_logic(self, search_tool_instance, sample_search_results):
-        """Test _search_by_document_source with content_type filter."""
-        results_with_metadata = [
+    async def test_content_type_filter_applies_client_side(
+        self, mock_vector_client: AsyncMock
+    ) -> None:
+        mock_vector_client.search_documents.return_value = [
             {"id": "1", "metadata": {"content_type": "text"}},
-            {"id": "2", "metadata": {"content_type": "json"}}
+            {"id": "2", "metadata": {"content_type": "json"}},
+            {"id": "3", "content_type": "text"},
         ]
-        search_tool_instance.vector_client.search_documents = AsyncMock(
-            return_value=results_with_metadata
-        )
-        
-        # Test filtering
-        result = await search_tool_instance._search_by_document_source(
-            document_source="test_source",
-            content_type="text"
-        )
-        assert len(result) == 1
-        assert result[0]["id"] == "1"
+        tool = DocumentSearchTool(vector_client=mock_vector_client)
+
+        raw = await tool.ainvoke({"document_source": "src", "content_type": "text"})
+        payload = json.loads(raw)
+
+        ids = sorted(r["id"] for r in payload["results"])
+        assert ids == ["1", "3"]
 
     @pytest.mark.asyncio
-    async def test_find_similar_documents_threshold(self, search_tool_instance):
-        """Test _find_similar_documents similarity threshold filtering."""
-        results = [
+    async def test_vector_client_exception_returns_error(
+        self, mock_vector_client: AsyncMock
+    ) -> None:
+        mock_vector_client.search_documents.side_effect = Exception("oops")
+        tool = DocumentSearchTool(vector_client=mock_vector_client)
+
+        raw = await tool.ainvoke({"document_source": "x"})
+        payload = json.loads(raw)
+
+        assert "error" in payload
+        assert payload["document_source"] == "x"
+
+    @pytest.mark.asyncio
+    async def test_fallback_triggers_when_empty(
+        self, mock_vector_client: AsyncMock, enable_fallback: Any
+    ) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = DocumentSearchTool(vector_client=mock_vector_client)
+
+        with patch(
+            "tools.search_tool._attempt_fallback_search",
+            return_value=[{"id": "fb", "content": "fb"}],
+        ):
+            raw = await tool.ainvoke({"document_source": "x"})
+
+        assert json.loads(raw)["total_results"] == 1
+
+
+# ---------------------------------------------------------------------------
+# SimilaritySearchTool
+# ---------------------------------------------------------------------------
+
+
+class TestSimilaritySearchTool:
+    @pytest.mark.asyncio
+    async def test_basic_returns_preview(
+        self, mock_vector_client: AsyncMock, sample_search_results: List[Dict[str, Any]]
+    ) -> None:
+        mock_vector_client.search_documents.return_value = sample_search_results
+        tool = SimilaritySearchTool(vector_client=mock_vector_client)
+
+        raw = await tool.ainvoke({"content": "entity behavior", "threshold": 0.7, "limit": 5})
+        payload = json.loads(raw)
+
+        assert payload["reference_content"] == "entity behavior"
+        assert payload["threshold"] == 0.7
+        assert payload["total_results"] == 3
+
+    @pytest.mark.asyncio
+    async def test_long_content_is_truncated_in_preview(
+        self, mock_vector_client: AsyncMock
+    ) -> None:
+        mock_vector_client.search_documents.return_value = [{"id": "1", "similarity_score": 0.9}]
+        tool = SimilaritySearchTool(vector_client=mock_vector_client)
+        long_content = "a" * 200
+
+        raw = await tool.ainvoke({"content": long_content, "threshold": 0.0})
+        payload = json.loads(raw)
+
+        assert payload["reference_content"].endswith("...")
+        assert len(payload["reference_content"]) == 103  # 100 chars + "..."
+
+    @pytest.mark.asyncio
+    async def test_threshold_filters_results(self, mock_vector_client: AsyncMock) -> None:
+        mock_vector_client.search_documents.return_value = [
             {"id": "1", "similarity_score": 0.9},
-            {"id": "2", "similarity_score": 0.5}
+            {"id": "2", "similarity_score": 0.5},
         ]
-        search_tool_instance.vector_client.search_documents = AsyncMock(
-            return_value=results
+        tool = SimilaritySearchTool(vector_client=mock_vector_client)
+
+        raw = await tool.ainvoke({"content": "x", "threshold": 0.7})
+        payload = json.loads(raw)
+
+        assert [r["id"] for r in payload["results"]] == ["1"]
+
+    @pytest.mark.asyncio
+    async def test_vector_client_exception_returns_error(
+        self, mock_vector_client: AsyncMock
+    ) -> None:
+        mock_vector_client.search_documents.side_effect = Exception("nope")
+        tool = SimilaritySearchTool(vector_client=mock_vector_client)
+
+        raw = await tool.ainvoke({"content": "x"})
+        payload = json.loads(raw)
+
+        assert "error" in payload
+
+
+# ---------------------------------------------------------------------------
+# Wrapper tools (Bedrock/Component/Conversion/Schema)
+# ---------------------------------------------------------------------------
+
+
+class TestBedrockApiSearchTool:
+    @pytest.mark.asyncio
+    async def test_formats_query_with_category(self, mock_vector_client: AsyncMock) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = BedrockApiSearchTool(vector_client=mock_vector_client)
+
+        await tool.ainvoke({"query": "player events", "api_category": "Scripting API"})
+
+        args = mock_vector_client.search_documents.await_args
+        assert args.kwargs["query_text"] == "Bedrock API Scripting API player events"
+
+    @pytest.mark.asyncio
+    async def test_formats_query_without_category(self, mock_vector_client: AsyncMock) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = BedrockApiSearchTool(vector_client=mock_vector_client)
+
+        await tool.ainvoke({"query": "player events"})
+
+        args = mock_vector_client.search_documents.await_args
+        assert args.kwargs["query_text"] == "Bedrock API player events"
+
+
+class TestComponentLookupTool:
+    @pytest.mark.asyncio
+    async def test_formats_query(self, mock_vector_client: AsyncMock) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = ComponentLookupTool(vector_client=mock_vector_client)
+
+        await tool.ainvoke({"component_name": "minecraft:behavior.float_wander"})
+
+        args = mock_vector_client.search_documents.await_args
+        assert (
+            args.kwargs["query_text"]
+            == "Bedrock component documentation for minecraft:behavior.float_wander"
         )
-        
-        # Test filtering with threshold 0.7
-        result = await search_tool_instance._find_similar_documents(
-            content="test content",
-            threshold=0.7
-        )
+        assert args.kwargs["top_k"] == 5  # default for this tool
+
+
+class TestConversionExamplesTool:
+    @pytest.mark.asyncio
+    async def test_formats_query(self, mock_vector_client: AsyncMock) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = ConversionExamplesTool(vector_client=mock_vector_client)
+
+        await tool.ainvoke({"query": "potion effects"})
+
+        args = mock_vector_client.search_documents.await_args
+        assert args.kwargs["query_text"] == "Java to Bedrock conversion example for potion effects"
+        assert args.kwargs["top_k"] == 5
+
+
+class TestSchemaValidationLookupTool:
+    @pytest.mark.asyncio
+    async def test_formats_query(self, mock_vector_client: AsyncMock) -> None:
+        mock_vector_client.search_documents.return_value = []
+        tool = SchemaValidationLookupTool(vector_client=mock_vector_client)
+
+        await tool.ainvoke({"schema_name": "entity definition"})
+
+        args = mock_vector_client.search_documents.await_args
+        assert args.kwargs["query_text"] == "Bedrock JSON schema for entity definition"
+        assert args.kwargs["top_k"] == 3  # default for this tool
+
+
+# ---------------------------------------------------------------------------
+# Pydantic args-schema validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_cls, bad_args, error_field",
+    [
+        # Empty / missing required string
+        (SemanticSearchTool, {"query": ""}, "query"),
+        (DocumentSearchTool, {"document_source": ""}, "document_source"),
+        (SimilaritySearchTool, {"content": ""}, "content"),
+        (BedrockApiSearchTool, {"query": ""}, "query"),
+        (ComponentLookupTool, {"component_name": ""}, "component_name"),
+        (ConversionExamplesTool, {"query": ""}, "query"),
+        (SchemaValidationLookupTool, {"schema_name": ""}, "schema_name"),
+        # Out-of-range numerics
+        (SemanticSearchTool, {"query": "x", "limit": 0}, "limit"),
+        (SemanticSearchTool, {"query": "x", "limit": 999}, "limit"),
+        (SimilaritySearchTool, {"content": "x", "threshold": 1.5}, "threshold"),
+        (SimilaritySearchTool, {"content": "x", "threshold": -0.1}, "threshold"),
+        # Forbidden extra field
+        (SemanticSearchTool, {"query": "x", "unexpected_field": 1}, "unexpected_field"),
+    ],
+)
+def test_typed_tool_rejects_invalid_args(
+    tool_cls: type, bad_args: Dict[str, Any], error_field: str, mock_vector_client: AsyncMock
+) -> None:
+    """Pydantic ``args_schema`` validates every required field and constraint."""
+    tool = tool_cls(vector_client=mock_vector_client)
+    with pytest.raises(ValidationError) as exc_info:
+        tool.invoke(bad_args)
+    assert error_field in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Fallback mechanism (module-level helper)
+# ---------------------------------------------------------------------------
+
+
+class TestAttemptFallbackSearch:
+    def test_disabled_returns_empty(self, disable_fallback: Any) -> None:
+        assert _attempt_fallback_search("q", 5) == []
+
+    def test_successful_import_wraps_string_result(self, enable_fallback: Any) -> None:
+        fake_instance = MagicMock()
+        fake_instance._run.return_value = "fallback results string"
+        fake_module = MagicMock()
+        setattr(fake_module, "WebSearchTool", MagicMock(return_value=fake_instance))
+
+        with patch("importlib.import_module", return_value=fake_module):
+            result = _attempt_fallback_search("q", 5)
+
         assert len(result) == 1
-        assert result[0]["id"] == "1"
+        assert result[0]["content"] == "fallback results string"
+        assert result[0]["document_source"] == "fallback_search"
 
+    def test_import_error_returns_empty(self, enable_fallback: Any) -> None:
+        with patch("importlib.import_module", side_effect=ImportError("boom")):
+            assert _attempt_fallback_search("q", 5) == []
+
+    def test_attribute_error_returns_empty(self, enable_fallback: Any) -> None:
+        # Use a real module-like object so getattr() raises AttributeError naturally
+        class _Empty:  # noqa: D401
+            pass
+
+        with patch("importlib.import_module", return_value=_Empty()):
+            assert _attempt_fallback_search("q", 5) == []
+
+    def test_generic_exception_returns_empty(self, enable_fallback: Any) -> None:
+        with patch("importlib.import_module", side_effect=RuntimeError("boom")):
+            assert _attempt_fallback_search("q", 5) == []
+
+    def test_search_service_error_propagates(self, enable_fallback: Any) -> None:
+        from tools.web_search_tool import SearchServiceError
+
+        fake_instance = MagicMock()
+        fake_instance._run.side_effect = SearchServiceError("upstream failure")
+        fake_module = MagicMock()
+        setattr(fake_module, "WebSearchTool", MagicMock(return_value=fake_instance))
+
+        with patch("importlib.import_module", return_value=fake_module):
+            with pytest.raises(SearchServiceError):
+                _attempt_fallback_search("q", 5)
+
+    def test_non_string_result_returns_empty(self, enable_fallback: Any) -> None:
+        fake_instance = MagicMock()
+        fake_instance._run.return_value = ["not a string"]
+        fake_module = MagicMock()
+        setattr(fake_module, "WebSearchTool", MagicMock(return_value=fake_instance))
+
+        with patch("importlib.import_module", return_value=fake_module):
+            assert _attempt_fallback_search("q", 5) == []
+
+
+# ---------------------------------------------------------------------------
+# Module-level payload helpers (direct unit tests)
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadHelpers:
     @pytest.mark.asyncio
-    async def test_close_async(self, search_tool_instance):
-        """Test close method with async vector_client.close."""
-        mock_close = AsyncMock()
-        search_tool_instance.vector_client.close = mock_close
-        
-        await search_tool_instance.close()
-        mock_close.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_close_sync(self, search_tool_instance):
-        """Test close method with sync vector_client.close."""
-        mock_close = MagicMock()
-        # Ensure it's not a coroutine function
-        search_tool_instance.vector_client.close = mock_close
-        
-        await search_tool_instance.close()
-        mock_close.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_close_no_method(self, search_tool_instance):
-        """Test close method when vector_client has no close method."""
-        delattr(search_tool_instance.vector_client, "close")
-        # Should not raise exception
-        await search_tool_instance.close()
-
-    @pytest.mark.asyncio
-    async def test_close_no_client(self, search_tool_instance):
-        """Test close method when vector_client is missing."""
-        delattr(search_tool_instance, "vector_client")
-        # Should not raise exception
-        await search_tool_instance.close()
-
-
-class TestSearchToolErrorHandling:
-    """Test error handling in SearchTool."""
-    
-    @pytest.mark.asyncio
-    async def test_json_decode_error_handling(self, search_tool_instance):
-        """Test handling of invalid JSON input."""
-        # Invalid JSON should be treated as string query in semantic_search
-        search_tool_instance._perform_semantic_search = AsyncMock(return_value=[])
-        result = await SearchTool.semantic_search.func("not a json string")
-        result_data = json.loads(result)
-        assert result_data.get("query") == "not a json string"
-
-        # Test document_search with invalid JSON
-        search_tool_instance._search_by_document_source = AsyncMock(return_value=[])
-        result = await SearchTool.document_search.func("not a json string")
-        result_data = json.loads(result)
-        assert result_data.get("document_source") == "not a json string"
-
-        # Test similarity_search with invalid JSON
-        search_tool_instance._find_similar_documents = AsyncMock(return_value=[])
-        result = await SearchTool.similarity_search.func("not a json string")
-        result_data = json.loads(result)
-        assert "reference_content" in result_data
-
-    @pytest.mark.asyncio
-    async def test_non_string_input_handling(self, search_tool_instance):
-        """Test handling of non-string input (e.g. dict)."""
-        search_tool_instance._perform_semantic_search = AsyncMock(return_value=[])
-        
-        # Test semantic_search with dict
-        query_dict = {"query": "test"}
-        result = await SearchTool.semantic_search.func(query_dict)
-        assert "query" in json.loads(result)
-
-        # Test document_search with dict
-        search_tool_instance._search_by_document_source = AsyncMock(return_value=[])
-        result = await SearchTool.document_search.func({"document_source": "src"})
-        assert "document_source" in json.loads(result)
-
-        # Test similarity_search with dict
-        search_tool_instance._find_similar_documents = AsyncMock(return_value=[])
-        result = await SearchTool.similarity_search.func({"content": "cont"})
-        assert "reference_content" in json.loads(result)
-
-    @pytest.mark.asyncio
-    async def test_all_tools_parameter_validation(self, search_tool_instance):
-        """Test parameter validation for all search tools."""
-        # bedrock_api_search
-        result = await SearchTool.bedrock_api_search.func("")
-        assert "error" in json.loads(result)
-        
-        # component_lookup
-        result = await SearchTool.component_lookup.func("")
-        assert "error" in json.loads(result)
-        
-        # conversion_examples
-        result = await SearchTool.conversion_examples.func("")
-        assert "error" in json.loads(result)
-        
-        # schema_validation_lookup
-        result = await SearchTool.schema_validation_lookup.func("")
-        assert "error" in json.loads(result)
-
-    @pytest.mark.asyncio
-    async def test_all_tools_exception_handling(self, search_tool_instance):
-        """Test exception handling for all search tools."""
-        # Use a real instance but mock its dependencies to fail, or patch a deeper method
-        with patch.object(SearchTool, '_perform_semantic_search', side_effect=Exception("Semantic fail")):
-            for tool_func in [
-                SearchTool.bedrock_api_search.func,
-                SearchTool.component_lookup.func,
-                SearchTool.conversion_examples.func,
-                SearchTool.schema_validation_lookup.func
-            ]:
-                result = await tool_func("test")
-                assert "error" in json.loads(result)
-
-    @pytest.mark.asyncio
-    async def test_non_string_input_all_tools(self, search_tool_instance):
-        """Test non-string input for all search tools."""
-        search_tool_instance._perform_semantic_search = AsyncMock(return_value=[])
-        
-        # bedrock_api_search with dict
-        result = await SearchTool.bedrock_api_search.func({"query": "q"})
-        assert "query" in result
-
-        # component_lookup with dict
-        result = await SearchTool.component_lookup.func({"component_name": "c"})
-        assert "query" in result
-
-        # conversion_examples with dict
-        result = await SearchTool.conversion_examples.func({"query": "q"})
-        assert "query" in result
-
-        # schema_validation_lookup with dict
-        result = await SearchTool.schema_validation_lookup.func({"schema_name": "s"})
-        assert "query" in result
-
-    @pytest.mark.asyncio
-    async def test_private_methods_exceptions(self, search_tool_instance):
-        """Test exception handling in private methods."""
-        search_tool_instance.vector_client.search_documents = AsyncMock(side_effect=Exception("DB Error"))
-        
-        # _perform_semantic_search
-        res1 = await search_tool_instance._perform_semantic_search("q")
-        assert res1 == []
-        
-        # _search_by_document_source
-        res2 = await search_tool_instance._search_by_document_source("s")
-        assert res2 == []
-        
-        # _find_similar_documents
-        res3 = await search_tool_instance._find_similar_documents("c")
-        assert res3 == []
-
-    @pytest.mark.asyncio
-    async def test_json_parsing_edge_cases(self, search_tool_instance):
-        """Test JSON parsing edge cases in tools."""
-        search_tool_instance._perform_semantic_search = AsyncMock(return_value=[])
-        
-        # bedrock_api_search with JSON
-        result = await SearchTool.bedrock_api_search.func(json.dumps({"query": "q", "api_category": "c"}))
-        assert "query" in result
-        
-        # component_lookup with JSON
-        result = await SearchTool.component_lookup.func(json.dumps({"component_name": "c"}))
-        assert "query" in result
-
-        # conversion_examples with JSON
-        result = await SearchTool.conversion_examples.func(json.dumps({"query": "q"}))
-        assert "query" in result
-
-        # schema_validation_lookup with JSON
-        result = await SearchTool.schema_validation_lookup.func(json.dumps({"schema_name": "s"}))
-        assert "query" in result
-
-
-class TestSearchToolIntegration:
-    """Integration tests for SearchTool."""
-    
-    @pytest.mark.asyncio
-    async def test_multiple_searches_in_sequence(self, search_tool_instance, sample_search_results):
-        """Test running multiple searches in sequence."""
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=sample_search_results
+    async def test_semantic_payload_serialises_results(
+        self, mock_vector_client: AsyncMock, sample_search_results: List[Dict[str, Any]]
+    ) -> None:
+        mock_vector_client.search_documents.return_value = sample_search_results
+        raw = await _semantic_search_payload(
+            mock_vector_client, query="q", limit=10, document_source=None
         )
-        
-        queries = ["block", "entity", "conversion"]
-        results = []
-        
-        for query in queries:
-            result = await SearchTool.semantic_search.func(query)
-            results.append(json.loads(result))
-        
-        assert len(results) == len(queries)
-        assert all("results" in r for r in results)
-    
+        payload = json.loads(raw)
+        assert payload["query"] == "q"
+        assert payload["total_results"] == 3
+
     @pytest.mark.asyncio
-    async def test_search_with_various_input_formats(self, search_tool_instance, sample_search_results):
-        """Test search with various input formats."""
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=sample_search_results
+    async def test_document_payload_includes_metadata(self, mock_vector_client: AsyncMock) -> None:
+        mock_vector_client.search_documents.return_value = [{"id": "1"}]
+        raw = await _document_search_payload(
+            mock_vector_client, document_source="src", content_type="text", limit=10
         )
-        
-        # Test JSON input
-        json_input = json.dumps({"query": "test", "limit": 5})
-        result1 = await SearchTool.semantic_search.func(json_input)
-        
-        # Test string input
-        result2 = await SearchTool.semantic_search.func("test")
-        
-        # Both should return valid results
-        assert all(isinstance(json.loads(r), dict) for r in [result1, result2])
+        payload = json.loads(raw)
+        assert payload["document_source"] == "src"
+        assert payload["content_type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_similarity_payload_truncates_preview(
+        self, mock_vector_client: AsyncMock
+    ) -> None:
+        mock_vector_client.search_documents.return_value = []
+        raw = await _similarity_search_payload(
+            mock_vector_client, content="x" * 200, threshold=0.0, limit=5
+        )
+        payload = json.loads(raw)
+        assert len(payload["reference_content"]) == 103
+        assert payload["reference_content"].endswith("...")
 
 
-class TestSearchToolResultFormatting:
-    """Test result formatting in SearchTool."""
-    
+# ---------------------------------------------------------------------------
+# SearchTool.close()
+# ---------------------------------------------------------------------------
+
+
+class TestSearchToolClose:
     @pytest.mark.asyncio
-    async def test_semantic_search_result_format(self, search_tool_instance, sample_search_results):
-        """Test semantic search result format."""
-        search_tool_instance._perform_semantic_search = AsyncMock(
-            return_value=sample_search_results
-        )
-        
-        result = await SearchTool.semantic_search.func("test")
-        result_data = json.loads(result)
-        
-        # Check required fields
-        assert "query" in result_data
-        assert "results" in result_data or "error" in result_data
-        assert "total_results" in result_data
-        
-        # Check result items have required fields
-        for item in result_data["results"]:
-            assert "id" in item
-            assert "content" in item
+    async def test_close_async_client(self) -> None:
+        client = AsyncMock(spec=VectorDBClient)
+        client.close = AsyncMock()
+        SearchTool._instance = None
+        with patch("tools.search_tool.VectorDBClient", return_value=client):
+            facade = SearchTool()
+            facade.vector_client = client  # ensure direct reference
+        await facade.close()
+        client.close.assert_awaited_once()
+        SearchTool._instance = None
+
+    @pytest.mark.asyncio
+    async def test_close_sync_client(self) -> None:
+        client = MagicMock(spec=VectorDBClient)
+        # MagicMock.close is a sync MagicMock by default
+        SearchTool._instance = None
+        with patch("tools.search_tool.VectorDBClient", return_value=client):
+            facade = SearchTool()
+            facade.vector_client = client
+        await facade.close()
+        client.close.assert_called_once()
+        SearchTool._instance = None
+
+    @pytest.mark.asyncio
+    async def test_close_no_client_is_noop(self) -> None:
+        SearchTool._instance = None
+        with patch("tools.search_tool.VectorDBClient"):
+            facade = SearchTool()
+        delattr(facade, "vector_client")
+        await facade.close()  # should not raise
+        SearchTool._instance = None
+
+    @pytest.mark.asyncio
+    async def test_close_client_without_close_method(self) -> None:
+        client = MagicMock(spec=[])  # no close attribute
+        SearchTool._instance = None
+        with patch("tools.search_tool.VectorDBClient", return_value=client):
+            facade = SearchTool()
+            facade.vector_client = client
+        await facade.close()  # should not raise
+        SearchTool._instance = None

--- a/ai-engine/tests/unit/test_rag_service.py
+++ b/ai-engine/tests/unit/test_rag_service.py
@@ -97,3 +97,43 @@ def test_rag_ainvoke_helper_wraps_chain():
     llm = FakeListChatModel(responses=["sum", "ans"])
     out = asyncio.run(ainvoke("test query", llm=llm, search_tool=_StubSearchTool()))
     assert out, "ainvoke() must return a non-empty answer"
+
+
+@pytest.mark.asyncio
+async def test_rag_chain_default_search_tool_routes_through_typed_basetool(monkeypatch):
+    """Regression for Phase 8 A: ``build_rag_chain(search_tool=None)`` must
+    resolve to the typed :class:`SemanticSearchTool` (a LangChain ``BaseTool``)
+    and dispatch through Path 1 of ``_make_search_step``.
+
+    Prior to the typed-args migration the default resolved to the legacy
+    ``SearchTool`` facade, which forced the brittle Path 2 descriptor branch
+    that invoked ``semantic_search.ainvoke({"query_data": query})``.
+    """
+    from services.rag_service import build_rag_chain
+    from tools.search_tool import SearchTool, SemanticSearchTool
+
+    SearchTool._instance = None  # force fresh facade
+    captured: dict = {}
+
+    async def fake_arun(self, query, limit=10, document_source=None):
+        captured["query"] = query
+        captured["limit"] = limit
+        captured["tool_type"] = type(self).__name__
+        return json.dumps({"results": [{"text": "hit-from-typed-tool", "source": "doc.md"}]})
+
+    monkeypatch.setattr(SemanticSearchTool, "_arun", fake_arun)
+
+    llm = FakeListChatModel(
+        responses=[
+            "Research summary: typed tool was invoked.",
+            "Final answer: contains hit-from-typed-tool.",
+        ]
+    )
+
+    chain = build_rag_chain(llm=llm)  # <-- search_tool=None on purpose
+    result = await chain.ainvoke({"query": "How do I port a Java block?"})
+
+    assert captured["query"] == "How do I port a Java block?"
+    assert captured["tool_type"] == "SemanticSearchTool"
+    assert "hit-from-typed-tool" in str(result)
+    SearchTool._instance = None

--- a/ai-engine/tools/search_tool.py
+++ b/ai-engine/tools/search_tool.py
@@ -1,15 +1,29 @@
+"""Typed ``BaseTool`` implementations for the RAG workflow (issue #1201, Phase 8 A).
+
+This module exposes seven LangChain ``BaseTool`` subclasses backed by the
+shared ``VectorDBClient``. Each tool declares a Pydantic ``args_schema`` so
+chat models with native tool-calling can invoke it with structured arguments
+instead of a JSON-encoded ``query_data: str`` blob.
+
+Backwards compatibility:
+
+* ``SearchTool`` is preserved as a facade. ``SearchTool.get_instance()`` still
+  vends a process-wide singleton; ``SearchTool().get_tools()`` returns the
+  seven typed ``BaseTool`` instances; ``SearchTool().semantic_search`` exposes
+  the default ``SemanticSearchTool`` so the RAG service can route through
+  the typed ``BaseTool`` branch of ``services.rag_service._make_search_step``.
 """
-SearchTool implementation for RAG workflow agents.
-Provides semantic search capabilities using the existing vector database with fallback mechanism.
-"""
+
+from __future__ import annotations
 
 import asyncio
 import importlib
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
-from langchain_core.tools import tool
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 from utils.config import Config
 from utils.vector_db_client import VectorDBClient
@@ -17,578 +31,618 @@ from utils.vector_db_client import VectorDBClient
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Pydantic args schemas
+# ---------------------------------------------------------------------------
+
+
+class SemanticSearchInput(BaseModel):
+    """Args for ``SemanticSearchTool``."""
+
+    model_config = ConfigDict(extra="forbid")
+    query: str = Field(min_length=1, description="Free-text search query.")
+    limit: int = Field(default=10, ge=1, le=50, description="Maximum results.")
+    document_source: Optional[str] = Field(default=None, description="Optional source filter.")
+
+
+class DocumentSearchInput(BaseModel):
+    """Args for ``DocumentSearchTool``."""
+
+    model_config = ConfigDict(extra="forbid")
+    document_source: str = Field(min_length=1, description="Document source identifier.")
+    content_type: Optional[str] = Field(
+        default=None, description="Optional content-type filter applied client-side."
+    )
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class SimilaritySearchInput(BaseModel):
+    """Args for ``SimilaritySearchTool``."""
+
+    model_config = ConfigDict(extra="forbid")
+    content: str = Field(min_length=1, description="Reference content to match against.")
+    threshold: float = Field(default=0.8, ge=0.0, le=1.0)
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class BedrockApiSearchInput(BaseModel):
+    """Args for ``BedrockApiSearchTool``."""
+
+    model_config = ConfigDict(extra="forbid")
+    query: str = Field(min_length=1, description="Bedrock API search query.")
+    api_category: Optional[str] = Field(
+        default=None,
+        description="Optional Bedrock category, e.g. 'Scripting API', 'Gametest Framework'.",
+    )
+    limit: int = Field(default=10, ge=1, le=50)
+
+
+class ComponentLookupInput(BaseModel):
+    """Args for ``ComponentLookupTool``."""
+
+    model_config = ConfigDict(extra="forbid")
+    component_name: str = Field(
+        min_length=1,
+        description="Bedrock component identifier, e.g. 'minecraft:behavior.float_wander'.",
+    )
+    limit: int = Field(default=5, ge=1, le=50)
+
+
+class ConversionExamplesInput(BaseModel):
+    """Args for ``ConversionExamplesTool``."""
+
+    model_config = ConfigDict(extra="forbid")
+    query: str = Field(min_length=1, description="Element / mechanic to convert.")
+    limit: int = Field(default=5, ge=1, le=50)
+
+
+class SchemaValidationLookupInput(BaseModel):
+    """Args for ``SchemaValidationLookupTool``."""
+
+    model_config = ConfigDict(extra="forbid")
+    schema_name: str = Field(
+        min_length=1, description="Bedrock JSON schema topic, e.g. 'entity definition'."
+    )
+    limit: int = Field(default=3, ge=1, le=50)
+
+
+# ---------------------------------------------------------------------------
+# Shared async helpers (single source of truth — no JSON re-encoding round-trip)
+# ---------------------------------------------------------------------------
+
+
+async def _semantic_search_payload(
+    vector_client: VectorDBClient,
+    *,
+    query: str,
+    limit: int,
+    document_source: Optional[str] = None,
+) -> str:
+    """Run a semantic search and serialise the canonical response shape."""
+    try:
+        results = await vector_client.search_documents(
+            query_text=query, top_k=limit, document_source_filter=document_source
+        )
+    except Exception as exc:
+        logger.error("Semantic search execution failed: %s", exc)
+        return json.dumps({"error": f"Semantic search failed: {exc}", "query": query})
+
+    if not results and Config.SEARCH_FALLBACK_ENABLED:
+        fallback = _attempt_fallback_search(query, limit)
+        if fallback:
+            results = fallback
+            logger.info("Fallback search returned %d results", len(results))
+
+    return json.dumps({"query": query, "results": results, "total_results": len(results)})
+
+
+async def _document_search_payload(
+    vector_client: VectorDBClient,
+    *,
+    document_source: str,
+    content_type: Optional[str],
+    limit: int,
+) -> str:
+    """Run a document-source search and serialise the canonical response shape."""
+    try:
+        results = await vector_client.search_documents(
+            query_text=document_source, top_k=limit, document_source_filter=document_source
+        )
+        if content_type and results:
+            results = [
+                r
+                for r in results
+                if r.get("metadata", {}).get("content_type") == content_type
+                or r.get("content_type") == content_type
+            ]
+    except Exception as exc:
+        logger.error("Document search failed: %s", exc)
+        return json.dumps(
+            {"error": f"Document search failed: {exc}", "document_source": document_source}
+        )
+
+    if not results and Config.SEARCH_FALLBACK_ENABLED:
+        fallback = _attempt_fallback_search(document_source, limit)
+        if fallback:
+            results = fallback
+            logger.info("Fallback search returned %d results", len(results))
+
+    return json.dumps(
+        {
+            "document_source": document_source,
+            "content_type": content_type,
+            "results": results,
+            "total_results": len(results),
+        }
+    )
+
+
+async def _similarity_search_payload(
+    vector_client: VectorDBClient,
+    *,
+    content: str,
+    threshold: float,
+    limit: int,
+) -> str:
+    """Run a similarity search and serialise the canonical response shape."""
+    try:
+        results = await vector_client.search_documents(query_text=content, top_k=limit)
+        if threshold > 0 and results:
+            results = [r for r in results if r.get("similarity_score", 0.0) >= threshold]
+    except Exception as exc:
+        logger.error("Similarity search failed: %s", exc)
+        return json.dumps(
+            {"error": f"Similarity search failed: {exc}", "content_preview": content[:100]}
+        )
+
+    if not results and Config.SEARCH_FALLBACK_ENABLED:
+        fallback = _attempt_fallback_search(content[:100], limit)
+        if fallback:
+            results = fallback
+            logger.info("Fallback search returned %d results", len(results))
+
+    preview = content[:100] + "..." if len(content) > 100 else content
+    return json.dumps(
+        {
+            "reference_content": preview,
+            "threshold": threshold,
+            "results": results,
+            "total_results": len(results),
+        }
+    )
+
+
+def _attempt_fallback_search(query: str, limit: int = 10) -> List[Dict[str, Any]]:
+    """Attempt to use the configured fallback search tool.
+
+    Mirrors the legacy behaviour: dynamically imports ``tools.<FALLBACK_SEARCH_TOOL>``,
+    instantiates ``<PascalCase>``, and adapts the result into the standard schema.
+    Returns ``[]`` on any failure so callers can surface "no results" cleanly.
+    """
+    if not Config.SEARCH_FALLBACK_ENABLED:
+        logger.info("Fallback search is disabled")
+        return []
+
+    tool_name = Config.FALLBACK_SEARCH_TOOL
+    module_path = f"tools.{tool_name}"
+    class_name = "".join(part.capitalize() for part in tool_name.split("_"))
+    logger.info("Attempting fallback search with %s.%s", module_path, class_name)
+
+    try:
+        module = importlib.import_module(module_path)
+        fallback_class = getattr(module, class_name)
+        fallback_instance = fallback_class()
+        fallback_result = fallback_instance._run(query)
+    except ImportError as exc:
+        logger.error("Fallback module '%s' not found: %s", module_path, exc)
+        return []
+    except AttributeError as exc:
+        logger.error("Fallback class '%s' not found in '%s': %s", class_name, module_path, exc)
+        return []
+    except Exception as exc:
+        # Re-raise SearchServiceError so callers distinguish service failure from
+        # genuinely empty results; everything else returns []. The import is local
+        # to avoid pulling web_search_tool at module-load time.
+        try:
+            from tools.web_search_tool import SearchServiceError
+
+            if isinstance(exc, SearchServiceError):
+                raise
+        except ImportError:
+            pass
+        logger.error("Error during fallback to %s: %s", tool_name, exc)
+        return []
+
+    if isinstance(fallback_result, str):
+        return [
+            {
+                "id": "fallback_0",
+                "content": fallback_result,
+                "document_source": "fallback_search",
+                "similarity_score": 0.7,
+                "metadata": {
+                    "indexed_at": "2025-01-09T00:00:00Z",
+                    "content_type": "text",
+                    "source": "fallback",
+                },
+            }
+        ][:limit]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Typed BaseTool subclasses
+# ---------------------------------------------------------------------------
+
+
+class _BaseSearchTool(BaseTool):
+    """Common scaffolding: holds an injected ``VectorDBClient``.
+
+    The injected client is stored as a ``PrivateAttr`` so it is not a Pydantic
+    field and cannot accidentally appear in ``args_schema``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    _vector_client: VectorDBClient = PrivateAttr()
+
+    def __init__(self, vector_client: Optional[VectorDBClient] = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._vector_client = vector_client if vector_client is not None else VectorDBClient()
+
+    @property
+    def vector_client(self) -> VectorDBClient:
+        """Public accessor for the injected client (used by tests)."""
+        return self._vector_client
+
+    @staticmethod
+    def _run_async(coro: Any) -> Any:
+        """Drive an awaitable from a sync caller; refuse if a loop is running."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+        raise RuntimeError(
+            "Sync invoke() called from inside a running event loop; use ainvoke() instead."
+        )
+
+
+class SemanticSearchTool(_BaseSearchTool):
+    """Perform semantic search across indexed documents."""
+
+    name: str = "semantic_search"
+    description: str = (
+        "Perform semantic search across indexed documents. "
+        "Args: query (str, required), limit (int 1-50, default 10), "
+        "document_source (optional str)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = SemanticSearchInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        query: str,
+        limit: int = 10,
+        document_source: Optional[str] = None,
+    ) -> str:
+        return await _semantic_search_payload(
+            self._vector_client,
+            query=query,
+            limit=limit,
+            document_source=document_source,
+        )
+
+    def _run(  # type: ignore[override]
+        self,
+        query: str,
+        limit: int = 10,
+        document_source: Optional[str] = None,
+    ) -> str:
+        return self._run_async(
+            self._arun(query=query, limit=limit, document_source=document_source)
+        )
+
+
+class DocumentSearchTool(_BaseSearchTool):
+    """Search for documents by source identifier."""
+
+    name: str = "document_search"
+    description: str = (
+        "Search for specific documents by source. "
+        "Args: document_source (str, required), content_type (optional str), "
+        "limit (int 1-50, default 10)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = DocumentSearchInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        document_source: str,
+        content_type: Optional[str] = None,
+        limit: int = 10,
+    ) -> str:
+        return await _document_search_payload(
+            self._vector_client,
+            document_source=document_source,
+            content_type=content_type,
+            limit=limit,
+        )
+
+    def _run(  # type: ignore[override]
+        self,
+        document_source: str,
+        content_type: Optional[str] = None,
+        limit: int = 10,
+    ) -> str:
+        return self._run_async(
+            self._arun(document_source=document_source, content_type=content_type, limit=limit)
+        )
+
+
+class SimilaritySearchTool(_BaseSearchTool):
+    """Find documents similar to a given content snippet."""
+
+    name: str = "similarity_search"
+    description: str = (
+        "Find documents similar to a content snippet. "
+        "Args: content (str, required), threshold (float 0.0-1.0, default 0.8), "
+        "limit (int 1-50, default 10)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = SimilaritySearchInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        content: str,
+        threshold: float = 0.8,
+        limit: int = 10,
+    ) -> str:
+        return await _similarity_search_payload(
+            self._vector_client, content=content, threshold=threshold, limit=limit
+        )
+
+    def _run(  # type: ignore[override]
+        self,
+        content: str,
+        threshold: float = 0.8,
+        limit: int = 10,
+    ) -> str:
+        return self._run_async(self._arun(content=content, threshold=threshold, limit=limit))
+
+
+class BedrockApiSearchTool(_BaseSearchTool):
+    """Search Bedrock Edition API documentation via semantic search."""
+
+    name: str = "bedrock_api_search"
+    description: str = (
+        "Search Bedrock Edition API documentation. "
+        "Args: query (str, required), api_category (optional str, e.g. 'Scripting API'), "
+        "limit (int 1-50, default 10)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = BedrockApiSearchInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        query: str,
+        api_category: Optional[str] = None,
+        limit: int = 10,
+    ) -> str:
+        category_part = f" {api_category}" if api_category else ""
+        formatted_query = f"Bedrock API{category_part} {query}".strip()
+        logger.info("Bedrock API search for: %s", formatted_query)
+        return await _semantic_search_payload(
+            self._vector_client, query=formatted_query, limit=limit
+        )
+
+    def _run(  # type: ignore[override]
+        self,
+        query: str,
+        api_category: Optional[str] = None,
+        limit: int = 10,
+    ) -> str:
+        return self._run_async(self._arun(query=query, api_category=api_category, limit=limit))
+
+
+class ComponentLookupTool(_BaseSearchTool):
+    """Lookup documentation for a specific Bedrock component."""
+
+    name: str = "component_lookup"
+    description: str = (
+        "Lookup Bedrock component documentation. "
+        "Args: component_name (str, required), limit (int 1-50, default 5)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = ComponentLookupInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        component_name: str,
+        limit: int = 5,
+    ) -> str:
+        formatted_query = f"Bedrock component documentation for {component_name}"
+        logger.info("Component lookup for: %s", formatted_query)
+        return await _semantic_search_payload(
+            self._vector_client, query=formatted_query, limit=limit
+        )
+
+    def _run(  # type: ignore[override]
+        self,
+        component_name: str,
+        limit: int = 5,
+    ) -> str:
+        return self._run_async(self._arun(component_name=component_name, limit=limit))
+
+
+class ConversionExamplesTool(_BaseSearchTool):
+    """Search Java→Bedrock conversion examples."""
+
+    name: str = "conversion_examples"
+    description: str = (
+        "Search Java→Bedrock conversion examples. "
+        "Args: query (str, required), limit (int 1-50, default 5)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = ConversionExamplesInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        query: str,
+        limit: int = 5,
+    ) -> str:
+        formatted_query = f"Java to Bedrock conversion example for {query}"
+        logger.info("Conversion examples search for: %s", formatted_query)
+        return await _semantic_search_payload(
+            self._vector_client, query=formatted_query, limit=limit
+        )
+
+    def _run(  # type: ignore[override]
+        self,
+        query: str,
+        limit: int = 5,
+    ) -> str:
+        return self._run_async(self._arun(query=query, limit=limit))
+
+
+class SchemaValidationLookupTool(_BaseSearchTool):
+    """Lookup Bedrock JSON schema information."""
+
+    name: str = "schema_validation_lookup"
+    description: str = (
+        "Lookup Bedrock JSON schema documentation. "
+        "Args: schema_name (str, required), limit (int 1-50, default 3)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = SchemaValidationLookupInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        schema_name: str,
+        limit: int = 3,
+    ) -> str:
+        formatted_query = f"Bedrock JSON schema for {schema_name}"
+        logger.info("Schema validation lookup for: %s", formatted_query)
+        return await _semantic_search_payload(
+            self._vector_client, query=formatted_query, limit=limit
+        )
+
+    def _run(  # type: ignore[override]
+        self,
+        schema_name: str,
+        limit: int = 3,
+    ) -> str:
+        return self._run_async(self._arun(schema_name=schema_name, limit=limit))
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatible facade
+# ---------------------------------------------------------------------------
+
+
 class SearchTool:
-    """
-    SearchTool for semantic search across indexed documents.
-    Integrates with the existing vector database infrastructure and includes fallback mechanism.
+    """Process-wide facade preserved so existing call sites keep working.
+
+    ``get_tools()`` returns ``BaseTool`` instances; ``get_instance()`` returns
+    a process-wide singleton; ``semantic_search`` exposes the default typed
+    semantic-search tool so the RAG service can dispatch via Path 1
+    (``BaseTool.ainvoke``).
     """
 
-    _instance = None
+    _instance: Optional[SearchTool] = None
 
-    def __init__(self):
-        """Initialize the SearchTool with vector database client."""
-        self.vector_client = VectorDBClient()
-        logger.info("SearchTool initialized")
+    def __init__(self, vector_client: Optional[VectorDBClient] = None) -> None:
+        self.vector_client = vector_client if vector_client is not None else VectorDBClient()
+        self._semantic = SemanticSearchTool(vector_client=self.vector_client)
+        self._document = DocumentSearchTool(vector_client=self.vector_client)
+        self._similarity = SimilaritySearchTool(vector_client=self.vector_client)
+        self._bedrock_api = BedrockApiSearchTool(vector_client=self.vector_client)
+        self._component = ComponentLookupTool(vector_client=self.vector_client)
+        self._conversion = ConversionExamplesTool(vector_client=self.vector_client)
+        self._schema = SchemaValidationLookupTool(vector_client=self.vector_client)
+        logger.info("SearchTool initialised with typed BaseTool implementations")
 
     @classmethod
-    def get_instance(cls):
-        """Get singleton instance of SearchTool."""
+    def get_instance(cls) -> SearchTool:
         if cls._instance is None:
             cls._instance = cls()
         return cls._instance
 
-    def get_tools(self) -> List:
-        """Return list of available search tools."""
+    def get_tools(self) -> List[BaseTool]:
         return [
-            SearchTool.semantic_search,
-            SearchTool.document_search,
-            SearchTool.similarity_search,
-            SearchTool.bedrock_api_search,
-            SearchTool.component_lookup,
-            SearchTool.conversion_examples,
-            SearchTool.schema_validation_lookup,
+            self._semantic,
+            self._document,
+            self._similarity,
+            self._bedrock_api,
+            self._component,
+            self._conversion,
+            self._schema,
         ]
 
-    @tool
-    @staticmethod
-    async def semantic_search(query_data: str) -> str:
-        """
-        Perform semantic search across indexed documents.
-
-        Args:
-            query_data: JSON string containing search query and optional filters
-
-        Returns:
-            JSON string with search results
-        """
-        tool_instance = SearchTool.get_instance()
-
-        try:
-            # Handle both JSON string and direct inputs
-            if isinstance(query_data, str):
-                try:
-                    data = json.loads(query_data)
-                except json.JSONDecodeError:
-                    data = {"query": query_data}
-            else:
-                data = query_data
-
-            query = data.get("query", "")
-            limit = data.get("limit", 10)
-            document_source = data.get("document_source", None)
-
-            if not query:
-                return json.dumps({"error": "Query is required for semantic search"})
-
-            # Perform semantic search using vector database
-            results = await tool_instance._perform_semantic_search(
-                query=query, limit=limit, document_source=document_source
-            )
-
-            # Check if results are insufficient and fallback is enabled
-            if not results and Config.SEARCH_FALLBACK_ENABLED:
-                logger.info("Primary semantic search returned no results, attempting fallback")
-                fallback_results = tool_instance._attempt_fallback_search(query, limit)
-                if fallback_results:
-                    results = fallback_results
-                    logger.info(f"Fallback search returned {len(results)} results")
-
-            response = {"query": query, "results": results, "total_results": len(results)}
-
-            logger.info(f"Semantic search completed for query: {query}")
-            return json.dumps(response)
-
-        except Exception as e:
-            logger.error(f"Semantic search failed: {str(e)}")
-            error_response = {"error": f"Semantic search failed: {str(e)}", "query": query_data}
-            return json.dumps(error_response)
-
-    @tool
-    @staticmethod
-    async def document_search(query_data: str) -> str:
-        """
-        Search for specific documents by source or content type.
-
-        Args:
-            query_data: JSON string containing search criteria
-
-        Returns:
-            JSON string with matching documents
-        """
-        tool_instance = SearchTool.get_instance()
-
-        try:
-            if isinstance(query_data, str):
-                try:
-                    data = json.loads(query_data)
-                except json.JSONDecodeError:
-                    data = {"document_source": query_data}
-            else:
-                data = query_data
-
-            document_source = data.get("document_source", "")
-            content_type = data.get("content_type", None)
-
-            if not document_source:
-                return json.dumps({"error": "Document source is required for document search"})
-
-            # Search for documents by source
-            results = await tool_instance._search_by_document_source(
-                document_source=document_source,
-                content_type=content_type,  # content_type filter might be applied client-side if needed
-                limit=data.get("limit", 10),  # Pass limit
-            )
-
-            # Check if results are insufficient and fallback is enabled
-            if not results and Config.SEARCH_FALLBACK_ENABLED:
-                logger.info("Primary document search returned no results, attempting fallback")
-                fallback_results = tool_instance._attempt_fallback_search(document_source, 10)
-                if fallback_results:
-                    results = fallback_results
-                    logger.info(f"Fallback search returned {len(results)} results")
-
-            response = {
-                "document_source": document_source,
-                "content_type": content_type,
-                "results": results,
-                "total_results": len(results),
-            }
-
-            logger.info(f"Document search completed for source: {document_source}")
-            return json.dumps(response)
-
-        except Exception as e:
-            logger.error(f"Document search failed: {str(e)}")
-            error_response = {"error": f"Document search failed: {str(e)}", "query": query_data}
-            return json.dumps(error_response)
-
-    @tool
-    @staticmethod
-    async def similarity_search(query_data: str) -> str:
-        """
-        Find documents similar to a given document or content.
-
-        Args:
-            query_data: JSON string containing reference content
-
-        Returns:
-            JSON string with similar documents
-        """
-        tool_instance = SearchTool.get_instance()
-
-        try:
-            if isinstance(query_data, str):
-                try:
-                    data = json.loads(query_data)
-                except json.JSONDecodeError:
-                    data = {"content": query_data}
-            else:
-                data = query_data
-
-            content = data.get("content", "")
-            threshold = data.get("threshold", 0.8)
-            limit = data.get("limit", 10)
-
-            if not content:
-                return json.dumps({"error": "Content is required for similarity search"})
-
-            # Find similar documents
-            results = await tool_instance._find_similar_documents(
-                content=content,
-                threshold=threshold,  # threshold might be applied client-side if needed
-                limit=limit,
-            )
-
-            # Check if results are insufficient and fallback is enabled
-            if not results and Config.SEARCH_FALLBACK_ENABLED:
-                logger.info("Primary similarity search returned no results, attempting fallback")
-                fallback_results = tool_instance._attempt_fallback_search(content[:100], limit)
-                if fallback_results:
-                    results = fallback_results
-                    logger.info(f"Fallback search returned {len(results)} results")
-
-            response = {
-                "reference_content": content[:100] + "..." if len(content) > 100 else content,
-                "threshold": threshold,
-                "results": results,
-                "total_results": len(results),
-            }
-
-            logger.info(f"Similarity search completed for content length: {len(content)}")
-            return json.dumps(response)
-
-        except Exception as e:
-            logger.error(f"Similarity search failed: {str(e)}")
-            error_response = {"error": f"Similarity search failed: {str(e)}", "query": query_data}
-            return json.dumps(error_response)
-
-    @tool
-    @staticmethod
-    async def bedrock_api_search(query_data: str) -> str:
-        """
-        Search for Bedrock Edition API documentation.
-        Input can be a simple query string or a JSON string:
-        '{"query": "player events", "api_category": "Scripting API"}'
-        or simply "player events".
-        `api_category` is optional and can be things like 'Scripting API', 'Gametest Framework', etc.
-        """
-        query = ""
-        api_category = None
-        try:
-            SearchTool.get_instance()
-            if isinstance(query_data, str):
-                try:
-                    data = json.loads(query_data)
-                    query = data.get("query", "")
-                    api_category = data.get("api_category")
-                except json.JSONDecodeError:
-                    query = query_data  # Treat as plain string query
-            else:  # Should not happen if called by LangChain with string arg
-                query = str(query_data)
-
-            if not query:
-                return json.dumps({"error": "Query parameter is required for Bedrock API search."})
-
-            formatted_query = f"Bedrock API {api_category if api_category else ''} {query}".strip()
-            logger.info(f"Bedrock API search for: {formatted_query}")
-
-            # Utilize existing semantic_search tool
-            return await SearchTool.semantic_search(
-                json.dumps(
-                    {
-                        "query": formatted_query,
-                        "limit": 10,  # Default limit for API search
-                    }
-                )
-            )
-        except Exception as e:
-            logger.error(f"Bedrock API search failed: {str(e)}")
-            return json.dumps(
-                {"error": f"Bedrock API search failed: {str(e)}", "original_query": query_data}
-            )
-
-    @tool
-    @staticmethod
-    async def component_lookup(query_data: str) -> str:
-        """
-        Lookup documentation for specific Bedrock Edition components (e.g., minecraft:loot, minecraft:behavior.float_wander).
-        Input can be a simple component name string or a JSON string:
-        '{"component_name": "minecraft:behavior.float_wander"}'
-        or simply "minecraft:behavior.float_wander".
-        """
-        component_name = ""
-        try:
-            SearchTool.get_instance()
-            if isinstance(query_data, str):
-                try:
-                    data = json.loads(query_data)
-                    component_name = data.get("component_name", "")
-                except json.JSONDecodeError:
-                    component_name = query_data
-            else:
-                component_name = str(query_data)
-
-            if not component_name:
-                return json.dumps({"error": "Component name is required for component lookup."})
-
-            formatted_query = f"Bedrock component documentation for {component_name}"
-            logger.info(f"Component lookup for: {formatted_query}")
-
-            return await SearchTool.semantic_search(
-                json.dumps(
-                    {
-                        "query": formatted_query,
-                        "limit": 5,  # More focused search
-                    }
-                )
-            )
-        except Exception as e:
-            logger.error(f"Component lookup failed: {str(e)}")
-            return json.dumps(
-                {"error": f"Component lookup failed: {str(e)}", "original_query": query_data}
-            )
-
-    @tool
-    @staticmethod
-    async def conversion_examples(query_data: str) -> str:
-        """
-        Search for examples of converting game elements or mechanics from Java Edition to Bedrock Edition.
-        Input can be a simple query string describing the element or a JSON string:
-        '{"query": "potion effects"}' or simply "potion effects".
-        """
-        query = ""
-        try:
-            SearchTool.get_instance()
-            if isinstance(query_data, str):
-                try:
-                    data = json.loads(query_data)
-                    query = data.get("query", "")
-                except json.JSONDecodeError:
-                    query = query_data
-            else:
-                query = str(query_data)
-
-            if not query:
-                return json.dumps({"error": "Query is required for conversion examples."})
-
-            formatted_query = f"Java to Bedrock conversion example for {query}"
-            logger.info(f"Conversion examples search for: {formatted_query}")
-
-            return await SearchTool.semantic_search(
-                json.dumps({"query": formatted_query, "limit": 5})
-            )
-        except Exception as e:
-            logger.error(f"Conversion examples search failed: {str(e)}")
-            return json.dumps(
-                {
-                    "error": f"Conversion examples search failed: {str(e)}",
-                    "original_query": query_data,
-                }
-            )
-
-    @tool
-    @staticmethod
-    async def schema_validation_lookup(query_data: str) -> str:
-        """
-        Search for Bedrock JSON schema information (e.g., for entities, blocks, items).
-        Input can be a simple schema name string or a JSON string:
-        '{"schema_name": "entity definition"}' or "entity definition".
-        """
-        schema_name = ""
-        try:
-            SearchTool.get_instance()
-            if isinstance(query_data, str):
-                try:
-                    data = json.loads(query_data)
-                    schema_name = data.get("schema_name", "")
-                except json.JSONDecodeError:
-                    schema_name = query_data
-            else:
-                schema_name = str(query_data)
-
-            if not schema_name:
-                return json.dumps(
-                    {"error": "Schema name/topic is required for schema validation lookup."}
-                )
-
-            formatted_query = f"Bedrock JSON schema for {schema_name}"
-            logger.info(f"Schema validation lookup for: {formatted_query}")
-
-            return await SearchTool.semantic_search(
-                json.dumps(
-                    {
-                        "query": formatted_query,
-                        "limit": 3,  # Schemas are often specific
-                    }
-                )
-            )
-        except Exception as e:
-            logger.error(f"Schema validation lookup failed: {str(e)}")
-            return json.dumps(
-                {
-                    "error": f"Schema validation lookup failed: {str(e)}",
-                    "original_query": query_data,
-                }
-            )
-
-    async def _perform_semantic_search(
-        self, query: str, limit: int = 10, document_source: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
-        """
-        Perform semantic search using vector database.
-
-        Args:
-            query: Search query
-            limit: Maximum number of results
-            document_source: Optional filter by document source
-
-        Returns:
-            List of search results
-        """
-        try:
-            results = await self.vector_client.search_documents(
-                query_text=query, top_k=limit, document_source_filter=document_source
-            )
-            return results
-        except Exception as e:
-            logger.error(f"Semantic search execution failed: {str(e)}")
-            return []
-
-    def _attempt_fallback_search(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
-        """
-        Attempt to use fallback search tool when primary search fails.
-
-        This method implements the fallback mechanism by dynamically importing
-        and instantiating the configured fallback tool. It handles various error
-        scenarios gracefully and logs appropriate messages.
-
-        Args:
-            query: Search query string
-            limit: Maximum number of results to return
-
-        Returns:
-            List of search results from fallback tool in standardized format,
-            or empty list if fallback fails or is disabled
-        """
-        if not Config.SEARCH_FALLBACK_ENABLED:
-            logger.info("Fallback search is disabled")
-            return []
-
-        tool_name = Config.FALLBACK_SEARCH_TOOL
-        logger.info(f"Attempting fallback search with {tool_name}")
-
-        try:
-            # Construct module and class names
-            module_path = f"tools.{tool_name}"
-            class_name_parts = [part.capitalize() for part in tool_name.split("_")]
-            class_name = "".join(class_name_parts)
-
-            # Import and instantiate fallback tool
-            module = importlib.import_module(module_path)
-            FallbackToolClass = getattr(module, class_name)
-            fallback_tool_instance = FallbackToolClass()
-
-            # Execute fallback search
-            fallback_result = fallback_tool_instance._run(query)
-
-            # Convert fallback result to expected format
-            if isinstance(fallback_result, str):
-                # Parse fallback result and convert to our expected format
-                fallback_results = [
-                    {
-                        "id": "fallback_0",
-                        "content": fallback_result,
-                        "document_source": "fallback_search",
-                        "similarity_score": 0.7,
-                        "metadata": {
-                            "indexed_at": "2025-01-09T00:00:00Z",
-                            "content_type": "text",
-                            "source": "fallback",
-                        },
-                    }
-                ]
-                return fallback_results[:limit]
-
-            return []
-
-        except ImportError as e:
-            logger.error(
-                f"Fallback tool '{tool_name}' module not found at '{module_path}': {str(e)}"
-            )
-            return []
-        except AttributeError as e:
-            logger.error(
-                f"Fallback tool class '{class_name}' not found in module '{module_path}': {str(e)}"
-            )
-            return []
-        except Exception as e:
-            # Re-raise SearchServiceError so callers distinguish service failure
-            # from genuinely empty results. Other exceptions still return [].
-            from tools.web_search_tool import SearchServiceError
-
-            if isinstance(e, SearchServiceError):
-                raise
-            logger.error(f"Error during fallback to {tool_name}: {str(e)}")
-            return []
-
-    async def _search_by_document_source(
-        self, document_source: str, content_type: Optional[str] = None, limit: int = 10
-    ) -> List[Dict[str, Any]]:
-        """
-        Search documents by source identifier.
-
-        Args:
-            document_source: Document source to search for
-            content_type: Optional content type filter (currently not used in backend call)
-            limit: Maximum number of results
-
-        Returns:
-            List of matching documents
-        """
-        try:
-            # Using document_source as query_text for now.
-            # The backend's search logic will determine how this is interpreted.
-            # If specific "get by source" functionality is needed, backend API should support it.
-            results = await self.vector_client.search_documents(
-                query_text=document_source,  # Or a more generic query if appropriate
-                top_k=limit,
-                document_source_filter=document_source,  # This is the key filter
-            )
-            # Client-side content_type filtering could be done here if results have 'content_type'
-            if content_type and results:
-                results = [
-                    r
-                    for r in results
-                    if r.get("metadata", {}).get("content_type") == content_type
-                    or r.get("content_type") == content_type
-                ]
-            return results
-        except Exception as e:
-            logger.error(f"Document source search failed: {str(e)}")
-            return []
-
-    async def _find_similar_documents(
-        self, content: str, threshold: float = 0.8, limit: int = 10
-    ) -> List[Dict[str, Any]]:
-        """
-        Find documents similar to given content.
-
-        Args:
-            content: Reference content
-            threshold: Similarity threshold (0-1)
-            limit: Maximum number of results
-
-        Returns:
-            List of similar documents
-        """
-        try:
-            results = await self.vector_client.search_documents(query_text=content, top_k=limit)
-            # Client-side threshold filtering could be done here if results have 'similarity_score'
-            if threshold > 0 and results:  # Assuming threshold=0 means no filtering
-                results = [r for r in results if r.get("similarity_score", 0.0) >= threshold]
-            return results
-        except Exception as e:
-            logger.error(f"Similarity search execution failed: {str(e)}")
-            return []
-
-    async def close(self):
-        """Close vector database connection."""
-        if hasattr(self, "vector_client"):
-            # Check if the close method is async or sync
-            if hasattr(self.vector_client, "close"):
-                close_method = self.vector_client.close
-                if hasattr(close_method, "__call__"):
-                    # Check if it's awaitable
-                    import asyncio
-
-                    if asyncio.iscoroutinefunction(close_method):
-                        await close_method()
-                    else:
-                        close_method()
-            logger.info("SearchTool connections closed")
-
-
-# Demo functionality for testing
-if __name__ == "__main__":
-    import asyncio
-
-    search_tool = SearchTool.get_instance()
-
-    async def demo():
-        # Test semantic search
-        sample_query_ai = "What are the latest advancements in AI?"
-        output_ai = await SearchTool.semantic_search(sample_query_ai)
-        print(f"Query: {sample_query_ai}")
-        print(f"Output:\n{output_ai}\n")
-
-        sample_query_mc = "Tell me about Minecraft modding."
-        output_mc = await SearchTool.semantic_search(sample_query_mc)
-        print(f"Query: {sample_query_mc}")
-        print(f"Output:\n{output_mc}\n")
-
-        sample_query_other = "Some other topic."
-        output_other = await SearchTool.semantic_search(sample_query_other)
-        print(f"Query: {sample_query_other}")
-        print(f"Output:\n{output_other}\n")
-
-    asyncio.run(demo())
+    @property
+    def semantic_search(self) -> SemanticSearchTool:
+        """Default semantic-search tool (typed ``BaseTool`` instance)."""
+        return self._semantic
+
+    @property
+    def document_search(self) -> DocumentSearchTool:
+        return self._document
+
+    @property
+    def similarity_search(self) -> SimilaritySearchTool:
+        return self._similarity
+
+    @property
+    def bedrock_api_search(self) -> BedrockApiSearchTool:
+        return self._bedrock_api
+
+    @property
+    def component_lookup(self) -> ComponentLookupTool:
+        return self._component
+
+    @property
+    def conversion_examples(self) -> ConversionExamplesTool:
+        return self._conversion
+
+    @property
+    def schema_validation_lookup(self) -> SchemaValidationLookupTool:
+        return self._schema
+
+    async def close(self) -> None:
+        """Close the underlying vector database connection if applicable."""
+        client = getattr(self, "vector_client", None)
+        if client is None:
+            return
+        close_method = getattr(client, "close", None)
+        if close_method is None:
+            return
+        if asyncio.iscoroutinefunction(close_method):
+            await close_method()
+        else:
+            close_method()
+        logger.info("SearchTool connections closed")
+
+
+__all__ = [
+    "SearchTool",
+    "SemanticSearchTool",
+    "DocumentSearchTool",
+    "SimilaritySearchTool",
+    "BedrockApiSearchTool",
+    "ComponentLookupTool",
+    "ConversionExamplesTool",
+    "SchemaValidationLookupTool",
+    "SemanticSearchInput",
+    "DocumentSearchInput",
+    "SimilaritySearchInput",
+    "BedrockApiSearchInput",
+    "ComponentLookupInput",
+    "ConversionExamplesInput",
+    "SchemaValidationLookupInput",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke
+
+    async def _demo() -> None:
+        tool = SemanticSearchTool()
+        for query in (
+            "What are the latest advancements in AI?",
+            "Tell me about Minecraft modding.",
+        ):
+            print(f"Query: {query}")
+            print(await tool.ainvoke({"query": query}))
+            print()
+
+    asyncio.run(_demo())


### PR DESCRIPTION
## Summary

Converts `ai-engine/tools/search_tool.py` from `@tool`-decorated static
methods taking a single `query_data: str` JSON argument to **seven typed
`langchain_core.tools.BaseTool` subclasses with Pydantic `args_schema`**.

This is **slice 1 of Phase 8 task A** (deferred Phase 1 work from the
LangChain/LangGraph cutover landed in #1445 / issue #1201). Refs #1201.

## Why

The Phase 1 migration moved every `@tool` import off the legacy
multi-agent framework but kept the inherited single-string-arg call
shape. That shape blocks three things:

1. **Native chat-model tool calling.** Models that emit structured
   tool-call payloads (OpenAI, Anthropic, Z.AI) cannot reliably target
   a tool whose only declared parameter is `data: str` — they emit
   structured JSON and the framework can't bind it.
2. **Schema validation.** Every tool currently re-implements its own
   `try: json.loads ... except: data = {single_field: data}` shim and
   ad-hoc required-field checks. Pydantic does this in one place,
   correctly, with constraint enforcement.
3. **The RAG service.** `services/rag_service._make_search_step`
   already prefers a typed `BaseTool` (Path 1), but the default
   `_resolve_search_tool(None)` returned the legacy facade and fell
   into the brittle Path 2 (`{"query_data": query}` keyword
   plumbing). After this PR the default path also routes through
   Path 1.

## Why this is the smallest first slice

`tools/search_tool.py` has the smallest blast radius of the deferred
A clusters (7 tools vs ~30 in `agents/logic_translator/tools.py`).
The pattern proven here will be reused for the agent-side clusters in
slices 2-N; landing them as separate PRs keeps each review scope small.

## What changed

### `ai-engine/tools/search_tool.py` (rewrite)
- Seven typed `BaseTool` subclasses (`SemanticSearchTool`,
  `DocumentSearchTool`, `SimilaritySearchTool`, `BedrockApiSearchTool`,
  `ComponentLookupTool`, `ConversionExamplesTool`,
  `SchemaValidationLookupTool`) with constrained `args_schema`
  (`extra="forbid"`, `min_length`, `ge`/`le` bounds).
- Shared async helpers `_semantic_search_payload`,
  `_document_search_payload`, `_similarity_search_payload` encapsulate
  the canonical response shape **and** the legacy fallback mechanism
  (single source of truth — wrapper tools no longer re-encode to JSON
  and recurse through `semantic_search`).
- `_attempt_fallback_search` promoted to a module-level function (was
  an instance method on the legacy facade).
- **Async-first**: `_arun` is the primary surface; `_run` uses
  `asyncio.run()` only when no loop is running and raises
  `RuntimeError` otherwise — prevents silent deadlocks under LangGraph.
- `SearchTool` facade preserved for backwards compatibility:
  `get_tools()` returns `BaseTool` instances; `get_instance()`
  singleton unchanged; `semantic_search` etc. exposed as `@property`
  returning the typed `BaseTool` so the RAG service can dispatch via
  Path 1.

### `ai-engine/services/rag_service.py` (4 lines surgical)
- `_resolve_search_tool(None)` now returns
  `SearchTool.get_instance().semantic_search` (a typed `BaseTool`) so
  the RAG default path dispatches via Path 1.
- Path 2 descriptor branch tries `{"query": q}` first, then
  `{"query_data": q}` for legacy compatibility.

### `ai-engine/tests/test_search_tool_comprehensive.py` (rewrite)
- 49 tests covering every public `ainvoke()` surface, Pydantic
  validation rejection (parametrized for empty / out-of-range /
  forbidden-extra-field), the fallback mechanism, the module-level
  payload helpers, and the facade `close()` lifecycle.
- Mocks `vector_client.search_documents` directly and injects mock
  vector clients into typed tools for isolation.

### `ai-engine/tests/unit/test_rag_service.py` (+1 regression test)
- `test_rag_chain_default_search_tool_routes_through_typed_basetool`
  proves `build_rag_chain(search_tool=None)` resolves to
  `SemanticSearchTool` and dispatches via Path 1.

### `ai-engine/test_integration.py` + `ai-engine/testing/rag_evaluator.py`
- Updated two non-CI consumer call sites that touched legacy
  `SearchTool` internals (`_attempt_fallback_search` now imported as a
  module function; `semantic_search.func()` → `ainvoke({"query": query})`).

## Acceptance gates (all green locally)

| Gate | Result |
|---|---|
| Phase 0 LangGraph parity smoke + MVP block + RAG + rate limiter + Z.AI | **29 passed** |
| Comprehensive search-tool tests | **49 passed** |
| Coverage on `tools.search_tool` | **96.37%** (gate: 80%) |
| Regression guard `tests/test_no_crewai_references.py` | **passed** |
| Tracked-source grep for legacy framework name | **CLEAN** |
| Broader RAG/search sweep (`tests/search/`, `test_advanced_rag_integration`, `test_rag_evaluator`, `test_rag_agents_coverage`) | **203 passed, 5 skipped** |
| Other `SearchTool` consumer (`test_agent_orchestration_comprehensive`) | **32 passed** |
| `ruff check` on changed files | **All checks passed** |
| `ruff format --check` on changed files (from `ai-engine/`) | **all formatted** |

## Out of scope (separate PRs)

- Other Phase 8 A clusters: `agents/logic_translator/tools.py` (~30
  tools), `agents/qa/`, `agents/bedrock_*`, `agents/recipe*`,
  `agents/java_analyzer/tools.py`, `agents/packaging_agent.py`.
- Phase 8 B + C (Docker base-image rebuild + chromadb floor bump,
  best landed together).
- Phase 8 D (Jaeger / OTel span audit).
- Phase 8 E (skeleton regen, scheduled after A is fully done).
- Phase 8 F (`ai-engine/` ↔ `ai_engine/` directory consolidation).

## Rollback

Single commit, independently revertible. The `services/rag_service.py`
changes are surgical (4 lines around `_resolve_search_tool` and Path 2
of `_make_search_step`); reverting restores the Path 2 legacy descriptor
invocation. The typed-tool classes can coexist with reverted callers.

## Working-agreement compliance

- Branch: `feature/1201-typed-search-tool-args`.
- Commit format: `refactor(ai-engine): convert SearchTool to typed
  BaseTool subclasses with args_schema`.
- Async-first; Pydantic V2 with `ConfigDict(extra="forbid")` +
  `PrivateAttr` for the injected `_vector_client`; `ClassVar` on
  `args_schema`; no `time.sleep` / `requests.get` / globals.
- Coverage on the rewritten module: 96.37% (≥ 80%).
- Regression guard phrasing follows the convention from #1445: "the
  legacy `@tool` wrapper pattern", "the legacy multi-agent framework"
  — never the actual name.
