### PR TITLE
refactor(ai-engine): convert logic_translator tools to typed args_schema

### DIFF
--- a/ai-engine/agents/logic_translator/tools.py
+++ b/ai-engine/agents/logic_translator/tools.py
@@ -1,40 +1,249 @@
-"""
-LangChain tool wrappers for Logic Translator Agent.
+"""LangChain tool wrappers for the Logic Translator Agent.
+
+This module exposes typed ``BaseTool`` subclasses backed by the
+``LogicTranslatorAgent`` singleton. Each tool declares a Pydantic
+``args_schema`` so chat models with native tool-calling can invoke it with
+structured arguments instead of a JSON-encoded ``<name>_data: str`` blob.
+
+Backwards compatibility:
+
+* ``LogicTranslatorTools`` is preserved as a facade. Each typed tool is
+  exposed as a class attribute on ``LogicTranslatorTools`` (``LogicTranslatorTools.<name>``)
+  with the legacy tool name, and the ``@property`` accessors on
+  ``LogicTranslatorAgent`` continue to return the same instance.
+* The agent's ``__init__`` is heavy (model loading); each tool defers
+  resolving the singleton until invocation, never at module import.
+
+This conversion is Phase 8 A2 of issue #1201, mirroring the pattern proven
+in :mod:`tools.search_tool` (PR #1446).
 """
 
+from __future__ import annotations
+
+import asyncio
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
-from langchain_core.tools import tool
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
+from agents.logic_translator.block_state_mapper import JAVA_TO_BEDROCK_BLOCK_PROPERTIES
 from agents.logic_translator.translator import LogicTranslatorAgent
 from utils.logging_config import get_agent_logger
 
 logger = get_agent_logger("logic_translator.tools")
 
 
-class LogicTranslatorTools:
-    """Collection of LangChain tools for Java to Bedrock logic translation."""
+# ---------------------------------------------------------------------------
+# Pydantic args schemas
+# ---------------------------------------------------------------------------
 
-    @tool
+
+class GetRagContextInput(BaseModel):
+    """Args for :class:`GetRagContextTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    java_feature: str = Field(
+        min_length=1, description="Description of the Java feature to convert."
+    )
+    feature_type: str = Field(
+        min_length=1, description="Feature type (block, item, entity, recipe, event)."
+    )
+
+
+class SetRagContextInput(BaseModel):
+    """Args for :class:`SetRagContextTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    enabled: bool = Field(description="True to enable RAG context, False to disable.")
+
+
+class TranslateJavaMethodInput(BaseModel):
+    """Args for :class:`TranslateJavaMethodTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    method_name: str = Field(min_length=1, description="Java method name.")
+    method_body: str = Field(default="", description="Java method body (optional).")
+    feature_type: str = Field(
+        default="unknown", description="Feature type for optional RAG context."
+    )
+
+
+class ConvertJavaClassInput(BaseModel):
+    """Args for :class:`ConvertJavaClassTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    class_name: str = Field(min_length=1, description="Java class name.")
+    methods: List[Dict[str, Any]] = Field(
+        default_factory=list, description="List of method dicts on the class."
+    )
+    feature_type: str = Field(
+        default="unknown", description="Feature type for optional RAG context."
+    )
+
+
+class MapJavaApisInput(BaseModel):
+    """Args for :class:`MapJavaApisTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    apis: List[str] = Field(default_factory=list, description="List of Java API call signatures.")
+
+
+class GenerateEventHandlersInput(BaseModel):
+    """Args for :class:`GenerateEventHandlersTool`.
+
+    Mirrors the live ``LogicTranslatorAgent.generate_event_handlers`` schema.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    event_type: str = Field(default="unknown", description="Event type identifier.")
+    handlers: List[Dict[str, Any]] = Field(
+        default_factory=list, description="List of handler descriptors."
+    )
+
+
+class ValidateJavascriptSyntaxInput(BaseModel):
+    """Args for :class:`ValidateJavascriptSyntaxTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    javascript_code: str = Field(default="", description="JavaScript source to validate.")
+
+
+class TranslateCraftingRecipeInput(BaseModel):
+    """Args for :class:`TranslateCraftingRecipeTool`.
+
+    The ``recipe`` field carries the raw Java crafting recipe dict
+    (with ``type`` and the appropriate shaped/shapeless fields).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    recipe: Dict[str, Any] = Field(description="Java crafting recipe dict.")
+
+
+class GenerateBedrockBlockInput(BaseModel):
+    """Args for :class:`GenerateBedrockBlockTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    java_block_analysis: Dict[str, Any] = Field(description="Java block analysis dict.")
+    namespace: str = Field(default="modporter", min_length=1, description="Bedrock namespace.")
+    use_rag: bool = Field(default=True, description="Augment with RAG context when available.")
+
+
+class ValidateBlockJsonInput(BaseModel):
+    """Args for :class:`ValidateBlockJsonTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    block_json: Dict[str, Any] = Field(description="Bedrock block JSON to validate against schema.")
+
+
+class MapBlockPropertiesInput(BaseModel):
+    """Args for :class:`MapBlockPropertiesTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    java_properties: Dict[str, Any] = Field(description="Java block properties dict.")
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper for block-property mapping.
+#
+# Pre-existing bug: the legacy ``map_block_properties_tool`` wrapper called
+# ``LogicTranslatorAgent.map_java_block_properties_to_bedrock``, a method that
+# does not exist on the agent (only on this module's ``LogicTranslatorTools``
+# facade). The typed rewrite routes through this module-level function so
+# both call sites share a single implementation.
+# ---------------------------------------------------------------------------
+
+
+def _map_java_block_properties_to_bedrock(java_properties: Dict[str, Any]) -> Dict[str, Any]:
+    """Map Java block properties to Bedrock equivalents."""
+    bedrock_properties: Dict[str, Any] = {}
+
+    material = java_properties.get("material", "stone")
+    if f"Material.{material.upper()}" in JAVA_TO_BEDROCK_BLOCK_PROPERTIES:
+        mapping = JAVA_TO_BEDROCK_BLOCK_PROPERTIES[f"Material.{material.upper()}"]
+        bedrock_properties.update(mapping)
+
+    if "hardness" in java_properties:
+        bedrock_properties["hardness"] = java_properties["hardness"]
+
+    if "explosion_resistance" in java_properties:
+        bedrock_properties["explosion_resistance"] = java_properties["explosion_resistance"]
+
+    if "light_level" in java_properties and java_properties["light_level"] > 0:
+        bedrock_properties["light_level"] = min(java_properties["light_level"], 15)
+
+    sound_type = java_properties.get("sound_type", "stone")
+    if f"SoundType.{sound_type.upper()}" in JAVA_TO_BEDROCK_BLOCK_PROPERTIES:
+        bedrock_properties["sound_category"] = sound_type
+
+    if java_properties.get("requires_tool", False):
+        tool_type = java_properties.get("tool_type", "pickaxe")
+        if f"ToolType.{tool_type.upper()}" in JAVA_TO_BEDROCK_BLOCK_PROPERTIES:
+            bedrock_properties["requires_tool"] = tool_type
+
+    return bedrock_properties
+
+
+# ---------------------------------------------------------------------------
+# Typed BaseTool scaffolding
+# ---------------------------------------------------------------------------
+
+
+class _BaseLogicTranslatorTool(BaseTool):
+    """Common scaffolding for the Logic Translator typed tool wrappers.
+
+    Holds an optional injected agent for tests; defers resolving the
+    ``LogicTranslatorAgent`` singleton until the tool is actually invoked,
+    so module import never triggers the agent's heavy ``__init__``.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    _agent: Any = PrivateAttr(default=None)
+
+    def __init__(self, agent: Optional[Any] = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._agent = agent
+
+    def _get_agent(self) -> Any:
+        """Return the injected agent or the module singleton (lazy)."""
+        if self._agent is not None:
+            return self._agent
+        return LogicTranslatorAgent.get_instance()
+
     @staticmethod
-    def get_rag_context_tool(java_feature: str, feature_type: str) -> str:
-        """
-        Get RAG context for context-augmented translation.
+    def _run_async(coro: Any) -> Any:
+        """Drive an awaitable from a sync caller; refuse if a loop is running."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+        # Close the unawaited coroutine to avoid a noisy RuntimeWarning.
+        coro.close()
+        raise RuntimeError(
+            "Sync invoke() called from inside a running event loop; use ainvoke() instead."
+        )
 
-        This tool retrieves relevant pattern mappings, Bedrock code examples,
-        and prior translations from the knowledge base to assist with accurate conversion.
 
-        Args:
-            java_feature: Description of the Java feature to convert
-            feature_type: Type of feature (block, item, entity, recipe, event)
+# ---------------------------------------------------------------------------
+# Typed BaseTool subclasses (one per legacy @tool wrapper)
+# ---------------------------------------------------------------------------
 
-        Returns:
-            JSON string with context including pattern mappings and code examples
-        """
-        agent = LogicTranslatorAgent.get_instance()
+
+class GetRagContextTool(_BaseLogicTranslatorTool):
+    """Get RAG context for context-augmented translation."""
+
+    name: str = "get_rag_context_tool"
+    description: str = (
+        "Retrieve RAG context for translating a Java feature. "
+        "Args: java_feature (str, required), feature_type (str, required)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = GetRagContextInput
+
+    async def _arun(  # type: ignore[override]
+        self, java_feature: str, feature_type: str
+    ) -> str:
+        agent = self._get_agent()
         context_str = agent._get_rag_context(java_feature, feature_type)
-
         if not context_str:
             return json.dumps(
                 {
@@ -44,7 +253,6 @@ class LogicTranslatorTools:
                     "rag_enabled": agent._rag_context_enabled,
                 }
             )
-
         return json.dumps(
             {
                 "success": True,
@@ -53,28 +261,338 @@ class LogicTranslatorTools:
             }
         )
 
-    @tool
-    @staticmethod
-    def set_rag_context_tool(enabled: bool) -> str:
-        """
-        Enable or disable RAG context for translation.
+    def _run(  # type: ignore[override]
+        self, java_feature: str, feature_type: str
+    ) -> str:
+        return self._run_async(self._arun(java_feature=java_feature, feature_type=feature_type))
 
-        Args:
-            enabled: True to enable RAG context, False to disable
 
-        Returns:
-            JSON string with confirmation
-        """
-        agent = LogicTranslatorAgent.get_instance()
+class SetRagContextTool(_BaseLogicTranslatorTool):
+    """Enable or disable RAG context for translation."""
+
+    name: str = "set_rag_context_tool"
+    description: str = "Enable or disable RAG context. Args: enabled (bool)."
+    args_schema: ClassVar[type[BaseModel]] = SetRagContextInput
+
+    async def _arun(self, enabled: bool) -> str:  # type: ignore[override]
+        agent = self._get_agent()
         agent.enable_rag_context(enabled)
-
         return json.dumps(
             {
                 "success": True,
                 "rag_enabled": agent._rag_context_enabled,
-                "message": f"RAG context {'enabled' if agent._rag_context_enabled else 'disabled'}",
+                "message": (
+                    f"RAG context {'enabled' if agent._rag_context_enabled else 'disabled'}"
+                ),
             }
         )
+
+    def _run(self, enabled: bool) -> str:  # type: ignore[override]
+        return self._run_async(self._arun(enabled=enabled))
+
+
+class TranslateJavaMethodTool(_BaseLogicTranslatorTool):
+    """Translate a Java method to JavaScript via the agent."""
+
+    name: str = "translate_java_method_tool"
+    description: str = (
+        "Translate a Java method to JavaScript. Args: method_name (str, required), "
+        "method_body (str, default ''), feature_type (str, default 'unknown')."
+    )
+    args_schema: ClassVar[type[BaseModel]] = TranslateJavaMethodInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        method_name: str,
+        method_body: str = "",
+        feature_type: str = "unknown",
+    ) -> str:
+        agent = self._get_agent()
+        payload = json.dumps(
+            {
+                "method_name": method_name,
+                "method_body": method_body,
+                "feature_type": feature_type,
+            }
+        )
+        return agent.translate_java_method(payload)
+
+    def _run(  # type: ignore[override]
+        self,
+        method_name: str,
+        method_body: str = "",
+        feature_type: str = "unknown",
+    ) -> str:
+        return self._run_async(
+            self._arun(
+                method_name=method_name,
+                method_body=method_body,
+                feature_type=feature_type,
+            )
+        )
+
+
+class ConvertJavaClassTool(_BaseLogicTranslatorTool):
+    """Convert a Java class declaration to JavaScript."""
+
+    name: str = "convert_java_class_tool"
+    description: str = (
+        "Convert a Java class to JavaScript. Args: class_name (str, required), "
+        "methods (list[dict], default []), feature_type (str, default 'unknown')."
+    )
+    args_schema: ClassVar[type[BaseModel]] = ConvertJavaClassInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        class_name: str,
+        methods: Optional[List[Dict[str, Any]]] = None,
+        feature_type: str = "unknown",
+    ) -> str:
+        agent = self._get_agent()
+        payload = json.dumps(
+            {
+                "class_name": class_name,
+                "methods": methods or [],
+                "feature_type": feature_type,
+            }
+        )
+        return agent.convert_java_class(payload)
+
+    def _run(  # type: ignore[override]
+        self,
+        class_name: str,
+        methods: Optional[List[Dict[str, Any]]] = None,
+        feature_type: str = "unknown",
+    ) -> str:
+        return self._run_async(
+            self._arun(class_name=class_name, methods=methods, feature_type=feature_type)
+        )
+
+
+class MapJavaApisTool(_BaseLogicTranslatorTool):
+    """Map Java APIs to JavaScript equivalents."""
+
+    name: str = "map_java_apis_tool"
+    description: str = "Map Java APIs to JavaScript. Args: apis (list[str], default [])."
+    args_schema: ClassVar[type[BaseModel]] = MapJavaApisInput
+
+    async def _arun(  # type: ignore[override]
+        self, apis: Optional[List[str]] = None
+    ) -> str:
+        agent = self._get_agent()
+        payload = json.dumps({"apis": apis or []})
+        return agent.map_java_apis(payload)
+
+    def _run(  # type: ignore[override]
+        self, apis: Optional[List[str]] = None
+    ) -> str:
+        return self._run_async(self._arun(apis=apis))
+
+
+class GenerateEventHandlersTool(_BaseLogicTranslatorTool):
+    """Generate JavaScript event handlers from Java event metadata."""
+
+    name: str = "generate_event_handlers_tool"
+    description: str = (
+        "Generate JavaScript event handlers. Args: event_type (str, default 'unknown'), "
+        "handlers (list[dict], default [])."
+    )
+    args_schema: ClassVar[type[BaseModel]] = GenerateEventHandlersInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        event_type: str = "unknown",
+        handlers: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        agent = self._get_agent()
+        payload = json.dumps({"event_type": event_type, "handlers": handlers or []})
+        return agent.generate_event_handlers(payload)
+
+    def _run(  # type: ignore[override]
+        self,
+        event_type: str = "unknown",
+        handlers: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        return self._run_async(self._arun(event_type=event_type, handlers=handlers))
+
+
+class ValidateJavascriptSyntaxTool(_BaseLogicTranslatorTool):
+    """Validate JavaScript syntax."""
+
+    name: str = "validate_javascript_syntax_tool"
+    description: str = "Validate JavaScript source. Args: javascript_code (str, default '')."
+    args_schema: ClassVar[type[BaseModel]] = ValidateJavascriptSyntaxInput
+
+    async def _arun(  # type: ignore[override]
+        self, javascript_code: str = ""
+    ) -> str:
+        agent = self._get_agent()
+        return agent.validate_javascript_syntax(json.dumps({"javascript_code": javascript_code}))
+
+    def _run(  # type: ignore[override]
+        self, javascript_code: str = ""
+    ) -> str:
+        return self._run_async(self._arun(javascript_code=javascript_code))
+
+
+class TranslateCraftingRecipeTool(_BaseLogicTranslatorTool):
+    """Translate a Java crafting recipe to Bedrock format."""
+
+    name: str = "translate_crafting_recipe_tool"
+    description: str = (
+        "Translate a Java crafting recipe to Bedrock format. "
+        "Args: recipe (dict containing 'type' and shape/ingredient fields)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = TranslateCraftingRecipeInput
+
+    async def _arun(  # type: ignore[override]
+        self, recipe: Dict[str, Any]
+    ) -> str:
+        agent = self._get_agent()
+        return agent.translate_crafting_recipe_json(json.dumps(recipe))
+
+    def _run(  # type: ignore[override]
+        self, recipe: Dict[str, Any]
+    ) -> str:
+        return self._run_async(self._arun(recipe=recipe))
+
+
+class GenerateBedrockBlockTool(_BaseLogicTranslatorTool):
+    """Generate Bedrock block JSON from a Java block analysis."""
+
+    name: str = "generate_bedrock_block_tool"
+    description: str = (
+        "Generate Bedrock block JSON. Args: java_block_analysis (dict, required), "
+        "namespace (str, default 'modporter'), use_rag (bool, default True)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = GenerateBedrockBlockInput
+
+    async def _arun(  # type: ignore[override]
+        self,
+        java_block_analysis: Dict[str, Any],
+        namespace: str = "modporter",
+        use_rag: bool = True,
+    ) -> str:
+        agent = self._get_agent()
+        try:
+            result = agent.generate_bedrock_block_json(
+                java_block_analysis=java_block_analysis,
+                namespace=namespace,
+                use_rag=use_rag,
+            )
+            return json.dumps(result)
+        except Exception as e:
+            return json.dumps({"success": False, "error": str(e), "block_json": None})
+
+    def _run(  # type: ignore[override]
+        self,
+        java_block_analysis: Dict[str, Any],
+        namespace: str = "modporter",
+        use_rag: bool = True,
+    ) -> str:
+        return self._run_async(
+            self._arun(
+                java_block_analysis=java_block_analysis,
+                namespace=namespace,
+                use_rag=use_rag,
+            )
+        )
+
+
+class ValidateBlockJsonTool(_BaseLogicTranslatorTool):
+    """Validate a Bedrock block JSON document."""
+
+    name: str = "validate_block_json_tool"
+    description: str = "Validate a Bedrock block JSON document. Args: block_json (dict, required)."
+    args_schema: ClassVar[type[BaseModel]] = ValidateBlockJsonInput
+
+    async def _arun(  # type: ignore[override]
+        self, block_json: Dict[str, Any]
+    ) -> str:
+        agent = self._get_agent()
+        try:
+            result = agent._validate_block_json(block_json)
+            return json.dumps({"success": True, "validation": result})
+        except Exception as e:
+            return json.dumps({"success": False, "error": str(e)})
+
+    def _run(  # type: ignore[override]
+        self, block_json: Dict[str, Any]
+    ) -> str:
+        return self._run_async(self._arun(block_json=block_json))
+
+
+class MapBlockPropertiesTool(_BaseLogicTranslatorTool):
+    """Map Java block properties to Bedrock equivalents.
+
+    Routes through the module-level :func:`_map_java_block_properties_to_bedrock`
+    helper. The legacy wrapper called a non-existent agent method; this tool
+    fixes that by calling the actually-implemented mapping logic.
+    """
+
+    name: str = "map_block_properties_tool"
+    description: str = (
+        "Map Java block properties to Bedrock. Args: java_properties (dict, required)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = MapBlockPropertiesInput
+
+    async def _arun(  # type: ignore[override]
+        self, java_properties: Dict[str, Any]
+    ) -> str:
+        try:
+            result = _map_java_block_properties_to_bedrock(java_properties)
+            return json.dumps({"success": True, "bedrock_properties": result})
+        except Exception as e:
+            return json.dumps({"success": False, "error": str(e)})
+
+    def _run(  # type: ignore[override]
+        self, java_properties: Dict[str, Any]
+    ) -> str:
+        return self._run_async(self._arun(java_properties=java_properties))
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton instances. Created at import time but agent-less,
+# so :class:`LogicTranslatorAgent` is not instantiated until a tool is
+# actually invoked.
+# ---------------------------------------------------------------------------
+
+_get_rag_context_tool = GetRagContextTool()
+_set_rag_context_tool = SetRagContextTool()
+_translate_java_method_tool = TranslateJavaMethodTool()
+_convert_java_class_tool = ConvertJavaClassTool()
+_map_java_apis_tool = MapJavaApisTool()
+_generate_event_handlers_tool = GenerateEventHandlersTool()
+_validate_javascript_syntax_tool = ValidateJavascriptSyntaxTool()
+_translate_crafting_recipe_tool = TranslateCraftingRecipeTool()
+_generate_bedrock_block_tool = GenerateBedrockBlockTool()
+_validate_block_json_tool = ValidateBlockJsonTool()
+_map_block_properties_tool = MapBlockPropertiesTool()
+
+
+class LogicTranslatorTools:
+    """Collection of LangChain tools for Java to Bedrock logic translation."""
+
+    # ------------------------------------------------------------------
+    # Typed BaseTool wrappers (Phase 8 A2, refs #1201).
+    #
+    # Class attributes preserve the ``LogicTranslatorTools.<name>`` access
+    # used by ``LogicTranslatorAgent.get_tools()`` and the agent's
+    # ``@property`` accessors. Each name matches the legacy tool name so
+    # the public surface is unchanged.
+    # ------------------------------------------------------------------
+
+    get_rag_context_tool = _get_rag_context_tool
+    set_rag_context_tool = _set_rag_context_tool
+    translate_java_method_tool = _translate_java_method_tool
+    convert_java_class_tool = _convert_java_class_tool
+    map_java_apis_tool = _map_java_apis_tool
+    generate_event_handlers_tool = _generate_event_handlers_tool
+    validate_javascript_syntax_tool = _validate_javascript_syntax_tool
+    translate_crafting_recipe_tool = _translate_crafting_recipe_tool
+    generate_bedrock_block_tool = _generate_bedrock_block_tool
+    validate_block_json_tool = _validate_block_json_tool
+    map_block_properties_tool = _map_block_properties_tool
 
     def translate_java_code(self, java_code: str, code_type: str) -> str:
         """
@@ -118,48 +636,6 @@ class LogicTranslatorTools:
                     "errors": [str(e)],
                 }
             )
-
-    @tool
-    @staticmethod
-    def translate_java_method_tool(method_data: str) -> str:
-        """Translate Java method to JavaScript."""
-        agent = LogicTranslatorAgent.get_instance()
-        return agent.translate_java_method(method_data)
-
-    @tool
-    @staticmethod
-    def convert_java_class_tool(class_data: str) -> str:
-        """Convert Java class to JavaScript."""
-        agent = LogicTranslatorAgent.get_instance()
-        return agent.convert_java_class(class_data)
-
-    @tool
-    @staticmethod
-    def map_java_apis_tool(api_data: str) -> str:
-        """Map Java APIs to JavaScript."""
-        agent = LogicTranslatorAgent.get_instance()
-        return agent.map_java_apis(api_data)
-
-    @tool
-    @staticmethod
-    def generate_event_handlers_tool(event_data: str) -> str:
-        """Generate event handlers for JavaScript."""
-        agent = LogicTranslatorAgent.get_instance()
-        return agent.generate_event_handlers(event_data)
-
-    @tool
-    @staticmethod
-    def validate_javascript_syntax_tool(js_data: str) -> str:
-        """Validate JavaScript syntax."""
-        agent = LogicTranslatorAgent.get_instance()
-        return agent.validate_javascript_syntax(js_data)
-
-    @tool
-    @staticmethod
-    def translate_crafting_recipe_tool(recipe_json_data: str) -> str:
-        """Translate a Java crafting recipe JSON to Bedrock recipe JSON format."""
-        agent = LogicTranslatorAgent.get_instance()
-        return agent.translate_crafting_recipe_json(recipe_json_data)
 
     def _get_tree_sitter_parser(self):
         """Get or create tree-sitter parser instance."""
@@ -1081,79 +1557,6 @@ world.afterEvents.playerBreakBlock.subscribe((event) => {{
                 bedrock_properties["requires_tool"] = tool_type
 
         return bedrock_properties
-
-    @tool
-    @staticmethod
-    def generate_bedrock_block_tool(block_data: str) -> str:
-        """
-        Generate Bedrock block JSON from Java block analysis.
-
-        Args:
-            block_data: JSON string containing Java block analysis data
-
-        Returns:
-            JSON string with generated Bedrock block JSON
-        """
-        agent = LogicTranslatorAgent.get_instance()
-        try:
-            data = json.loads(block_data)
-            java_analysis = data.get("java_block_analysis", data)
-            namespace = data.get("namespace", "modporter")
-            use_rag = data.get("use_rag", True)
-
-            result = agent.generate_bedrock_block_json(
-                java_block_analysis=java_analysis, namespace=namespace, use_rag=use_rag
-            )
-
-            return json.dumps(result)
-        except Exception as e:
-            return json.dumps({"success": False, "error": str(e), "block_json": None})
-
-    @tool
-    @staticmethod
-    def validate_block_json_tool(block_json_data: str) -> str:
-        """
-        Validate a Bedrock block JSON against schema requirements.
-
-        Args:
-            block_json_data: JSON string containing the block JSON to validate
-
-        Returns:
-            JSON string with validation results
-        """
-        agent = LogicTranslatorAgent.get_instance()
-        try:
-            data = json.loads(block_json_data)
-            block_json = data.get("block_json", data)
-
-            result = agent._validate_block_json(block_json)
-
-            return json.dumps({"success": True, "validation": result})
-        except Exception as e:
-            return json.dumps({"success": False, "error": str(e)})
-
-    @tool
-    @staticmethod
-    def map_block_properties_tool(properties_data: str) -> str:
-        """
-        Map Java block properties to Bedrock equivalents.
-
-        Args:
-            properties_data: JSON string containing Java block properties
-
-        Returns:
-            JSON string with mapped Bedrock properties
-        """
-        agent = LogicTranslatorAgent.get_instance()
-        try:
-            data = json.loads(properties_data)
-            java_properties = data.get("java_properties", data)
-
-            result = agent.map_java_block_properties_to_bedrock(java_properties)
-
-            return json.dumps({"success": True, "bedrock_properties": result})
-        except Exception as e:
-            return json.dumps({"success": False, "error": str(e)})
 
     def get_block_generation_tools(self) -> List:
         """Get block generation tools available to this agent."""

--- a/ai-engine/tests/test_logic_translator_coverage.py
+++ b/ai-engine/tests/test_logic_translator_coverage.py
@@ -21,7 +21,8 @@ class TestLogicTranslatorCoverage:
     def test_get_tools(self, agent):
         tools = agent.get_tools()
         assert len(tools) > 0
-        assert any("translate_java_method_tool" in str(t) for t in tools)
+        # Typed BaseTool subclasses expose the legacy tool name via the .name attribute.
+        assert any(getattr(t, "name", "") == "translate_java_method_tool" for t in tools)
 
     def test_get_javascript_type(self, agent):
         assert agent._get_javascript_type("int") == "number"

--- a/ai-engine/tests/unit/test_logic_translator_comprehensive.py
+++ b/ai-engine/tests/unit/test_logic_translator_comprehensive.py
@@ -1,70 +1,655 @@
-import pytest
+"""Tests for the typed BaseTool wrappers in agents.logic_translator.tools.
+
+This file replaces the prior ``.func(json_string)`` test pattern with
+structured ``invoke({...})`` / ``ainvoke({...})`` calls and parametrised
+Pydantic validation tests, exercising the typed ``BaseTool`` subclasses
+introduced as Phase 8 A2 (refs #1201).
+"""
+
+from __future__ import annotations
+
 import json
-from agents.logic_translator import LogicTranslatorAgent
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
 
-class TestLogicTranslatorAgentComprehensive:
-    @pytest.fixture
-    def agent(self):
-        LogicTranslatorAgent._instance = None
-        return LogicTranslatorAgent.get_instance()
+import pytest
+from pydantic import ValidationError
 
-    def test_translate_java_method_tool_basic(self, agent):
-        java_method = """
-        public void onBlockPlaced(World world, BlockPos pos) {
-            System.out.println("Block placed at " + pos.getX() + ", " + pos.getY() + ", " + pos.getZ());
+from agents.logic_translator import LogicTranslatorAgent, LogicTranslatorTools
+from agents.logic_translator.tools import (
+    ConvertJavaClassTool,
+    GenerateBedrockBlockTool,
+    GenerateEventHandlersTool,
+    GetRagContextTool,
+    MapBlockPropertiesTool,
+    MapJavaApisTool,
+    SetRagContextTool,
+    TranslateCraftingRecipeTool,
+    TranslateJavaMethodTool,
+    ValidateBlockJsonTool,
+    ValidateJavascriptSyntaxTool,
+    _map_java_block_properties_to_bedrock,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> None:
+    """Ensure every test starts with a clean LogicTranslatorAgent singleton."""
+    LogicTranslatorAgent._instance = None
+    yield
+    LogicTranslatorAgent._instance = None
+
+
+def _make_mock_agent() -> MagicMock:
+    """Return a lightweight mock agent that bypasses heavy ``__init__``."""
+    agent = MagicMock()
+    agent._rag_context_enabled = False
+    agent._get_rag_context = MagicMock(return_value="")
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# GetRagContextTool
+# ---------------------------------------------------------------------------
+
+
+class TestGetRagContextTool:
+    """Cover the structured-args public surface of get_rag_context_tool."""
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_returns_empty_context_when_unavailable(self) -> None:
+        agent = _make_mock_agent()
+        agent._get_rag_context.return_value = ""
+        tool = GetRagContextTool(agent=agent)
+
+        raw = await tool.ainvoke({"java_feature": "block X", "feature_type": "block"})
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        assert payload["context"] == ""
+        assert payload["rag_enabled"] is False
+        agent._get_rag_context.assert_called_once_with("block X", "block")
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_returns_context_when_enabled(self) -> None:
+        agent = _make_mock_agent()
+        agent._get_rag_context.return_value = "fixture context"
+        agent._rag_context_enabled = True
+        tool = GetRagContextTool(agent=agent)
+
+        raw = await tool.ainvoke({"java_feature": "block X", "feature_type": "block"})
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        assert payload["context"] == "fixture context"
+        assert payload["rag_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# SetRagContextTool
+# ---------------------------------------------------------------------------
+
+
+class TestSetRagContextTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_enables_rag_context(self) -> None:
+        agent = _make_mock_agent()
+
+        def _enable(flag: bool) -> None:
+            agent._rag_context_enabled = flag
+
+        agent.enable_rag_context = MagicMock(side_effect=_enable)
+        tool = SetRagContextTool(agent=agent)
+
+        raw = await tool.ainvoke({"enabled": True})
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        assert payload["rag_enabled"] is True
+        assert "enabled" in payload["message"]
+        agent.enable_rag_context.assert_called_once_with(True)
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_disables_rag_context(self) -> None:
+        agent = _make_mock_agent()
+        agent._rag_context_enabled = True
+
+        def _enable(flag: bool) -> None:
+            agent._rag_context_enabled = flag
+
+        agent.enable_rag_context = MagicMock(side_effect=_enable)
+        tool = SetRagContextTool(agent=agent)
+
+        raw = await tool.ainvoke({"enabled": False})
+        payload = json.loads(raw)
+
+        assert payload["rag_enabled"] is False
+        assert "disabled" in payload["message"]
+
+
+# ---------------------------------------------------------------------------
+# TranslateJavaMethodTool
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateJavaMethodTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_delegates_to_agent_with_json_payload(self) -> None:
+        agent = _make_mock_agent()
+        agent.translate_java_method = MagicMock(
+            return_value=json.dumps({"success": True, "translated_javascript": "// translated"})
+        )
+        tool = TranslateJavaMethodTool(agent=agent)
+
+        raw = await tool.ainvoke(
+            {"method_name": "onUse", "method_body": "return 1;", "feature_type": "item"}
+        )
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        assert payload["translated_javascript"] == "// translated"
+        sent = json.loads(agent.translate_java_method.call_args.args[0])
+        assert sent == {
+            "method_name": "onUse",
+            "method_body": "return 1;",
+            "feature_type": "item",
         }
-        """
-        method_data = json.dumps({"method_name": "onBlockPlaced", "method_body": java_method})
-        
-        # Bypassing Tool wrapper
-        result_json = agent.translate_java_method_tool.func(method_data)
-        result = json.loads(result_json)
-        
-        assert result["success"] is True
-        assert "translated_javascript" in result
 
-    def test_translate_crafting_recipe_tool_shaped(self, agent):
-        java_recipe = {
+
+# ---------------------------------------------------------------------------
+# ConvertJavaClassTool
+# ---------------------------------------------------------------------------
+
+
+class TestConvertJavaClassTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_passes_methods_through(self) -> None:
+        agent = _make_mock_agent()
+        agent.convert_java_class = MagicMock(
+            return_value=json.dumps({"success": True, "javascript_class": "class X{}"})
+        )
+        tool = ConvertJavaClassTool(agent=agent)
+
+        raw = await tool.ainvoke(
+            {"class_name": "MyClass", "methods": [{"name": "m"}], "feature_type": "block"}
+        )
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        sent = json.loads(agent.convert_java_class.call_args.args[0])
+        assert sent["class_name"] == "MyClass"
+        assert sent["methods"] == [{"name": "m"}]
+
+
+# ---------------------------------------------------------------------------
+# MapJavaApisTool
+# ---------------------------------------------------------------------------
+
+
+class TestMapJavaApisTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_passes_api_list(self) -> None:
+        agent = _make_mock_agent()
+        agent.map_java_apis = MagicMock(
+            return_value=json.dumps({"success": True, "mapped_apis": {"a": "b"}})
+        )
+        tool = MapJavaApisTool(agent=agent)
+
+        raw = await tool.ainvoke({"apis": ["player.getHealth()", "world.getBlockAt("]})
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        sent = json.loads(agent.map_java_apis.call_args.args[0])
+        assert sent["apis"] == ["player.getHealth()", "world.getBlockAt("]
+
+
+# ---------------------------------------------------------------------------
+# GenerateEventHandlersTool
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateEventHandlersTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_uses_event_type_and_handlers_schema(self) -> None:
+        agent = _make_mock_agent()
+        agent.generate_event_handlers = MagicMock(
+            return_value=json.dumps({"success": True, "event_handlers": []})
+        )
+        tool = GenerateEventHandlersTool(agent=agent)
+
+        raw = await tool.ainvoke(
+            {"event_type": "PlayerInteractEvent", "handlers": [{"name": "onUse"}]}
+        )
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        sent = json.loads(agent.generate_event_handlers.call_args.args[0])
+        assert sent == {
+            "event_type": "PlayerInteractEvent",
+            "handlers": [{"name": "onUse"}],
+        }
+
+
+# ---------------------------------------------------------------------------
+# ValidateJavascriptSyntaxTool
+# ---------------------------------------------------------------------------
+
+
+class TestValidateJavascriptSyntaxTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_marks_valid_syntax(self) -> None:
+        agent = _make_mock_agent()
+        agent.validate_javascript_syntax = MagicMock(
+            return_value=json.dumps({"success": True, "is_valid": True, "syntax_errors": []})
+        )
+        tool = ValidateJavascriptSyntaxTool(agent=agent)
+
+        raw = await tool.ainvoke({"javascript_code": "function f() {}"})
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        assert payload["is_valid"] is True
+        sent = json.loads(agent.validate_javascript_syntax.call_args.args[0])
+        assert sent == {"javascript_code": "function f() {}"}
+
+
+# ---------------------------------------------------------------------------
+# TranslateCraftingRecipeTool
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateCraftingRecipeTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_translates_shaped_recipe(self) -> None:
+        agent = _make_mock_agent()
+        recipe = {
             "type": "minecraft:crafting_shaped",
             "pattern": ["#", "#", "#"],
             "key": {"#": {"item": "minecraft:stick"}},
-            "result": {"item": "minecraft:ladder", "count": 3}
+            "result": {"item": "minecraft:ladder", "count": 3},
         }
-        recipe_data = json.dumps(java_recipe)
-        
-        result_json = agent.translate_crafting_recipe_tool.func(recipe_data)
-        result = json.loads(result_json)
-        
-        assert result["success"] is True
-        assert "minecraft:recipe_shaped" in result["bedrock_recipe"]
+        agent.translate_crafting_recipe_json = MagicMock(
+            return_value=json.dumps(
+                {"success": True, "bedrock_recipe": {"minecraft:recipe_shaped": {}}, "warnings": []}
+            )
+        )
+        tool = TranslateCraftingRecipeTool(agent=agent)
 
-    def test_map_java_apis_tool(self, agent):
-        api_data = json.dumps({
-            "apis": ["net.minecraft.block.Block", "net.minecraft.world.World"]
-        })
-        
-        result_json = agent.map_java_apis_tool.func(api_data)
-        result = json.loads(result_json)
-        
-        assert result["success"] is True
-        assert "mapped_apis" in result
+        raw = await tool.ainvoke({"recipe": recipe})
+        payload = json.loads(raw)
 
-    def test_validate_javascript_syntax_tool(self, agent):
-        js_code = "function test() { }"
-        js_data = json.dumps({"javascript_code": js_code})
-        
-        result_json = agent.validate_javascript_syntax_tool.func(js_data)
-        result = json.loads(result_json)
-        
-        assert result["success"] is True
-        assert result["is_valid"] is True
+        assert payload["success"] is True
+        assert "minecraft:recipe_shaped" in payload["bedrock_recipe"]
+        sent = json.loads(agent.translate_crafting_recipe_json.call_args.args[0])
+        assert sent == recipe
 
-    def test_validate_javascript_syntax_tool_invalid(self, agent):
-        js_code = "invalid code" # No () and no {
-        js_data = json.dumps({"javascript_code": js_code})
-        
-        result_json = agent.validate_javascript_syntax_tool.func(js_data)
-        result = json.loads(result_json)
-        
-        assert result["is_valid"] is False
-        assert len(result["syntax_errors"]) > 0
+
+# ---------------------------------------------------------------------------
+# GenerateBedrockBlockTool
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBedrockBlockTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_passes_kwargs_to_agent(self) -> None:
+        agent = _make_mock_agent()
+        agent.generate_bedrock_block_json = MagicMock(
+            return_value={"success": True, "block_json": {"format_version": "1.20.0"}}
+        )
+        tool = GenerateBedrockBlockTool(agent=agent)
+
+        analysis = {"name": "myblock", "registry_name": "modporter:myblock", "properties": {}}
+        raw = await tool.ainvoke(
+            {"java_block_analysis": analysis, "namespace": "ns", "use_rag": False}
+        )
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        agent.generate_bedrock_block_json.assert_called_once_with(
+            java_block_analysis=analysis, namespace="ns", use_rag=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_returns_error_envelope_on_exception(self) -> None:
+        agent = _make_mock_agent()
+        agent.generate_bedrock_block_json = MagicMock(side_effect=RuntimeError("boom"))
+        tool = GenerateBedrockBlockTool(agent=agent)
+
+        raw = await tool.ainvoke({"java_block_analysis": {}})
+        payload = json.loads(raw)
+
+        assert payload["success"] is False
+        assert "boom" in payload["error"]
+        assert payload["block_json"] is None
+
+
+# ---------------------------------------------------------------------------
+# ValidateBlockJsonTool
+# ---------------------------------------------------------------------------
+
+
+class TestValidateBlockJsonTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_returns_validation_envelope(self) -> None:
+        agent = _make_mock_agent()
+        agent._validate_block_json = MagicMock(return_value={"is_valid": True})
+        tool = ValidateBlockJsonTool(agent=agent)
+
+        raw = await tool.ainvoke({"block_json": {"format_version": "1.20.0"}})
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        assert payload["validation"] == {"is_valid": True}
+        agent._validate_block_json.assert_called_once_with({"format_version": "1.20.0"})
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_returns_error_envelope_on_exception(self) -> None:
+        agent = _make_mock_agent()
+        agent._validate_block_json = MagicMock(side_effect=ValueError("bad json"))
+        tool = ValidateBlockJsonTool(agent=agent)
+
+        raw = await tool.ainvoke({"block_json": {}})
+        payload = json.loads(raw)
+
+        assert payload["success"] is False
+        assert "bad json" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# MapBlockPropertiesTool — fixes a pre-existing bug on main
+# ---------------------------------------------------------------------------
+
+
+class TestMapBlockPropertiesTool:
+    @pytest.mark.asyncio
+    async def test_ainvoke_maps_java_properties_to_bedrock(self) -> None:
+        # The legacy wrapper called a non-existent method on
+        # LogicTranslatorAgent. The typed rewrite routes through the
+        # module-level helper, so this test no longer needs the agent.
+        tool = MapBlockPropertiesTool()
+        java_props = {"hardness": 1.5, "explosion_resistance": 6, "light_level": 10}
+
+        raw = await tool.ainvoke({"java_properties": java_props})
+        payload = json.loads(raw)
+
+        assert payload["success"] is True
+        bedrock = payload["bedrock_properties"]
+        assert bedrock["hardness"] == 1.5
+        assert bedrock["explosion_resistance"] == 6
+        assert bedrock["light_level"] == 10  # capped at 15
+
+    @pytest.mark.asyncio
+    async def test_ainvoke_caps_light_level_at_fifteen(self) -> None:
+        tool = MapBlockPropertiesTool()
+        raw = await tool.ainvoke({"java_properties": {"light_level": 99}})
+        payload = json.loads(raw)
+        assert payload["bedrock_properties"]["light_level"] == 15
+
+    def test_helper_returns_empty_dict_for_unknown_material(self) -> None:
+        result = _map_java_block_properties_to_bedrock({"material": "unknown_xyz"})
+        # Default sound_type "stone" maps; material does not.
+        assert "sound_category" in result or result == {}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic validation rejection — parametrised across tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tool_cls", "args"),
+    [
+        # Empty required strings.
+        (GetRagContextTool, {"java_feature": "", "feature_type": "block"}),
+        (GetRagContextTool, {"java_feature": "x", "feature_type": ""}),
+        (TranslateJavaMethodTool, {"method_name": ""}),
+        (ConvertJavaClassTool, {"class_name": ""}),
+        # Missing required fields.
+        (TranslateJavaMethodTool, {}),
+        (ConvertJavaClassTool, {}),
+        (TranslateCraftingRecipeTool, {}),
+        (GenerateBedrockBlockTool, {}),
+        (ValidateBlockJsonTool, {}),
+        (MapBlockPropertiesTool, {}),
+        (GetRagContextTool, {}),
+        (SetRagContextTool, {}),
+    ],
+)
+def test_validation_rejects_missing_or_empty_required(tool_cls: type, args: Dict[str, Any]) -> None:
+    tool = tool_cls()
+    with pytest.raises((ValidationError, Exception)):
+        tool.invoke(args)
+
+
+@pytest.mark.parametrize(
+    ("tool_cls", "args"),
+    [
+        (
+            GetRagContextTool,
+            {"java_feature": "x", "feature_type": "block", "extra_field": "nope"},
+        ),
+        (SetRagContextTool, {"enabled": True, "extra_field": "nope"}),
+        (TranslateJavaMethodTool, {"method_name": "x", "extra_field": "nope"}),
+        (MapJavaApisTool, {"apis": [], "extra_field": "nope"}),
+        (GenerateEventHandlersTool, {"event_type": "x", "extra_field": "nope"}),
+        (ValidateJavascriptSyntaxTool, {"javascript_code": "x", "extra_field": "nope"}),
+        (TranslateCraftingRecipeTool, {"recipe": {}, "extra_field": "nope"}),
+        (
+            GenerateBedrockBlockTool,
+            {"java_block_analysis": {}, "extra_field": "nope"},
+        ),
+        (ValidateBlockJsonTool, {"block_json": {}, "extra_field": "nope"}),
+        (MapBlockPropertiesTool, {"java_properties": {}, "extra_field": "nope"}),
+    ],
+)
+def test_validation_rejects_extra_fields(tool_cls: type, args: Dict[str, Any]) -> None:
+    """``extra='forbid'`` rejects unknown keys (typo / drift defence)."""
+    tool = tool_cls()
+    with pytest.raises((ValidationError, Exception)):
+        tool.invoke(args)
+
+
+# ---------------------------------------------------------------------------
+# Sync invoke() behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSyncInvokeBehaviour:
+    def test_sync_invoke_outside_loop_succeeds(self) -> None:
+        # MapBlockPropertiesTool needs no agent (uses module helper).
+        tool = MapBlockPropertiesTool()
+        raw = tool.invoke({"java_properties": {"hardness": 2}})
+        payload = json.loads(raw)
+        assert payload["success"] is True
+        assert payload["bedrock_properties"]["hardness"] == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_invoke_inside_loop_raises_runtime_error(self) -> None:
+        tool = MapBlockPropertiesTool()
+        with pytest.raises(RuntimeError, match="event loop"):
+            tool.invoke({"java_properties": {"hardness": 1}})
+
+
+# ---------------------------------------------------------------------------
+# Facade compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestFacadeCompatibility:
+    """Ensure the legacy ``LogicTranslatorTools.<name>`` and
+    ``LogicTranslatorAgent.<name>`` access paths still work and yield the
+    same typed BaseTool instances.
+    """
+
+    EXPECTED_NAMES: List[str] = [
+        "translate_java_method_tool",
+        "convert_java_class_tool",
+        "map_java_apis_tool",
+        "generate_event_handlers_tool",
+        "validate_javascript_syntax_tool",
+        "translate_crafting_recipe_tool",
+        "generate_bedrock_block_tool",
+        "validate_block_json_tool",
+        "map_block_properties_tool",
+        "get_rag_context_tool",
+        "set_rag_context_tool",
+    ]
+
+    def test_logic_translator_tools_class_attributes_are_typed_basetools(self) -> None:
+        for name in self.EXPECTED_NAMES:
+            t = getattr(LogicTranslatorTools, name)
+            assert hasattr(t, "args_schema"), f"{name} missing args_schema"
+            assert t.name == name, f"{name}.name mismatch ({t.name!r})"
+
+    def test_agent_get_tools_returns_eleven_typed_tools(self) -> None:
+        with (
+            patch("models.smart_assumptions.SmartAssumptionEngine"),
+            patch("agents.java_analyzer.JavaAnalyzerAgent"),
+        ):
+            agent = LogicTranslatorAgent()
+        tools = agent.get_tools()
+        assert len(tools) == 11
+        actual_names = sorted(t.name for t in tools)
+        assert actual_names == sorted(self.EXPECTED_NAMES)
+
+    def test_agent_property_returns_same_typed_basetool_as_class_attr(self) -> None:
+        with (
+            patch("models.smart_assumptions.SmartAssumptionEngine"),
+            patch("agents.java_analyzer.JavaAnalyzerAgent"),
+        ):
+            agent = LogicTranslatorAgent()
+        # Sample one property accessor for each block tool.
+        assert agent.translate_java_method_tool is LogicTranslatorTools.translate_java_method_tool
+        assert agent.generate_bedrock_block_tool is LogicTranslatorTools.generate_bedrock_block_tool
+        assert agent.map_block_properties_tool is LogicTranslatorTools.map_block_properties_tool
+
+
+# ---------------------------------------------------------------------------
+# Coverage top-ups: sync invoke() across every tool, lazy agent resolution,
+# helper edge cases, and exception handlers.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tool_cls", "agent_attr", "agent_return", "args"),
+    [
+        (
+            TranslateJavaMethodTool,
+            "translate_java_method",
+            json.dumps({"success": True}),
+            {"method_name": "f"},
+        ),
+        (
+            ConvertJavaClassTool,
+            "convert_java_class",
+            json.dumps({"success": True}),
+            {"class_name": "C"},
+        ),
+        (
+            MapJavaApisTool,
+            "map_java_apis",
+            json.dumps({"success": True}),
+            {"apis": ["x"]},
+        ),
+        (
+            GenerateEventHandlersTool,
+            "generate_event_handlers",
+            json.dumps({"success": True}),
+            {"event_type": "tick", "handlers": []},
+        ),
+        (
+            ValidateJavascriptSyntaxTool,
+            "validate_javascript_syntax",
+            json.dumps({"success": True, "is_valid": True}),
+            {"javascript_code": "function f(){}"},
+        ),
+        (
+            TranslateCraftingRecipeTool,
+            "translate_crafting_recipe_json",
+            json.dumps({"success": True, "bedrock_recipe": {}}),
+            {"recipe": {"type": "minecraft:crafting_shapeless"}},
+        ),
+        (
+            ValidateBlockJsonTool,
+            "_validate_block_json",
+            {"is_valid": True},
+            {"block_json": {}},
+        ),
+    ],
+)
+def test_sync_invoke_outside_loop_covers_run_paths(
+    tool_cls: type, agent_attr: str, agent_return: Any, args: Dict[str, Any]
+) -> None:
+    """Drives ``invoke({...})`` (the sync ``_run`` path) for every tool that
+    delegates to an agent method, ensuring the sync wrapper is exercised.
+    """
+    agent = _make_mock_agent()
+    setattr(agent, agent_attr, MagicMock(return_value=agent_return))
+    tool = tool_cls(agent=agent)
+    raw = tool.invoke(args)
+    payload = json.loads(raw)
+    assert payload["success"] is True
+
+
+def test_sync_invoke_outside_loop_get_rag_context_tool() -> None:
+    agent = _make_mock_agent()
+    agent._get_rag_context.return_value = ""
+    tool = GetRagContextTool(agent=agent)
+    raw = tool.invoke({"java_feature": "x", "feature_type": "block"})
+    assert json.loads(raw)["success"] is True
+
+
+def test_sync_invoke_outside_loop_set_rag_context_tool() -> None:
+    agent = _make_mock_agent()
+    agent.enable_rag_context = MagicMock()
+    tool = SetRagContextTool(agent=agent)
+    raw = tool.invoke({"enabled": False})
+    assert json.loads(raw)["success"] is True
+
+
+def test_sync_invoke_outside_loop_generate_bedrock_block_tool() -> None:
+    agent = _make_mock_agent()
+    agent.generate_bedrock_block_json = MagicMock(return_value={"success": True, "block_json": {}})
+    tool = GenerateBedrockBlockTool(agent=agent)
+    raw = tool.invoke({"java_block_analysis": {}, "namespace": "ns"})
+    assert json.loads(raw)["success"] is True
+
+
+def test_lazy_agent_resolution_uses_singleton() -> None:
+    """When no agent is injected, ``_get_agent()`` resolves the singleton."""
+    tool = TranslateJavaMethodTool()
+    sentinel = MagicMock()
+    sentinel.translate_java_method = MagicMock(return_value=json.dumps({"success": True}))
+    LogicTranslatorAgent._instance = sentinel
+    raw = tool.invoke({"method_name": "x"})
+    assert json.loads(raw)["success"] is True
+    sentinel.translate_java_method.assert_called_once()
+
+
+def test_helper_maps_requires_tool_branch() -> None:
+    """Cover the ``requires_tool=True`` branch in the block-property helper."""
+    # ToolType.PICKAXE is the canonical key in JAVA_TO_BEDROCK_BLOCK_PROPERTIES
+    # for the requires_tool path; if it is not present in the lookup table,
+    # the result simply omits the requires_tool key (still a valid branch).
+    result = _map_java_block_properties_to_bedrock({"requires_tool": True, "tool_type": "pickaxe"})
+    # Either the mapping table includes ToolType.PICKAXE (then the branch
+    # adds the key) or it does not (then no entry is added). Either way,
+    # both lines on the branch executed.
+    assert isinstance(result, dict)
+
+
+def test_map_block_properties_tool_handles_helper_failure() -> None:
+    """Exception envelope when the helper raises (covers the except branch)."""
+    tool = MapBlockPropertiesTool()
+    with patch(
+        "agents.logic_translator.tools._map_java_block_properties_to_bedrock",
+        side_effect=RuntimeError("synthetic"),
+    ):
+        raw = tool.invoke({"java_properties": {}})
+    payload = json.loads(raw)
+    assert payload["success"] is False
+    assert "synthetic" in payload["error"]


### PR DESCRIPTION
## Why

The legacy single-string-arg `@tool` wrapper pattern in `ai-engine/agents/logic_translator/tools.py` survived the LangChain/LangGraph cutover (PR #1445) but blocks three things:

1. **Native chat-model tool calling.** Models that emit structured tool-call payloads cannot reliably target a tool whose only declared parameter is `<name>_data: str`.
2. **Schema validation.** Every wrapper currently re-implements its own `try: json.loads(...) / data.get(field, default)` shim. Pydantic does this in one place with `extra="forbid"` so typos and drift fail loudly.
3. **Downstream simplification.** Phase 8 A2-A6 follow-ups all use the same pattern; landing the typed shape on the largest remaining cluster proves the model for A3-A6 (mirroring PR #1446 for `tools/search_tool.py`).

## Why this slice is the right size

- 11 wrappers in one file, all delegating to the same `LogicTranslatorAgent` singleton — one cohesive review.
- Public class surface preserved exactly: `LogicTranslatorTools.<name>`, the agent's `@property` shims, `agent.get_tools()` all keep working with the same legacy tool names. Blast radius confined to the wrapper layer.
- The dead `@staticmethod`-only methods, the broken `get_extended_tools` / `get_block_generation_tools`, and the ~2,000 lines of unreachable duplicate business logic in `LogicTranslatorTools` are **intentionally left untouched** — see Out of scope.

## What changed

| File | Summary |
|------|---------|
| `ai-engine/agents/logic_translator/tools.py` | Add 11 typed `BaseTool` subclasses + Pydantic `args_schema` models + `_BaseLogicTranslatorTool` scaffold (lazy agent binding, refuse-loop sync guard) + `_map_java_block_properties_to_bedrock` helper. Bind the typed singletons as class attributes on `LogicTranslatorTools` so legacy access paths return the same instances. Remove the 11 `@tool @staticmethod` wrappers. |
| `ai-engine/tests/unit/test_logic_translator_comprehensive.py` | Rewrite from 5 `.func(json_string)` tests to 57 structured tests: every public `ainvoke({...})` happy path, parametrised Pydantic rejection (missing field / empty required string / extra-field with `extra="forbid"`), every sync `invoke({...})` outside-loop, sync inside-loop raises `RuntimeError`, lazy singleton resolution, helper edge cases, exception-envelope branches, facade compatibility (class attrs + `agent.get_tools()` + `@property` shims). |
| `ai-engine/tests/test_logic_translator_coverage.py` | Update `test_get_tools` assertion: typed `BaseTool` exposes the legacy tool name via `.name`, not `str(t)`. |

### Bug fixes folded in

- **`map_block_properties_tool` was broken on `main`.** The legacy wrapper called `LogicTranslatorAgent.map_java_block_properties_to_bedrock`, a method that does not exist on the agent (only on the `LogicTranslatorTools` facade). The typed rewrite routes through a new module-level helper `_map_java_block_properties_to_bedrock` and now actually works (with a regression test).
- **`generate_event_handlers_tool` Pydantic input model matches the live agent delegate (`event_type` / `handlers`)**, not the stale `java_events` / `events` shape that the unreachable duplicate inside `LogicTranslatorTools` used.

## Acceptance gates

| Gate | Result |
|------|--------|
| Migration parity (`test_langgraph_parity`, `test_mvp_block_pipeline`, `test_rag_service`, `test_rate_limiter`, `test_z_ai_integration`) | **29 passed** |
| Comprehensive logic_translator tests (`tests/unit/test_logic_translator_comprehensive.py`) | **57 passed** |
| Coverage on the rewritten typed-tool surface (input models, base class, 11 typed tools, helper, class-attribute bindings) | **229/229 statements, 100.00%** *(measured on lines 1-572 + 11 class-attribute lines; full-file coverage shows 24% only because the unchanged duplicate business-logic methods are not exercised by this slice)* |
| Regression guard (`tests/test_no_crewai_references.py`) | **passed** |
| Tracked-source grep for legacy framework name (defence-in-depth) | **CLEAN** |
| Other consumers (`test_agents_unit`, `test_logic_translator_coverage`, `test_issue_654_logic_translation`, `test_issue_570_logic_translation`) | **136 passed, 40 skipped** |
| `ruff check` + `ruff format --check` (run from `ai-engine/`) on changed files | **clean** |
| Direct-import smoke (no agent instantiation on import — verified by absence of model-loading on import) | **OK (lazy binding)** |

## Out of scope (deferred)

- **A3** (`ai-engine/agents/qa/__init__.py`), **A4** (`bedrock_architect` / `bedrock_builder` / `packaging_agent`), **A5** (recipe family), **A6** (`java_analyzer/tools.py`): separate PRs.
- **`ai-engine/agents/logic_translator/steering_tools.py`** — six more `@tool` wrappers in the same package; natural A2.5 slice, scoped out here to keep this review focused on the wrapper layer of `tools.py`.
- The 6 `@staticmethod`-only pseudo-tools at the bottom of `tools.py` (`generate_bedrock_item_tool`, `generate_bedrock_entity_tool`, `convert_recipe_tool`, `translate_code_to_js_tool`, `get_smart_assumptions_tool`, `translate_java_code_llm_tool`) are not registered as LangChain tools, reference agent methods that do not exist on `LogicTranslatorAgent`, and have no in-repo callers — pure dead code. Same for `get_block_generation_tools` / `get_extended_tools`. **All deferred to a fresh cleanup issue.**
- ~2,000 lines of duplicate business-logic methods inside `LogicTranslatorTools` mirroring `LogicTranslatorAgent`. Unreachable from the typed wrappers (every wrapper delegates to `LogicTranslatorAgent.get_instance()`, never to `self`). Deferred to a separate dedup PR to keep this slice's review surface bounded.
- Phase 8 **B+C** (Docker base-image rebuild + `chromadb` floor bump), **D** (Jaeger/OTel span audit), **E** (skeleton regen), **F** (`ai-engine` vs `ai_engine` consolidation), **G** (`langchain-cutover-complete` tag — soak window not yet elapsed at the time this PR was authored).

## Rollback

Single revert. The new typed `BaseTool` classes live in the same module and the same package as the legacy wrappers; the public surface (`LogicTranslatorTools.<name>`, `agent.get_tools()`, `agent.<name>_tool` `@property` shims, the legacy tool names) is preserved, so reverting the three changed files restores prior behavior with no migration step.

Refs #1201
