### PR TITLE
fix(backend): make ai-engine reachable from backend process for non-colliding imports

### DIFF
--- a/ai-engine/search/multimodal_search_engine.py
+++ b/ai-engine/search/multimodal_search_engine.py
@@ -13,6 +13,8 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+logger = logging.getLogger(__name__)
+
 from schemas.multimodal_schema import (
     ContentType,
     EmbeddingModel,
@@ -35,8 +37,6 @@ except ImportError:
     except ImportError:
         EMBEDDING_GENERATOR_AVAILABLE = False
         logger.warning("Embedding generator not available for multi-modal search")
-
-logger = logging.getLogger(__name__)
 
 
 # Default weights for modality-aware scoring

--- a/backend/src/api/knowledge_base.py
+++ b/backend/src/api/knowledge_base.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_db
+from utils.ai_engine_path import ensure_ai_engine_on_path
 from db import crud
 from db.models import PatternSubmission
 
@@ -113,12 +114,7 @@ class ConversionPatternResponse(BaseModel):
 
 def _get_community_manager():
     """Get CommunityPatternManager from AI engine."""
-    ai_engine_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
-        "ai-engine",
-    )
-    if ai_engine_path not in sys.path:
-        sys.path.insert(0, ai_engine_path)
+    ensure_ai_engine_on_path()
 
     from knowledge.community import CommunityPatternManager
 
@@ -127,12 +123,7 @@ def _get_community_manager():
 
 def _get_pattern_library():
     """Get PatternLibrary from AI engine."""
-    ai_engine_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
-        "ai-engine",
-    )
-    if ai_engine_path not in sys.path:
-        sys.path.insert(0, ai_engine_path)
+    ensure_ai_engine_on_path()
 
     from knowledge.patterns import PatternLibrary
 
@@ -405,12 +396,7 @@ class RelatedChunksResponse(BaseModel):
 
 def _get_cross_reference_detector():
     """Get CrossReferenceDetector from AI engine."""
-    ai_engine_path = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
-        "ai-engine",
-    )
-    if ai_engine_path not in sys.path:
-        sys.path.insert(0, ai_engine_path)
+    ensure_ai_engine_on_path()
 
     from knowledge.cross_reference import CrossReferenceDetector
 

--- a/backend/src/api/premium_conversion.py
+++ b/backend/src/api/premium_conversion.py
@@ -23,6 +23,7 @@ from db.base import get_db
 from db.models import User
 from security.auth import verify_api_key
 from api._authz import get_current_user  # issue #1417
+from utils.ai_engine_path import ensure_ai_engine_on_path
 from services.feature_flags import is_feature_enabled, FeatureFlagNotEnabledError
 
 logger = logging.getLogger(__name__)
@@ -134,6 +135,7 @@ async def premium_convert(
     }
     ```
     """
+    ensure_ai_engine_on_path()
     from mmsd.premium_client import PortKitPremium, ConversionResult
 
     api_key = os.environ.get("OPENROUTER_API_KEY", "")
@@ -192,6 +194,7 @@ async def list_premium_models(
     }
     ```
     """
+    ensure_ai_engine_on_path()
     from mmsd.premium_client import MODEL_CONFIGS
 
     return PremiumModelsResponse(models={k: v["model_id"] for k, v in MODEL_CONFIGS.items()})
@@ -225,6 +228,7 @@ async def estimate_premium_cost(
     }
     ```
     """
+    ensure_ai_engine_on_path()
     from mmsd.premium_client import PortKitPremium
 
     api_key = os.environ.get("OPENROUTER_API_KEY", "dummy-key-for-estimate")

--- a/backend/src/tests/unit/test_ai_engine_path.py
+++ b/backend/src/tests/unit/test_ai_engine_path.py
@@ -22,17 +22,28 @@ def reset_state():
 
 
 class TestEnsureAiEnginePath:
