### PR TITLE
chore(ai-engine): fix F841 + format drift in test_integration.py

### DIFF
--- a/ai-engine/test_integration.py
+++ b/ai-engine/test_integration.py
@@ -156,18 +156,20 @@ def test_rag_chain_integration():
     try:
         from services.rag_service import build_rag_chain
 
-        chain = build_rag_chain()
+        build_rag_chain()  # smoke: must not raise
         print("[OK] RAG chain initialized via services.rag_service")
         return True
     except Exception as e:
         print(f"[FAIL] RAG chain integration test failed: {e}")
         return False
 
+
 def _legacy_rag_crew_integration_disabled():  # noqa: D401 - kept for git history clarity
     """Legacy LangChain integration — removed in #1201."""
     try:
         # placeholder so the rest of this function compiles for diff readability
         from services.rag_service import build_rag_chain  # noqa: F401
+
         rag_crew = type("LegacyShim", (), {"get_system_status": lambda self: {}})()
 
         # Check system status


### PR DESCRIPTION
Drive-by cleanup of two pre-existing ruff issues in `ai-engine/test_integration.py`:

1. **F841** at line 159 — `chain = build_rag_chain()` assigned but never used. Replaced with `build_rag_chain()  # smoke: must not raise` so the intent (verify call doesn't throw) is explicit.
2. **Format drift** — missing blank line before `_legacy_rag_crew_integration_disabled` and inconsistent spacing. Resolved by `ruff format`.

Both issues confirmed pre-existing on `main` via stash + recheck. No behavioral change.

Closes Pitfall #10 / Item 3 from `.planning/notes/2026-05-14-followups.md`. This was deliberately left out of PR #1447 to keep its review surface bounded; addressing it now as a small drive-by.