### PR TITLE
chore(ai-engine): reconcile chromadb pin across pyproject.toml, setup.py, requirements.txt

### DIFF
--- a/ai-engine/pyproject.toml
+++ b/ai-engine/pyproject.toml
@@ -243,9 +243,8 @@ dependencies = [
     "openai>=2.32.0",
     "sentence-transformers",
 
-    # Vector Database (pin version for embedchain compatibility)
-
-    "chromadb<1.6.0",
+    # Vector Database — pin relaxed after legacy framework removal (#1439, unblocked by #1201)
+    "chromadb>=1.5.8,<2.0",
     
     # Data Processing
     "numpy",

--- a/ai-engine/setup.py
+++ b/ai-engine/setup.py
@@ -36,7 +36,7 @@ def get_install_requires():
         # Embeddings - Using sentence-transformers for local embeddings
         # Note: This is a core dependency for RAG functionality
         "sentence-transformers>=2.2.0",
-        # Vector Database (pin version for embedchain compatibility)
+        # Vector Database — pin relaxed after legacy framework removal (#1439, unblocked by #1201)
         "chromadb>=1.5.8,<2.0",
         # Data Processing
         "numpy",


### PR DESCRIPTION
## Summary

Reconciles the chromadb pin so all three sources in `ai-engine/` agree on `>=1.5.8,<2.0`. Cleans up stale `embedchain compatibility` comments left over from the pre-LangChain-cutover era.

## What was wrong

Three pin sources had drifted after the legacy-framework removals:

| File | Pin (before) | History |
|---|---|---|
| `ai-engine/requirements.txt:17` | `chromadb>=1.5.8,<2.0` | ✅ updated in #1439 |
| `ai-engine/setup.py:40` | `chromadb>=1.5.8,<2.0` | ✅ updated in #1439 |
| `ai-engine/pyproject.toml:248` | `chromadb<1.6.0` | ❌ never updated; still had old `embedchain compatibility` comment |

The `<1.6.0` ceiling existed because CrewAI's embedchain dependency had a tight chromadb compat matrix. Embedchain was removed in #1201 (LangChain cutover), so the ceiling no longer needs to track its compat. The other two sources reflect this; pyproject.toml was missed.

## What this PR does

- Updates `ai-engine/pyproject.toml`: `chromadb<1.6.0` → `chromadb>=1.5.8,<2.0`
- Updates the comment on the same line to match the rationale already in `requirements.txt`
- Updates the matching comment on `ai-engine/setup.py` (pin itself was already correct)

No code changes — pure metadata.

## Verification

- All three sources now match exactly: `chromadb>=1.5.8,<2.0`
- Fresh venv install resolves to chromadb 1.5.9 (latest 1.x); `pip check` clean
- `pyproject.toml` parses cleanly via `tomllib`
- Repo-wide grep confirms no more `embedchain` references in pin comments

## Closes

B+C from `.planning/notes/2026-05-14-followups.md`. Note: the original B+C scope included a base-image rebuild — that's only needed if the dep tree actually changes, which it doesn't here (1.1.1 → 1.5.9 was already on the table; this just makes the metadata honest about it).
