### PR TITLE
refactor(ai-engine): convert steering_tools to typed args_schema (A2.5)

### DIFF
--- a/ai-engine/agents/logic_translator/steering_tools.py
+++ b/ai-engine/agents/logic_translator/steering_tools.py
@@ -16,25 +16,19 @@ Usage:
 """
 
 import json
-import logging
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
-try:
-    from langchain_core.tools import tool
-except ImportError:
-    # Fallback if LangChain not available
-    def tool(func):
-        return func
+from typing import ClassVar
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
 
 from steering import (
-    SteeringPipeline,
     SteeringPipelineConfig,
-    SteeringMode,
     get_steering_pipeline,
     configure_steering_pipeline,
     SteeringEvaluator,
     evaluate_steering_effectiveness,
-    IdiomCategory,
 )
 
 from utils.logging_config import get_agent_logger
@@ -84,7 +78,8 @@ class SteeringTools:
                 sae_endpoint=sae_endpoint,
                 sae_api_key=sae_api_key,
                 steering_scale=steering_scale,
-                suppression_targets=suppression_targets or [
+                suppression_targets=suppression_targets
+                or [
                     "java_forge_suppress",
                     "java_class_suppress",
                 ],
@@ -95,23 +90,27 @@ class SteeringTools:
             pipeline = configure_steering_pipeline(config)
             pipeline.enable_steering()
 
-            return json.dumps({
-                "success": True,
-                "steering_enabled": True,
-                "config": {
-                    "steering_scale": steering_scale,
-                    "suppression_targets": config.suppression_targets,
-                    "inference_backend": inference_backend,
-                },
-            })
+            return json.dumps(
+                {
+                    "success": True,
+                    "steering_enabled": True,
+                    "config": {
+                        "steering_scale": steering_scale,
+                        "suppression_targets": config.suppression_targets,
+                        "inference_backend": inference_backend,
+                    },
+                }
+            )
 
         except Exception as e:
             logger.error(f"Failed to configure steering: {e}")
-            return json.dumps({
-                "success": False,
-                "error": str(e),
-                "steering_enabled": False,
-            })
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": str(e),
+                    "steering_enabled": False,
+                }
+            )
 
     @staticmethod
     def apply_steering(
@@ -142,18 +141,22 @@ class SteeringTools:
                 steering_features=steering_features,
             )
 
-            return json.dumps({
-                "success": True,
-                "evaluation": result.to_dict(),
-                "steering_applied": pipeline._steering_enabled,
-            })
+            return json.dumps(
+                {
+                    "success": True,
+                    "evaluation": result.to_dict(),
+                    "steering_applied": pipeline._steering_enabled,
+                }
+            )
 
         except Exception as e:
             logger.error(f"Failed to apply steering evaluation: {e}")
-            return json.dumps({
-                "success": False,
-                "error": str(e),
-            })
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": str(e),
+                }
+            )
 
     @staticmethod
     def get_steering_stats() -> str:
@@ -167,17 +170,21 @@ class SteeringTools:
             pipeline = get_steering_pipeline()
             stats = pipeline.get_stats()
 
-            return json.dumps({
-                "success": True,
-                "stats": stats,
-            })
+            return json.dumps(
+                {
+                    "success": True,
+                    "stats": stats,
+                }
+            )
 
         except Exception as e:
             logger.error(f"Failed to get steering stats: {e}")
-            return json.dumps({
-                "success": False,
-                "error": str(e),
-            })
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": str(e),
+                }
+            )
 
     @staticmethod
     def enable_steering() -> str:
@@ -186,17 +193,21 @@ class SteeringTools:
             pipeline = get_steering_pipeline()
             pipeline.enable_steering()
 
-            return json.dumps({
-                "success": True,
-                "steering_enabled": True,
-            })
+            return json.dumps(
+                {
+                    "success": True,
+                    "steering_enabled": True,
+                }
+            )
 
         except Exception as e:
             logger.error(f"Failed to enable steering: {e}")
-            return json.dumps({
-                "success": False,
-                "error": str(e),
-            })
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": str(e),
+                }
+            )
 
     @staticmethod
     def disable_steering() -> str:
@@ -205,130 +216,233 @@ class SteeringTools:
             pipeline = get_steering_pipeline()
             pipeline.disable_steering()
 
-            return json.dumps({
-                "success": True,
-                "steering_enabled": False,
-            })
+            return json.dumps(
+                {
+                    "success": True,
+                    "steering_enabled": False,
+                }
+            )
 
         except Exception as e:
             logger.error(f"Failed to disable steering: {e}")
-            return json.dumps({
-                "success": False,
-                "error": str(e),
-            })
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": str(e),
+                }
+            )
 
 
-# LangChain Tool Wrappers
-@tool
-def configure_steering_tool(config_json: str) -> str:
-    """
-    Configure SAE-based feature steering for Java idiom suppression.
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed args_schema models — one per LangChain tool wrapper
+# ─────────────────────────────────────────────────────────────────────────────
 