-    def test_returns_true_when_repo_layout_resolves(self):
-        """In a real checkout, the repo-root-relative candidate should resolve."""
-        # The repo root is reachable from this test file, so ai-engine/ exists.
+    def test_returns_true_when_a_candidate_directory_exists(self, tmp_path, monkeypatch):
+        """When the env-override candidate exists, the helper returns True and adds it to sys.path."""
+        # Use the env override so the test is independent of the host repo layout.
+        # CI runs the backend container in isolation where the real ai-engine/
+        # directory is not co-located with the backend tree.
+        override = tmp_path / "ai-engine-fixture"
+        override.mkdir()
+        monkeypatch.setenv("AI_ENGINE_PATH", str(override))
+        aep.reset_for_tests()
+
         ok = aep.ensure_ai_engine_on_path()
         assert ok is True
-        # The resolved dir should be on sys.path.
-        assert aep._RESOLVED is not None
-        assert str(aep._RESOLVED) in sys.path
+        assert override == aep._RESOLVED
+        assert str(override) in sys.path
 
-    def test_idempotent_subsequent_calls(self):
+    def test_idempotent_subsequent_calls(self, tmp_path, monkeypatch):
         """A second call is a memoized no-op and returns True."""
+        override = tmp_path / "ai-engine-fixture"
+        override.mkdir()
+        monkeypatch.setenv("AI_ENGINE_PATH", str(override))
+        aep.reset_for_tests()
+
         aep.ensure_ai_engine_on_path()
         snapshot = list(sys.path)
         result = aep.ensure_ai_engine_on_path()

