### PR TITLE
fix(ai-engine): mmsd.premium_client._parse_output mismatched JSON as JS

### DIFF
--- a/ai-engine/mmsd/premium_client.py
+++ b/ai-engine/mmsd/premium_client.py
@@ -625,7 +625,7 @@ class PortKitPremium:
                 break
 
         # Extract JS blocks
-        js_blocks = re.findall(r"```(?:javascript|js)\s*(.*?)\s*```", output, re.DOTALL)
+        js_blocks = re.findall(r"```(?:javascript|js)\b\s*(.*?)\s*```", output, re.DOTALL)
         script = max(js_blocks, key=len).strip() if js_blocks else ""
 
         success = bool(reasoning and (manifest or script))

--- a/ai-engine/tests/test_premium_client.py
+++ b/ai-engine/tests/test_premium_client.py
@@ -198,13 +198,6 @@ class TestBuildMessages:
 class TestParseOutput:
     """Tests for output parsing."""
 
-    @pytest.mark.xfail(
-        reason="Pre-existing parser bug in PortKitPremium._parse_output: "
-        "bedrock_script is populated with manifest JSON instead of script TS. "
-        "Test was uncollectable on main due to namespace mismatch (`from ai_engine.mmsd.*`); "
-        "consolidating the namespace surfaced the latent failure. Fix in a follow-up PR.",
-        strict=True,
-    )
     def test_parse_output_extracts_reasoning_and_manifest(self):
         from mmsd.premium_client import PortKitPremium
 
@@ -234,6 +227,59 @@ import { world } from "@minecraft/server";
         assert "Block Registration" in result.reasoning
         assert "format_version" in result.bedrock_manifest
         assert "minecraft/server" in result.bedrock_script
+        client.close()
+
+    def test_parse_output_does_not_confuse_json_block_for_js(self):
+        """Regression: ``r"```(?:javascript|js)..."`` without word boundary used
+        to match the start of a ``json`` fence, so the JSON manifest content
+        leaked into bedrock_script. Word boundary in the alternation prevents this.
+        """
+        from mmsd.premium_client import PortKitPremium
+
+        client = PortKitPremium(api_key="sk-test-key")
+        # Note: this output has a JSON block BEFORE any JS block — the order
+        # that triggered the original bug.
+        output = """## Conversion Plan
+
+step 1
+
+## Bedrock Add-on Output
+
+### manifest.json
+```json
+{"format_version": 2, "header": {"name": "X"}}
+```
+
+### scripts/main.js
+```javascript
+console.log("hello");
+```"""
+        result = client._parse_output(output, "deepseek-v4-pro", 1000)
+        assert result.bedrock_manifest.startswith("{"), result.bedrock_manifest
+        assert "format_version" in result.bedrock_manifest
+        assert result.bedrock_script == 'console.log("hello");', result.bedrock_script
+        # Critical regression assertions:
+        assert "format_version" not in result.bedrock_script
+        assert "{" not in result.bedrock_script
+        client.close()
+
+    def test_parse_output_handles_json_only_no_js(self):
+        """A JSON-only output should not produce a stray bedrock_script."""
+        from mmsd.premium_client import PortKitPremium
+
+        client = PortKitPremium(api_key="sk-test-key")
+        output = """## Conversion Plan
+
+plan
+
+## Bedrock Add-on Output
+
+```json
+{"format_version": 2, "header": {"name": "X"}}
+```"""
+        result = client._parse_output(output, "deepseek-v4-pro", 1000)
+        assert "format_version" in result.bedrock_manifest
+        assert result.bedrock_script == ""
         client.close()
 
     def test_parse_output_handles_missing_sections(self):


### PR DESCRIPTION
## Summary

Fixes the parser bug in `mmsd.premium_client._parse_output` that was surfaced (but not fixed) by PR #1448. The xfail marker added there was `strict=True`, so this fix removes the marker as well — without this PR, any future accidental fix would XPASS-fail in CI.

## The bug

`_parse_output` used `r"```(?:javascript|js)\s*(.*?)\s*```"` to extract the JS bedrock_script block. Without a word boundary, the `js` alternative matched the first two characters of `json`, so the regex captured the JSON manifest contents as a stray "JS" block:

```python
>>> re.findall(r"```(?:javascript|js)\s*(.*?)\s*```", output, re.DOTALL)
['on\n{\n    "format_version": 2, ...}',  # ← JSON contents matched as 'js'
 'import { world } from "@minecraft/server";']
```

`max(js_blocks, key=len)` then picked the longer false match, so `bedrock_script` ended up containing the manifest JSON.

## The fix

One character: add `\b` after the alternation.

```diff
-js_blocks = re.findall(r"```(?:javascript|js)\s*(.*?)\s*```", output, re.DOTALL)
+js_blocks = re.findall(r"```(?:javascript|js)\b\s*(.*?)\s*```", output, re.DOTALL)
```

After `js`, the next character in `json` is `o` (a word character), so `\b` does not match there. The regex now only matches genuine ` ```js ` and ` ```javascript ` fences.

## Verification

- `test_parse_output_extracts_reasoning_and_manifest` (the previously strict-xfail'd test) now **PASSES**. xfail marker removed.
- Added 2 regression tests:
  - `test_parse_output_does_not_confuse_json_block_for_js` — the exact failure mode (JSON-before-JS), with explicit assertions that `bedrock_script` is JS-only and contains no `{` or `format_version`.
  - `test_parse_output_handles_json_only_no_js` — JSON-only output must not produce a stray `bedrock_script`.
- 23/23 tests in `test_premium_client.py` pass (was 20 + 1 xfail).
- 884 unit tests pass under `pytest ai-engine/tests/unit/`.
- `ruff check` / `ruff format --check` clean.

## Closes

Follow-up **Item 7** from PR #1448's "Out of scope" list.