-    Args:
-        config_json: JSON string with configuration:
-            - sae_endpoint: Optional SAE endpoint URL
-            - sae_api_key: Optional API key
-            - steering_scale: Steering magnitude (default 2.0)
-            - suppression_targets: List of targets like ["java_forge", "java_class"]
-            - inference_backend: "openai_compatible", "vllm", "sglang", "transformers"
-            - inference_endpoint: Optional custom inference URL
 
-    Returns:
-        JSON confirmation with steering status
-    """
-    try:
-        config = json.loads(config_json)
-    except json.JSONDecodeError:
-        return json.dumps({"success": False, "error": "Invalid JSON config"})
+class ConfigureSteeringInput(BaseModel):
+    """Args for :class:`ConfigureSteeringTool`."""
 
-    return SteeringTools.configure_steering(
-        sae_endpoint=config.get("sae_endpoint"),
-        sae_api_key=config.get("sae_api_key"),
-        steering_scale=config.get("steering_scale", 2.0),
-        suppression_targets=config.get("suppression_targets"),
-        inference_backend=config.get("inference_backend", "openai_compatible"),
-        inference_endpoint=config.get("inference_endpoint"),
+    model_config = ConfigDict(extra="forbid")
+    sae_endpoint: Optional[str] = Field(
+        default=None,
+        description="Optional SAE service endpoint URL.",
+    )
+    sae_api_key: Optional[str] = Field(
+        default=None,
+        description="Optional API key for the SAE service.",
+    )
+    steering_scale: float = Field(
+        default=2.0,
+        description="Steering vector magnitude (default 2.0).",
+    )
+    suppression_targets: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            'Idiom types to suppress, e.g. ["java_forge_suppress", '
+            '"java_class_suppress"]. None uses pipeline defaults.'
+        ),
+    )
+    inference_backend: str = Field(
+        default="openai_compatible",
+        description=(
+            "Inference backend identifier: openai_compatible, vllm, sglang, or transformers."
+        ),
+    )
+    inference_endpoint: Optional[str] = Field(
+        default=None,
+        description="Optional custom inference endpoint URL.",
     )
 
 
-@tool
-def apply_steering_tool(java_code: str, bedrock_code: str) -> str:
-    """
-    Apply SAE-based steering evaluation to a conversion result.
+class ApplySteeringInput(BaseModel):
+    """Args for :class:`ApplySteeringTool`."""
 