--- a/backend/src/tests/unit/test_ai_engine_path.py
+++ b/backend/src/tests/unit/test_ai_engine_path.py
@@ -1,0 +1,128 @@
+"""Tests for backend.src.utils.ai_engine_path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from utils import ai_engine_path as aep
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    """Each test gets a fresh memoization state and clean sys.path snapshot."""
+    aep.reset_for_tests()
+    original_path = list(sys.path)
+    yield
+    sys.path[:] = original_path
+    aep.reset_for_tests()
+
+
+class TestEnsureAiEnginePath:
+    def test_returns_true_when_repo_layout_resolves(self):
+        """In a real checkout, the repo-root-relative candidate should resolve."""
+        # The repo root is reachable from this test file, so ai-engine/ exists.
+        ok = aep.ensure_ai_engine_on_path()
+        assert ok is True
+        # The resolved dir should be on sys.path.
+        assert aep._RESOLVED is not None
+        assert str(aep._RESOLVED) in sys.path
+
+    def test_idempotent_subsequent_calls(self):
+        """A second call is a memoized no-op and returns True."""
+        aep.ensure_ai_engine_on_path()
+        snapshot = list(sys.path)
+        result = aep.ensure_ai_engine_on_path()
+        assert result is True
+        assert sys.path == snapshot
+
+    def test_env_override_takes_precedence(self, tmp_path, monkeypatch):
+        """AI_ENGINE_PATH env var beats the production and repo-root candidates."""
+        override = tmp_path / "custom-ai-engine"
+        override.mkdir()
+        monkeypatch.setenv("AI_ENGINE_PATH", str(override))
+        aep.reset_for_tests()
+        ok = aep.ensure_ai_engine_on_path()
+        assert ok is True
+        assert override == aep._RESOLVED
+        assert str(override) in sys.path
+
+    def test_does_not_duplicate_path_entry(self):
+        """If the dir is already on sys.path, don't add it again."""
+        aep.ensure_ai_engine_on_path()
+        resolved = str(aep._RESOLVED)
+        first_count = sys.path.count(resolved)
+        # Force re-resolution
+        aep.reset_for_tests()
+        aep.ensure_ai_engine_on_path()
+        assert sys.path.count(resolved) == first_count
+
+    def test_appends_path_instead_of_prepending_to_avoid_shadowing(self, tmp_path):
+        """ai-engine must not shadow backend packages such as utils/schemas/models."""
+        backend_src = tmp_path / "backend-src"
+        ai_engine = tmp_path / "ai-engine"
+        backend_src.mkdir()
+        ai_engine.mkdir()
+        sys.path[:] = [str(backend_src)]
+
+        with patch.object(aep, "_candidate_paths", return_value=[ai_engine]):
+            aep.reset_for_tests()
+            ok = aep.ensure_ai_engine_on_path()
+
+        assert ok is True
+        assert sys.path == [str(backend_src), str(ai_engine)]
+
+    def test_returns_false_when_no_candidate_resolves(self, tmp_path, monkeypatch):
+        """All candidates missing → returns False, doesn't crash, doesn't pollute sys.path."""
+        # Override env var to point at a missing dir
+        missing = tmp_path / "does-not-exist"
+        monkeypatch.setenv("AI_ENGINE_PATH", str(missing))
+        # Patch the production and repo-root candidates to also miss
+        with patch.object(aep, "_candidate_paths", return_value=[missing]):
+            aep.reset_for_tests()
+            snapshot = list(sys.path)
+            ok = aep.ensure_ai_engine_on_path()
+            assert ok is False
+            assert sys.path == snapshot
+
+    def test_repeated_failure_does_not_relog(self, tmp_path, monkeypatch, caplog):
+        """After a failed attempt, subsequent calls return False without re-logging."""
+        missing = tmp_path / "does-not-exist"
+        with patch.object(aep, "_candidate_paths", return_value=[missing]):
+            aep.reset_for_tests()
+            with caplog.at_level("WARNING"):
+                aep.ensure_ai_engine_on_path()
+            warn_count_first = sum(
+                1 for r in caplog.records if "ai-engine directory not found" in r.message
+            )
+            caplog.clear()
+            with caplog.at_level("WARNING"):
+                aep.ensure_ai_engine_on_path()
+            warn_count_second = sum(
+                1 for r in caplog.records if "ai-engine directory not found" in r.message
+            )
+            assert warn_count_first == 1
+            assert warn_count_second == 0
+
+
+class TestCandidatePaths:
+    def test_includes_production_path(self):
+        candidates = aep._candidate_paths()
+        assert Path("/app/ai-engine") in candidates
+
+    def test_includes_repo_root_relative(self):
+        """The repo-root candidate is parents[3] / 'ai-engine' from this file."""
+        candidates = aep._candidate_paths()
+        # The expected repo-root candidate
+        here = Path(aep.__file__).resolve()
+        expected = here.parents[3] / "ai-engine"
+        assert expected in candidates
+
+    def test_env_override_first_when_set(self, monkeypatch, tmp_path):
+        custom = tmp_path / "custom"
+        monkeypatch.setenv("AI_ENGINE_PATH", str(custom))
+        candidates = aep._candidate_paths()
+        assert candidates[0] == custom

--- a/backend/src/utils/ai_engine_path.py
+++ b/backend/src/utils/ai_engine_path.py
@@ -1,0 +1,115 @@
+"""Make the ai-engine package importable from the backend process.
+
+The ai-engine and backend are deployed in the same Docker image but as separate
+Python processes with separate PYTHONPATHs. The backend's PYTHONPATH does NOT
+include /app/ai-engine, but several backend endpoints and Celery tasks
+nonetheless import from the AI Engine's flat-top-level packages
+(`mmsd.*`, `knowledge.*`, etc.) — historical decisions that bypass
+the intended HTTP service boundary. Only non-colliding top-level packages are
+safe to import this way; `utils.*`, `models.*`, `schemas.*`, and `services.*`
+collide with backend packages and must be migrated to HTTP calls instead.
+
+This helper appends ai-engine to sys.path on demand. It tries (in order):
+
+1. ``$AI_ENGINE_PATH`` env var — explicit override
+2. ``/app/ai-engine`` — production layout (Fly.io ``Dockerfile.fly`` copies
+   ai-engine here)
+3. Repo-root-relative path walking up from this file — local-dev / pytest layout
+
+If none resolve to an existing directory, it returns False and lets the
+caller's import raise its own ImportError (which carries a clearer message
+than anything we could fabricate).
+
+This is a tactical fix for the import-resolution bug surfaced by
+PR #1448 (`refactor(ai-engine): consolidate ai_engine/ namespace`). The
+strategic fix is to convert these direct imports into HTTP calls against
+the AI Engine service running on a separate process. See
+``.planning/notes/2026-05-14-followups.md`` Item 8.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Memoize the resolved path so we only compute / log once per process.
+_RESOLVED: Path | None = None
+_RESOLVED_ATTEMPTED: bool = False
+
+
+def _candidate_paths() -> list[Path]:
+    """Yield candidate ai-engine directory locations in priority order."""
+    candidates: list[Path] = []
+
+    env_override = os.environ.get("AI_ENGINE_PATH")
+    if env_override:
+        candidates.append(Path(env_override))
+
+    # Production layout (Fly.io Dockerfile.fly: COPY ai-engine/ /app/ai-engine/)
+    candidates.append(Path("/app/ai-engine"))
+
+    # Local-dev / pytest layout: walk up from backend/src/utils/ai_engine_path.py
+    #   parent[0] = backend/src/utils/
+    #   parent[1] = backend/src/
+    #   parent[2] = backend/
+    #   parent[3] = repo root
+    here = Path(__file__).resolve()
+    candidates.append(here.parents[3] / "ai-engine")
+
+    return candidates
+
+
+def ensure_ai_engine_on_path() -> bool:
+    """Ensure the ai-engine package directory is on sys.path.
+
+    Returns:
+        True if a usable ai-engine directory was found and added (or was
+        already present); False if no candidate resolved.
+
+    Idempotent: safe to call multiple times. The first successful call
+    memoizes the result; subsequent calls are O(1).
+    """
+    global _RESOLVED, _RESOLVED_ATTEMPTED
+
+    if _RESOLVED is not None:
+        return True
+
+    if _RESOLVED_ATTEMPTED:
+        # We tried before and failed; don't keep trying / re-logging.
+        return False
+
+    for candidate in _candidate_paths():
+        if candidate.is_dir():
+            candidate_str = str(candidate)
+            if candidate_str not in sys.path:
+                # Append instead of prepending. Prepending would let ai-engine
+                # shadow backend packages with the same top-level names
+                # (`utils`, `models`, `schemas`, `services`) for the remainder
+                # of the worker process. Appending still makes non-colliding
+                # packages such as `mmsd` and `knowledge` importable.
+                sys.path.append(candidate_str)
+                logger.info("ai-engine appended to sys.path: %s", candidate_str)
+            else:
+                logger.debug("ai-engine already on sys.path: %s", candidate_str)
+            _RESOLVED = candidate
+            return True
+
+    _RESOLVED_ATTEMPTED = True
+    logger.warning(
+        "ai-engine directory not found at any candidate path: %s. "
+        "Imports of non-colliding ai-engine packages from backend code will fail. "
+        "Set AI_ENGINE_PATH env var to override.",
+        [str(p) for p in _candidate_paths()],
+    )
+    return False
+
+
+def reset_for_tests() -> None:
+    """Clear memoized state. Test-only helper."""
+    global _RESOLVED, _RESOLVED_ATTEMPTED
+    _RESOLVED = None
+    _RESOLVED_ATTEMPTED = False


### PR DESCRIPTION
## Summary

Safely fixes the non-colliding backend → ai-engine import paths flagged by PR #1448, without globally shadowing backend packages. This PR now intentionally limits itself to `mmsd.*` and `knowledge.*` imports. Attempts to wire `search.*` were removed after review because `search.*` depends on colliding `schemas.*` / `utils.*` packages and must be migrated via HTTP-based decoupling instead.

## Background

Backend code has several direct Python imports from the ai-engine tree, but the backend process does not have `/app/ai-engine` on `PYTHONPATH`. The old inline helper pattern in `knowledge_base.py` walked 4 dirnames up from `__file__`; that can work on a host checkout but resolves incorrectly in the production Docker layout.

## What this PR does

### 1. New helper: `backend/src/utils/ai_engine_path.py`
`ensure_ai_engine_on_path()` tries:
- `$AI_ENGINE_PATH` env override
- `/app/ai-engine` (Fly production, set up by `Dockerfile.fly`)
- repo-root-relative path (local dev / pytest)

It **appends** the resolved ai-engine directory to `sys.path` instead of prepending. This is deliberate: prepending would let ai-engine shadow backend packages with the same top-level names (`utils`, `models`, `schemas`, `services`) for the remainder of the backend worker process.

### 2. Refactor safe `knowledge.*` helper paths
Three duplicated inline path-manipulation blocks in `knowledge_base.py` are replaced with `ensure_ai_engine_on_path()`:
- `_get_community_manager()` → `knowledge.community`
- `_get_pattern_library()` → `knowledge.patterns`
- `_get_cross_reference_detector()` → `knowledge.cross_reference`

`knowledge` does not collide with a backend package, so appending is sufficient and safe.

### 3. Wire helper at 3 safe `mmsd.*` sites
| File | Import | Status |
|---|---|---|
| `premium_conversion.py` | `from mmsd.premium_client import PortKitPremium, ConversionResult` | ✅ now works |
| `premium_conversion.py` | `from mmsd.premium_client import MODEL_CONFIGS` | ✅ now works |
| `premium_conversion.py` | `from mmsd.premium_client import PortKitPremium` | ✅ now works |

### 4. Drive-by fix in `multimodal_search_engine.py`
`logger = logging.getLogger(__name__)` was defined after a try/except block that called `logger.warning(...)` in the except path. Moved logger initialization above that block.

### 5. Tests
10 tests in `backend/src/tests/unit/test_ai_engine_path.py`, including a regression test that verifies ai-engine is appended after existing backend paths to avoid package shadowing.

## What this PR deliberately does NOT do

### `search.*` and `utils.*` backend imports remain out of scope
These paths are unsafe with `sys.path` because of regular-package collisions:
- `backend/src/utils/__init__.py` vs `ai-engine/utils/__init__.py`
- `backend/src/schemas/__init__.py` vs `ai-engine/schemas/__init__.py`
- `backend/src/models/__init__.py` vs `ai-engine/models/__init__.py`
- `backend/src/services/__init__.py` vs `ai-engine/services/__init__.py`

Python does not merge regular packages. Whichever package is imported/cached first wins. Direct-import fixes for these modules would either fail or poison the backend worker's import environment.

Known remaining dead/unsafe sites include:
- `knowledge_base.py:658` — `from utils.texture_metadata_extractor import ...`
- `knowledge_base.py:742` — `from utils.model_metadata_extractor import ...`
- `celery_tasks.py:650` — `from utils.texture_metadata_extractor import ...`
- `api/embeddings.py`, `api/comparison.py`, `api/rag.py`, `services/cache.py`, `services/batch_queuing.py`, `services/resource/*.py`, etc.

**Strategic fix:** backend should call the AI Engine via its FastAPI service boundary (port 8001 in production), not via direct Python imports.

## Verification

| Check | Result |
|---|---|
| `pytest backend/src/tests/unit/test_ai_engine_path.py` | ✅ 10/10 pass |
| Manual smoke from `PYTHONPATH=backend/src python3` | ✅ backend `utils` remains backend; `mmsd.premium_client` imports successfully |
| `ruff check` / `ruff format --check` on changed files | ✅ clean |

## Related

- Follow-up to PR #1448.
- This narrows Item 8 to the safe subset and leaves Item 11 (namespace collision / HTTP refactor) as the architectural follow-up.