-    This tool evaluates whether Java idioms were properly suppressed
-    in the generated Bedrock code.
-
-    Args:
-        java_code: Original Java source code
-        bedrock_code: Generated Bedrock JavaScript code
-
-    Returns:
-        JSON with evaluation metrics (suppression rate, quality score, warnings)
-    """
-    return SteeringTools.apply_steering(java_code, bedrock_code)
-
-
-@tool
-def get_steering_stats_tool() -> str:
-    """
-    Get current steering pipeline statistics.
-
-    Returns:
-        JSON with generation counts, steering applications, and feature tracking
-    """
-    return SteeringTools.get_steering_stats()
-
-
-@tool
-def enable_steering_tool() -> str:
-    """
-    Enable SAE-based feature steering globally.
-
-    Returns:
-        JSON confirmation
-    """
-    return SteeringTools.enable_steering()
-
-
-@tool
-def disable_steering_tool() -> str:
-    """
-    Disable SAE-based feature steering globally.
-
-    Returns:
-        JSON confirmation
-    """
-    return SteeringTools.disable_steering()
-
-
-@tool
-def evaluate_conversion_quality_tool(
-    original_java: str, generated_bedrock: str, steering_applied: bool = True
-) -> str:
-    """
-    Evaluate the quality of a Java-to-Bedrock conversion.
-
-    Args:
-        original_java: Original Java code
-        generated_bedrock: Generated Bedrock code
-        steering_applied: Whether steering was used (default True)
-
-    Returns:
-        JSON with overall quality score (0-100) and per-category metrics
-    """
-    result = evaluate_steering_effectiveness(
-        java_code=original_java,
-        bedrock_code=generated_bedrock,
-        steering_applied=steering_applied,
+    model_config = ConfigDict(extra="forbid")
+    java_code: str = Field(
+        min_length=1,
+        description="Original Java source code that was converted.",
+    )
+    bedrock_code: str = Field(
+        min_length=1,
+        description="Generated Bedrock JavaScript code to evaluate.",
     )
 
-    return result.to_json()
+
+class _NoArgs(BaseModel):
+    """Empty input schema for steering tools that take no arguments."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class EvaluateConversionQualityInput(BaseModel):
+    """Args for :class:`EvaluateConversionQualityTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    original_java: str = Field(
+        min_length=1,
+        description="Original Java source code.",
+    )
+    generated_bedrock: str = Field(
+        min_length=1,
+        description="Generated Bedrock JavaScript / JSON code.",
+    )
+    steering_applied: bool = Field(
+        default=True,
+        description="Whether SAE steering was used during generation.",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed BaseTool subclasses — replace the previous @tool decorated wrappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BaseSteeringTool(BaseTool):
+    """Common scaffolding for the steering typed tool wrappers."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class ConfigureSteeringTool(_BaseSteeringTool):
+    """Configure SAE-based feature steering for Java idiom suppression."""
+
+    name: str = "configure_steering_tool"
+    description: str = (
+        "Configure SAE-based feature steering. "
+        "Args: sae_endpoint, sae_api_key, steering_scale, "
+        "suppression_targets, inference_backend, inference_endpoint."
+    )
+    args_schema: ClassVar[type[BaseModel]] = ConfigureSteeringInput
+
+    def _run(  # type: ignore[override]
+        self,
+        sae_endpoint: Optional[str] = None,
+        sae_api_key: Optional[str] = None,
+        steering_scale: float = 2.0,
+        suppression_targets: Optional[List[str]] = None,
+        inference_backend: str = "openai_compatible",
+        inference_endpoint: Optional[str] = None,
+    ) -> str:
+        return SteeringTools.configure_steering(
+            sae_endpoint=sae_endpoint,
+            sae_api_key=sae_api_key,
+            steering_scale=steering_scale,
+            suppression_targets=suppression_targets,
+            inference_backend=inference_backend,
+            inference_endpoint=inference_endpoint,
+        )
+
+
+class ApplySteeringTool(_BaseSteeringTool):
+    """Evaluate whether Java idioms were properly suppressed in the conversion."""
+
+    name: str = "apply_steering_tool"
+    description: str = (
+        "Apply SAE-based steering evaluation to a Java→Bedrock conversion. "
+        "Returns suppression rate, quality score, and warnings. "
+        "Args: java_code (str, required), bedrock_code (str, required)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = ApplySteeringInput
+
+    def _run(self, java_code: str, bedrock_code: str) -> str:  # type: ignore[override]
+        return SteeringTools.apply_steering(java_code, bedrock_code)
+
+
+class GetSteeringStatsTool(_BaseSteeringTool):
+    """Return current steering pipeline statistics."""
+
+    name: str = "get_steering_stats_tool"
+    description: str = (
+        "Get steering pipeline statistics: generation counts, steering "
+        "applications, feature tracking. Takes no arguments."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _NoArgs
+
+    def _run(self) -> str:  # type: ignore[override]
+        return SteeringTools.get_steering_stats()
+
+
+class EnableSteeringTool(_BaseSteeringTool):
+    """Enable SAE-based feature steering globally."""
+
+    name: str = "enable_steering_tool"
+    description: str = "Enable SAE-based feature steering globally. Takes no arguments."
+    args_schema: ClassVar[type[BaseModel]] = _NoArgs
+
+    def _run(self) -> str:  # type: ignore[override]
+        return SteeringTools.enable_steering()
+
+
+class DisableSteeringTool(_BaseSteeringTool):
+    """Disable SAE-based feature steering globally."""
+
+    name: str = "disable_steering_tool"
+    description: str = "Disable SAE-based feature steering globally. Takes no arguments."
+    args_schema: ClassVar[type[BaseModel]] = _NoArgs
+
+    def _run(self) -> str:  # type: ignore[override]
+        return SteeringTools.disable_steering()
+
+
+class EvaluateConversionQualityTool(_BaseSteeringTool):
+    """Evaluate the quality of a Java-to-Bedrock conversion."""
+
+    name: str = "evaluate_conversion_quality_tool"
+    description: str = (
+        "Evaluate Java→Bedrock conversion quality. Returns overall score "
+        "(0-100) and per-category metrics. "
+        "Args: original_java (str, required), generated_bedrock (str, required), "
+        "steering_applied (bool, default True)."
+    )
+    args_schema: ClassVar[type[BaseModel]] = EvaluateConversionQualityInput
+
+    def _run(  # type: ignore[override]
+        self,
+        original_java: str,
+        generated_bedrock: str,
+        steering_applied: bool = True,
+    ) -> str:
+        result = evaluate_steering_effectiveness(
+            java_code=original_java,
+            bedrock_code=generated_bedrock,
+            steering_applied=steering_applied,
+        )
+        return result.to_json()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level tool instances — preserve the names the wider codebase imports
+# ─────────────────────────────────────────────────────────────────────────────
+
+configure_steering_tool: ConfigureSteeringTool = ConfigureSteeringTool()
+apply_steering_tool: ApplySteeringTool = ApplySteeringTool()
+get_steering_stats_tool: GetSteeringStatsTool = GetSteeringStatsTool()
+enable_steering_tool: EnableSteeringTool = EnableSteeringTool()
+disable_steering_tool: DisableSteeringTool = DisableSteeringTool()
+evaluate_conversion_quality_tool: EvaluateConversionQualityTool = EvaluateConversionQualityTool()
 
 
 def register_steering_tools(agent) -> None:
-    """
-    Register all steering tools with a LangChain agent.
+    """Register all steering tools with a LangChain agent.
 
     Args:
         agent: LangChain agent instance to register tools with
@@ -338,9 +452,6 @@ def register_steering_tools(agent) -> None:
 
         agent = LogicTranslatorAgent()
         register_steering_tools(agent)
-        for tool in agent.tools:
-            if 'steering' in str(tool):
-                print(f"Registered: {tool.name}")
     """
     steering_tools = [
         configure_steering_tool,
@@ -351,7 +462,7 @@ def register_steering_tools(agent) -> None:
         evaluate_conversion_quality_tool,
     ]
 
-    for tool in steering_tools:
-        if hasattr(agent, 'tools'):
-            agent.tools.append(tool)
-        logger.info(f"Registered steering tool: {tool.name}")
+    for steering_tool in steering_tools:
+        if hasattr(agent, "tools"):
+            agent.tools.append(steering_tool)
+        logger.info(f"Registered steering tool: {steering_tool.name}")

--- a/ai-engine/tests/unit/test_steering_tools_typed.py
+++ b/ai-engine/tests/unit/test_steering_tools_typed.py
@@ -1,0 +1,201 @@
+"""Tests for the typed BaseTool wrappers in agents/logic_translator/steering_tools.py.
+
+These wrappers replace the previous bare ``@tool`` decorators (PR #1448 follow-up).
+Each tool now exposes an explicit Pydantic ``args_schema`` so chat models with
+native tool-calling can invoke it with structured arguments rather than a
+JSON-encoded string blob.
+
+Pattern matches PR #1447's typed migration of ``logic_translator/tools.py``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ValidationError
+
+from agents.logic_translator.steering_tools import (
+    ApplySteeringInput,
+    ApplySteeringTool,
+    ConfigureSteeringInput,
+    ConfigureSteeringTool,
+    DisableSteeringTool,
+    EnableSteeringTool,
+    EvaluateConversionQualityInput,
+    EvaluateConversionQualityTool,
+    GetSteeringStatsTool,
+    _NoArgs,
+    apply_steering_tool,
+    configure_steering_tool,
+    disable_steering_tool,
+    enable_steering_tool,
+    evaluate_conversion_quality_tool,
+    get_steering_stats_tool,
+    register_steering_tools,
+)
+
+
+class TestModuleLevelInstancesAreTypedBaseTools:
+    """Verify the import-name aliases that the wider codebase uses are now
+    BaseTool instances with proper args_schema. PR #1448 follow-up.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_instance,expected_class,expected_schema_name",
+        [
+            (configure_steering_tool, ConfigureSteeringTool, "ConfigureSteeringInput"),
+            (apply_steering_tool, ApplySteeringTool, "ApplySteeringInput"),
+            (get_steering_stats_tool, GetSteeringStatsTool, "_NoArgs"),
+            (enable_steering_tool, EnableSteeringTool, "_NoArgs"),
+            (disable_steering_tool, DisableSteeringTool, "_NoArgs"),
+            (
+                evaluate_conversion_quality_tool,
+                EvaluateConversionQualityTool,
+                "EvaluateConversionQualityInput",
+            ),
+        ],
+    )
+    def test_instance_is_typed_basetool(self, tool_instance, expected_class, expected_schema_name):
+        assert isinstance(tool_instance, BaseTool)
+        assert isinstance(tool_instance, expected_class)
+        assert tool_instance.args_schema is not None
+        assert tool_instance.args_schema.__name__ == expected_schema_name
+        assert issubclass(tool_instance.args_schema, BaseModel)
+
+
+class TestNoArgTools:
+    """Tools with empty args_schema accept ``invoke({})`` and return JSON strings."""
+
+    def test_enable_tool_invoke_empty_dict(self):
+        result = enable_steering_tool.invoke({})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        assert parsed["steering_enabled"] is True
+
+    def test_disable_tool_invoke_empty_dict(self):
+        result = disable_steering_tool.invoke({})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        assert parsed["steering_enabled"] is False
+
+    def test_stats_tool_invoke_empty_dict(self):
+        result = get_steering_stats_tool.invoke({})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        assert "stats" in parsed
+        assert "steering_enabled" in parsed["stats"]
+
+
+class TestApplySteeringTool:
+    def test_invoke_with_typed_args(self):
+        result = apply_steering_tool.invoke(
+            {
+                "java_code": "public class X { void foo() {} }",
+                "bedrock_code": "const x = { foo: () => {} };",
+            }
+        )
+        parsed = json.loads(result)
+        # Apply returns evaluation metrics — just assert it parses and has shape
+        assert "success" in parsed or "evaluation" in parsed or "metrics" in parsed
+
+    def test_args_schema_rejects_empty_strings(self):
+        with pytest.raises(ValidationError):
+            ApplySteeringInput.model_validate({"java_code": "", "bedrock_code": "anything"})
+
+    def test_args_schema_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            ApplySteeringInput.model_validate(
+                {"java_code": "x", "bedrock_code": "y", "rogue_field": True}
+            )
+
+
+class TestConfigureSteeringTool:
+    def test_invoke_with_minimal_args_uses_defaults(self):
+        result = configure_steering_tool.invoke({})
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        assert parsed["config"]["steering_scale"] == 2.0
+        assert parsed["config"]["inference_backend"] == "openai_compatible"
+
+    def test_invoke_with_typed_overrides(self):
+        result = configure_steering_tool.invoke(
+            {
+                "steering_scale": 3.5,
+                "inference_backend": "vllm",
+                "suppression_targets": ["java_forge_suppress"],
+            }
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        assert parsed["config"]["steering_scale"] == 3.5
+        assert parsed["config"]["inference_backend"] == "vllm"
+        assert parsed["config"]["suppression_targets"] == ["java_forge_suppress"]
+
+    def test_args_schema_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            ConfigureSteeringInput.model_validate({"made_up_field": 1})
+
+
+class TestEvaluateConversionQualityTool:
+    def test_invoke_with_typed_args(self):
+        result = evaluate_conversion_quality_tool.invoke(
+            {
+                "original_java": "public class X {}",
+                "generated_bedrock": "const x = {};",
+                "steering_applied": False,
+            }
+        )
+        parsed = json.loads(result)
+        # Result.to_json() shape — just assert it parses to a dict
+        assert isinstance(parsed, dict)
+
+    def test_steering_applied_defaults_to_true(self):
+        # Validate via the schema that the default is True
+        validated = EvaluateConversionQualityInput.model_validate(
+            {"original_java": "x", "generated_bedrock": "y"}
+        )
+        assert validated.steering_applied is True
+
+    def test_args_schema_rejects_empty_required_strings(self):
+        with pytest.raises(ValidationError):
+            EvaluateConversionQualityInput.model_validate(
+                {"original_java": "", "generated_bedrock": "y"}
+            )
+
+
+class TestNoArgsSchema:
+    def test_no_args_schema_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            _NoArgs.model_validate({"any_field": True})
+
+    def test_no_args_schema_accepts_empty(self):
+        validated = _NoArgs.model_validate({})
+        assert validated.model_dump() == {}
+
+
+class TestRegisterSteeringTools:
+    def test_register_attaches_all_six_tools_to_agent(self):
+        class FakeAgent:
+            tools: list = []
+
+        agent = FakeAgent()
+        agent.tools = []
+        register_steering_tools(agent)
+        names = {t.name for t in agent.tools}
+        assert names == {
+            "configure_steering_tool",
+            "apply_steering_tool",
+            "get_steering_stats_tool",
+            "enable_steering_tool",
+            "disable_steering_tool",
+            "evaluate_conversion_quality_tool",
+        }
+
+    def test_register_skips_when_agent_has_no_tools_attr(self):
+        # Should not raise even if agent has no `tools` attribute
+        class BareAgent:
+            pass
+
+        register_steering_tools(BareAgent())  # no exception


### PR DESCRIPTION
## Summary

Continues the typed-args migration from PR #1447 (logic_translator/tools.py) and PR #1446 (search_tool.py). Converts the 6 `@tool` wrappers in `agents/logic_translator/steering_tools.py` to typed `BaseTool` subclasses with explicit Pydantic `args_schema`.

This is the **A2.5 slice** from the migration roadmap — the smallest remaining cluster (6 wrappers, ~30 min of focused work).

## Wrappers migrated

| Wrapper | Args schema | Notes |
|---|---|---|
| `configure_steering_tool` | `ConfigureSteeringInput` (6 fields) | Was `config_json: str`. Chose typed model over string pass-through (no in-repo callers use raw JSON). |
| `apply_steering_tool` | `ApplySteeringInput` (java_code, bedrock_code) | Already 2 args, easy convert. |
| `get_steering_stats_tool` | `_NoArgs` | Empty `BaseModel` per the pattern validated in PR #1448's pre-flight. |
| `enable_steering_tool` | `_NoArgs` | same |
| `disable_steering_tool` | `_NoArgs` | same |
| `evaluate_conversion_quality_tool` | `EvaluateConversionQualityInput` (3 fields) | |

All schemas use `ConfigDict(extra="forbid")` so chat-model hallucinated extra fields fail loud at validation.

Module-level names (`configure_steering_tool`, etc.) preserved as `BaseTool` instances, so existing imports in `agents/logic_translator/__init__.py` and `register_steering_tools` keep working unchanged.

## Verification

- New file `ai-engine/tests/unit/test_steering_tools_typed.py` with **22 tests** covering:
  - Instance & schema identity for all 6 tools
  - `invoke({})` for the 3 no-arg tools
  - Typed-args invoke for the other 3 tools
  - Default-value validation
  - Extra-field rejection
  - Empty-string rejection on required fields
  - `register_steering_tools` happy path + missing-attribute path
- `pytest ai-engine/tests/unit/` — **906 pass** (was 884 = +22 from new file). Zero regressions.
- Manual smoke: each tool's `.invoke({...})` returns expected JSON.
- `ruff check` / `ruff format --check` clean.

## Closes

A2.5 from `.planning/notes/2026-05-14-followups.md`. Critical-path next is **A3** (`agents/qa/__init__.py` — 6 wrappers + alias deprecation test).
