### PR TITLE
refactor(ai-engine): typed args_schema for bedrock_architect + bedrock_builder (A4a)

### DIFF
--- a/ai-engine/agents/bedrock_architect.py
+++ b/ai-engine/agents/bedrock_architect.py
@@ -2,15 +2,23 @@
 
 This module provides the BedrockArchitectAgent class which orchestrates conversion
 strategies using smart assumptions as specified in PRD Feature 2.
+
+Phase 8 A4a (refs #1201): the legacy ``@tool @staticmethod`` wrappers have
+been replaced with typed :class:`langchain_core.tools.BaseTool` subclasses,
+each declaring an explicit Pydantic ``args_schema``. The single-string
+``<name>_data`` shape is preserved so chat models and existing call sites
+continue to invoke ``BedrockArchitectAgent.<tool_name>.invoke({...})``
+without changes.
 """
 
 from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, ClassVar, Dict, List
 
-from langchain_core.tools import tool
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
 
 from models.smart_assumptions import (
     AssumptionResult,
@@ -65,9 +73,17 @@ class BedrockArchitectAgent:
             self.create_llm_conversion_plan_tool,
         ]
 
-    @tool
+    # ------------------------------------------------------------------
+    # Static implementations (used by typed BaseTool subclasses below).
+    #
+    # These were previously decorated with ``@tool @staticmethod``; the
+    # ``@tool`` decorator has been removed and each method renamed with a
+    # leading underscore so it does not collide with the class-attribute
+    # binding of the typed BaseTool instance below.
+    # ------------------------------------------------------------------
+
     @staticmethod
-    def analyze_java_feature_tool(feature_data: str) -> str:
+    def _analyze_java_feature(feature_data: str) -> str:
         """Analyze a Java mod feature to determine applicable smart assumptions."""
         agent = BedrockArchitectAgent.get_instance()
 
@@ -78,11 +94,20 @@ class BedrockArchitectAgent:
 
             assumption = analysis_result.applied_assumption
             if assumption.impact.value == "high":
-                return f"High-impact conversion required using {assumption.java_feature} assumption. Significant functionality changes expected."
+                return (
+                    f"High-impact conversion required using {assumption.java_feature} "
+                    "assumption. Significant functionality changes expected."
+                )
             elif assumption.impact.value == "medium":
-                return f"Moderate conversion using {assumption.java_feature} assumption. Some functionality changes expected."
+                return (
+                    f"Moderate conversion using {assumption.java_feature} assumption. "
+                    "Some functionality changes expected."
+                )
             else:
-                return f"Low-impact conversion using {assumption.java_feature} assumption. Minimal functionality changes expected."
+                return (
+                    f"Low-impact conversion using {assumption.java_feature} assumption. "
+                    "Minimal functionality changes expected."
+                )
 
         try:
             data = json.loads(feature_data)
@@ -119,9 +144,8 @@ class BedrockArchitectAgent:
             logger.error(f"Feature analysis error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def apply_smart_assumption_tool(assumption_data: str) -> str:
+    def _apply_smart_assumption(assumption_data: str) -> str:
         """Apply smart assumption to a feature."""
         agent = BedrockArchitectAgent.get_instance()
         try:
@@ -158,7 +182,8 @@ class BedrockArchitectAgent:
                     },
                 }
                 logger.info(
-                    f"Applied assumption for {feature_context.feature_id}: {plan_component.assumption_type}"
+                    f"Applied assumption for {feature_context.feature_id}: "
+                    f"{plan_component.assumption_type}"
                 )
             else:
                 response = {
@@ -173,9 +198,8 @@ class BedrockArchitectAgent:
             logger.error(f"Assumption application error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def create_conversion_plan_tool(plan_data: Any) -> str:
+    def _create_conversion_plan(plan_data: Any) -> str:
         """Create a conversion plan for features."""
         agent = BedrockArchitectAgent.get_instance()
         try:
@@ -254,9 +278,8 @@ class BedrockArchitectAgent:
             logger.error(f"Conversion plan creation error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def get_assumption_conflicts_tool(conflict_data: str) -> str:
+    def _get_assumption_conflicts(conflict_data: str) -> str:
         """Get assumption conflicts for features."""
         agent = BedrockArchitectAgent.get_instance()
         try:
@@ -271,9 +294,8 @@ class BedrockArchitectAgent:
             logger.error(f"Conflict analysis error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def validate_bedrock_compatibility_tool(compatibility_data: str) -> str:
+    def _validate_bedrock_compatibility(compatibility_data: str) -> str:
         """Validate Bedrock compatibility of features."""
         BedrockArchitectAgent.get_instance()
 
@@ -361,11 +383,20 @@ class BedrockArchitectAgent:
 
         assumption = analysis_result.applied_assumption
         if assumption.impact.value == "high":
-            return f"High-impact conversion required using {assumption.java_feature} assumption. Significant functionality changes expected."
+            return (
+                f"High-impact conversion required using {assumption.java_feature} "
+                "assumption. Significant functionality changes expected."
+            )
         elif assumption.impact.value == "medium":
-            return f"Moderate conversion using {assumption.java_feature} assumption. Some functionality changes expected."
+            return (
+                f"Moderate conversion using {assumption.java_feature} assumption. "
+                "Some functionality changes expected."
+            )
         else:
-            return f"Low-impact conversion using {assumption.java_feature} assumption. Minimal functionality changes expected."
+            return (
+                f"Low-impact conversion using {assumption.java_feature} assumption. "
+                "Minimal functionality changes expected."
+            )
 
     def _validate_component_compatibility(self, component: Dict[str, Any]) -> Dict[str, Any]:
         """Validate individual component compatibility with Bedrock"""
@@ -413,27 +444,23 @@ class BedrockArchitectAgent:
 
     # --- Placeholder methods for Bedrock Definition Generation ---
 
-    @tool
     @staticmethod
-    def generate_block_definitions_tool(block_data: str) -> str:
+    def _generate_block_definitions(block_data: str) -> str:
         """Generate Bedrock block definition files (placeholder)."""
         return BedrockArchitectAgent._generate_placeholder_definition(block_data, "block")
 
-    @tool
     @staticmethod
-    def generate_item_definitions_tool(item_data: str) -> str:
+    def _generate_item_definitions(item_data: str) -> str:
         """Generate Bedrock item definition files (placeholder)."""
         return BedrockArchitectAgent._generate_placeholder_definition(item_data, "item")
 
-    @tool
     @staticmethod
-    def generate_recipe_definitions_tool(recipe_data: str) -> str:
+    def _generate_recipe_definitions(recipe_data: str) -> str:
         """Generate Bedrock recipe JSON files (placeholder)."""
         return BedrockArchitectAgent._generate_placeholder_definition(recipe_data, "recipe")
 
-    @tool
     @staticmethod
-    def generate_entity_definitions_tool(entity_data: str) -> str:
+    def _generate_entity_definitions(entity_data: str) -> str:
         """Generate Bedrock entity definition files (placeholder)."""
         return BedrockArchitectAgent._generate_placeholder_definition(entity_data, "entity")
 
@@ -466,7 +493,10 @@ class BedrockArchitectAgent:
                     "metadata_generated": {  # Custom section for our tool's info
                         "source_java_id": component_data.get("id", "unknown_java_id"),
                         "conversion_tool": "ModPorterAI_BedrockArchitect",
-                        "conversion_notes": f"This is an AI-generated placeholder {component_type} definition. Review and refine.",
+                        "conversion_notes": (
+                            f"This is an AI-generated placeholder {component_type} "
+                            "definition. Review and refine."
+                        ),
                     },
                 },
             }
@@ -502,15 +532,19 @@ class BedrockArchitectAgent:
                     "success": True,
                     "component_type": component_type,
                     "identifier": identifier,
-                    "definition_json": placeholder_definition,  # Return the definition as a JSON object, not a string
-                    "message": f"Placeholder {component_type} definition generated successfully for {identifier}.",
+                    "definition_json": placeholder_definition,
+                    "message": (
+                        f"Placeholder {component_type} definition generated successfully "
+                        f"for {identifier}."
+                    ),
                 },
                 indent=2,
             )
 
         except json.JSONDecodeError as e:
             logger.error(
-                f"Invalid JSON input for placeholder {component_type} definition: {str(e)} - Input: {component_data_str[:500]}...",
+                f"Invalid JSON input for placeholder {component_type} definition: "
+                f"{str(e)} - Input: {component_data_str[:500]}...",
                 exc_info=True,
             )  # Log part of the input
             return json.dumps(
@@ -527,14 +561,15 @@ class BedrockArchitectAgent:
             return json.dumps(
                 {
                     "success": False,
-                    "error": f"Failed to generate placeholder {component_type} definition: {str(e)}",
+                    "error": (
+                        f"Failed to generate placeholder {component_type} definition: {str(e)}"
+                    ),
                 },
                 indent=2,
             )
 
-    @tool
     @staticmethod
-    def create_llm_conversion_plan_tool(plan_data: str) -> str:
+    def _create_llm_conversion_plan(plan_data: str) -> str:
         """
         Use LLM + RAG to generate conversion plans with Bedrock API context.
 
@@ -576,7 +611,8 @@ class BedrockArchitectAgent:
                     "model_used": result.get("model_used", "unknown"),
                 }
                 logger.info(
-                    f"LLM conversion plan generated with feasibility: {result.get('overall_feasibility', 'unknown')}"
+                    "LLM conversion plan generated with feasibility: "
+                    f"{result.get('overall_feasibility', 'unknown')}"
                 )
             else:
                 response = {
@@ -595,3 +631,293 @@ class BedrockArchitectAgent:
             }
             logger.error(f"LLM conversion planning error: {e}")
             return json.dumps(error_response)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed args_schema models — one per LangChain tool wrapper
+#
+# Each schema preserves the legacy single-string ``<name>_data`` shape so chat
+# models and existing call sites continue to invoke ``BedrockArchitectAgent.
+# <tool_name>.invoke({"<name>_data": "..."})`` without changes. Pydantic
+# ``extra="forbid"`` makes hallucinated extra fields fail loud at validation,
+# and ``min_length=1`` rejects empty strings before they reach the underlying
+# JSON-decoding logic.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _AnalyzeJavaFeatureInput(BaseModel):
+    """Args for :class:`_AnalyzeJavaFeatureTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    feature_data: str = Field(
+        min_length=1,
+        description=(
+            "JSON string with feature_id, feature_type, name, and original_data "
+            "describing the Java mod feature to analyze."
+        ),
+    )
+
+
+class _ApplySmartAssumptionInput(BaseModel):
+    """Args for :class:`_ApplySmartAssumptionTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    assumption_data: str = Field(
+        min_length=1,
+        description=(
+            "JSON string containing a feature_context object describing the "
+            "Java mod feature to which a smart assumption should be applied."
+        ),
+    )
+
+
+class _CreateConversionPlanInput(BaseModel):
+    """Args for :class:`_CreateConversionPlanTool`.
+
+    Accepts either a JSON string or a list of feature dicts to preserve the
+    legacy ``plan_data: Any`` calling shape; non-string values are JSON-encoded
+    by the underlying impl before being parsed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    plan_data: Any = Field(
+        description=(
+            "JSON string or list of feature dicts describing the Java mod "
+            "features to assemble into a conversion plan."
+        ),
+    )
+
+
+class _GetAssumptionConflictsInput(BaseModel):
+    """Args for :class:`_GetAssumptionConflictsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    conflict_data: str = Field(
+        min_length=1,
+        description=(
+            "JSON string with a feature_type field identifying which feature "
+            "type to inspect for assumption conflicts."
+        ),
+    )
+
+
+class _ValidateBedrockCompatibilityInput(BaseModel):
+    """Args for :class:`_ValidateBedrockCompatibilityTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    compatibility_data: str = Field(
+        min_length=1,
+        description=(
+            "JSON string with a components list describing conversion plan "
+            "components to validate against Bedrock compatibility rules."
+        ),
+    )
+
+
+class _GenerateBlockDefinitionsInput(BaseModel):
+    """Args for :class:`_GenerateBlockDefinitionsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    block_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock block to generate.",
+    )
+
+
+class _GenerateItemDefinitionsInput(BaseModel):
+    """Args for :class:`_GenerateItemDefinitionsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    item_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock item to generate.",
+    )
+
+
+class _GenerateRecipeDefinitionsInput(BaseModel):
+    """Args for :class:`_GenerateRecipeDefinitionsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    recipe_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock recipe to generate.",
+    )
+
+
+class _GenerateEntityDefinitionsInput(BaseModel):
+    """Args for :class:`_GenerateEntityDefinitionsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    entity_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock entity to generate.",
+    )
+
+
+class _CreateLlmConversionPlanInput(BaseModel):
+    """Args for :class:`_CreateLlmConversionPlanTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    plan_data: str = Field(
+        min_length=1,
+        description=(
+            "JSON string with feature_context and bedrock_docs_query fields used "
+            "to drive the LLM-augmented conversion-plan generation."
+        ),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed BaseTool subclasses — replace the previous @tool @staticmethod wrappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BaseBedrockArchitectTool(BaseTool):
+    """Common scaffolding for Bedrock Architect typed tool wrappers."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _AnalyzeJavaFeatureTool(_BaseBedrockArchitectTool):
+    name: str = "analyze_java_feature_tool"
+    description: str = (
+        "Analyze a Java mod feature to determine applicable smart assumptions. "
+        "Args: feature_data (str, required) — JSON with feature_id, feature_type, "
+        "name, and original_data."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _AnalyzeJavaFeatureInput
+
+    def _run(self, feature_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._analyze_java_feature(feature_data)
+
+
+class _ApplySmartAssumptionTool(_BaseBedrockArchitectTool):
+    name: str = "apply_smart_assumption_tool"
+    description: str = (
+        "Apply a smart assumption to a Java mod feature, returning the resulting "
+        "conversion-plan component. "
+        "Args: assumption_data (str, required) — JSON containing a feature_context."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ApplySmartAssumptionInput
+
+    def _run(self, assumption_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._apply_smart_assumption(assumption_data)
+
+
+class _CreateConversionPlanTool(_BaseBedrockArchitectTool):
+    name: str = "create_conversion_plan_tool"
+    description: str = (
+        "Create a conversion plan for a list of Java mod features. "
+        "Args: plan_data (str or list, required) — JSON string or list of feature dicts."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _CreateConversionPlanInput
+
+    def _run(self, plan_data: Any) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._create_conversion_plan(plan_data)
+
+
+class _GetAssumptionConflictsTool(_BaseBedrockArchitectTool):
+    name: str = "get_assumption_conflicts_tool"
+    description: str = (
+        "Get the assumption-conflict analysis for a given feature type. "
+        "Args: conflict_data (str, required) — JSON with a feature_type field."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GetAssumptionConflictsInput
+
+    def _run(self, conflict_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._get_assumption_conflicts(conflict_data)
+
+
+class _ValidateBedrockCompatibilityTool(_BaseBedrockArchitectTool):
+    name: str = "validate_bedrock_compatibility_tool"
+    description: str = (
+        "Validate the Bedrock compatibility of a conversion plan, surfacing "
+        "warnings and recommendations per component. "
+        "Args: compatibility_data (str, required) — JSON with a components list."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ValidateBedrockCompatibilityInput
+
+    def _run(self, compatibility_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._validate_bedrock_compatibility(compatibility_data)
+
+
+class _GenerateBlockDefinitionsTool(_BaseBedrockArchitectTool):
+    name: str = "generate_block_definitions_tool"
+    description: str = (
+        "Generate a placeholder Bedrock block definition. "
+        "Args: block_data (str, required) — JSON describing the block."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateBlockDefinitionsInput
+
+    def _run(self, block_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._generate_block_definitions(block_data)
+
+
+class _GenerateItemDefinitionsTool(_BaseBedrockArchitectTool):
+    name: str = "generate_item_definitions_tool"
+    description: str = (
+        "Generate a placeholder Bedrock item definition. "
+        "Args: item_data (str, required) — JSON describing the item."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateItemDefinitionsInput
+
+    def _run(self, item_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._generate_item_definitions(item_data)
+
+
+class _GenerateRecipeDefinitionsTool(_BaseBedrockArchitectTool):
+    name: str = "generate_recipe_definitions_tool"
+    description: str = (
+        "Generate a placeholder Bedrock recipe definition. "
+        "Args: recipe_data (str, required) — JSON describing the recipe."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateRecipeDefinitionsInput
+
+    def _run(self, recipe_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._generate_recipe_definitions(recipe_data)
+
+
+class _GenerateEntityDefinitionsTool(_BaseBedrockArchitectTool):
+    name: str = "generate_entity_definitions_tool"
+    description: str = (
+        "Generate a placeholder Bedrock entity definition. "
+        "Args: entity_data (str, required) — JSON describing the entity."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateEntityDefinitionsInput
+
+    def _run(self, entity_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._generate_entity_definitions(entity_data)
+
+
+class _CreateLlmConversionPlanTool(_BaseBedrockArchitectTool):
+    name: str = "create_llm_conversion_plan_tool"
+    description: str = (
+        "Use the LLM + RAG pipeline to generate a Bedrock conversion plan with "
+        "feasibility assessment. "
+        "Args: plan_data (str, required) — JSON with feature_context and "
+        "bedrock_docs_query."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _CreateLlmConversionPlanInput
+
+    def _run(self, plan_data: str) -> str:  # type: ignore[override]
+        return BedrockArchitectAgent._create_llm_conversion_plan(plan_data)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level tool instances — preserved as class attributes on
+# BedrockArchitectAgent so the existing access patterns
+# (``BedrockArchitectAgent.<tool_name>`` and ``agent.<tool_name>``)
+# both continue to work unchanged for call sites and tests.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+BedrockArchitectAgent.analyze_java_feature_tool = _AnalyzeJavaFeatureTool()
+BedrockArchitectAgent.apply_smart_assumption_tool = _ApplySmartAssumptionTool()
+BedrockArchitectAgent.create_conversion_plan_tool = _CreateConversionPlanTool()
+BedrockArchitectAgent.get_assumption_conflicts_tool = _GetAssumptionConflictsTool()
+BedrockArchitectAgent.validate_bedrock_compatibility_tool = _ValidateBedrockCompatibilityTool()
+BedrockArchitectAgent.generate_block_definitions_tool = _GenerateBlockDefinitionsTool()
+BedrockArchitectAgent.generate_item_definitions_tool = _GenerateItemDefinitionsTool()
+BedrockArchitectAgent.generate_recipe_definitions_tool = _GenerateRecipeDefinitionsTool()
+BedrockArchitectAgent.generate_entity_definitions_tool = _GenerateEntityDefinitionsTool()
+BedrockArchitectAgent.create_llm_conversion_plan_tool = _CreateLlmConversionPlanTool()

--- a/ai-engine/agents/bedrock_builder.py
+++ b/ai-engine/agents/bedrock_builder.py
@@ -12,7 +12,10 @@ import zipfile
 from pathlib import Path
 from typing import Any, Dict, List
 
-from langchain_core.tools import tool
+from typing import ClassVar
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
 from jinja2 import Environment, FileSystemLoader
 from PIL import Image
 
@@ -855,30 +858,159 @@ class BedrockBuilderAgent:
         """Legacy method for compatibility."""
         return []
 
-    @tool
+    # ------------------------------------------------------------------
+    # Static implementations (used by typed BaseTool subclasses below).
+    #
+    # These were previously decorated with @tool @staticmethod; the
+    # @tool decorator has been removed and each method renamed with a
+    # leading underscore so it does not collide with the class-attribute
+    # binding of the typed BaseTool instance below.
+    # ------------------------------------------------------------------
+
     @staticmethod
-    def build_bedrock_structure_tool(structure_data: str) -> str:
+    def _build_bedrock_structure(structure_data: str) -> str:
         """Build basic Bedrock addon structure."""
         # Implementation placeholder
         return json.dumps({"success": True, "message": "Structure created"})
 
-    @tool
     @staticmethod
-    def generate_block_definitions_tool(block_data: str) -> str:
+    def _generate_block_definitions(block_data: str) -> str:
         """Generate Bedrock block definition files."""
         # Implementation placeholder
         return json.dumps({"success": True, "message": "Block definitions generated"})
 
-    @tool
     @staticmethod
-    def convert_assets_tool(asset_data: str) -> str:
+    def _convert_assets(asset_data: str) -> str:
         """Convert assets to Bedrock format."""
         # Implementation placeholder
         return json.dumps({"success": True, "message": "Assets converted"})
 
-    @tool
     @staticmethod
-    def package_addon_tool(package_data: str) -> str:
+    def _package_addon(package_data: str) -> str:
         """Package addon into .mcaddon file."""
         # Implementation placeholder
         return json.dumps({"success": True, "message": "Addon packaged"})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed args_schema models — one per LangChain tool wrapper
+#
+# Phase 8 A4a (refs #1201). Each schema preserves the legacy single-string
+# <name>_data shape so chat models and existing call sites continue to
+# invoke BedrockBuilderAgent.<tool_name>.invoke({"<name>_data": "..."})
+# without changes. extra="forbid" makes hallucinated extra fields fail
+# loud at validation, and min_length=1 rejects empty strings.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BuildBedrockStructureInput(BaseModel):
+    """Args for :class:`_BuildBedrockStructureTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    structure_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock addon directory structure to build.",
+    )
+
+
+class _GenerateBlockDefinitionsInput(BaseModel):
+    """Args for :class:`_GenerateBlockDefinitionsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    block_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock block definitions to generate.",
+    )
+
+
+class _ConvertAssetsInput(BaseModel):
+    """Args for :class:`_ConvertAssetsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    asset_data: str = Field(
+        min_length=1,
+        description="JSON string describing the assets (textures, models, sounds) to convert.",
+    )
+
+
+class _PackageAddonInput(BaseModel):
+    """Args for :class:`_PackageAddonTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    package_data: str = Field(
+        min_length=1,
+        description="JSON string describing the addon to package into a .mcaddon archive.",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed BaseTool subclasses — replace the previous @tool @staticmethod wrappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BaseBedrockBuilderTool(BaseTool):
+    """Common scaffolding for Bedrock Builder typed tool wrappers."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _BuildBedrockStructureTool(_BaseBedrockBuilderTool):
+    name: str = "build_bedrock_structure_tool"
+    description: str = (
+        "Build basic Bedrock addon directory structure. "
+        "Args: structure_data (str, required) — JSON describing the structure."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _BuildBedrockStructureInput
+
+    def _run(self, structure_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._build_bedrock_structure(structure_data)
+
+
+class _GenerateBlockDefinitionsTool(_BaseBedrockBuilderTool):
+    name: str = "generate_block_definitions_tool"
+    description: str = (
+        "Generate Bedrock block definition files. "
+        "Args: block_data (str, required) — JSON describing the blocks."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateBlockDefinitionsInput
+
+    def _run(self, block_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._generate_block_definitions(block_data)
+
+
+class _ConvertAssetsTool(_BaseBedrockBuilderTool):
+    name: str = "convert_assets_tool"
+    description: str = (
+        "Convert mod assets to Bedrock format. "
+        "Args: asset_data (str, required) — JSON describing the assets."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ConvertAssetsInput
+
+    def _run(self, asset_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._convert_assets(asset_data)
+
+
+class _PackageAddonTool(_BaseBedrockBuilderTool):
+    name: str = "package_addon_tool"
+    description: str = (
+        "Package an addon into a .mcaddon archive. "
+        "Args: package_data (str, required) — JSON describing the package."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _PackageAddonInput
+
+    def _run(self, package_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._package_addon(package_data)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level tool instances — preserved as class attributes on
+# BedrockBuilderAgent so the existing access patterns
+# (BedrockBuilderAgent.<tool_name> and agent.<tool_name>) both
+# continue to work unchanged for call sites and tests.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+BedrockBuilderAgent.build_bedrock_structure_tool = _BuildBedrockStructureTool()
+BedrockBuilderAgent.generate_block_definitions_tool = _GenerateBlockDefinitionsTool()
+BedrockBuilderAgent.convert_assets_tool = _ConvertAssetsTool()
+BedrockBuilderAgent.package_addon_tool = _PackageAddonTool()

--- a/ai-engine/tests/unit/test_bedrock_architect_builder_typed.py
+++ b/ai-engine/tests/unit/test_bedrock_architect_builder_typed.py
@@ -1,0 +1,459 @@
+"""Tests for the typed BaseTool wrappers in agents/bedrock_architect.py and
+agents/bedrock_builder.py.
+
+These wrappers replace the previous bare ``@tool @staticmethod`` decorators
+(Phase 8 A4a, refs #1201). Each tool now exposes an explicit Pydantic
+``args_schema`` so chat models with native tool-calling can invoke it with
+validated arguments rather than an opaque single string.
+
+Pattern matches PR #1453 (qa typed args) and PR #1451 (steering typed args):
+the legacy ``<name>_data: str`` shape is preserved end-to-end so existing
+call sites and the existing coverage suite (``test_bedrock_architect_coverage``,
+``test_bedrock_builder_mvp``) pass unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ValidationError
+
+from agents.bedrock_architect import (
+    BedrockArchitectAgent,
+    _AnalyzeJavaFeatureInput,
+    _AnalyzeJavaFeatureTool,
+    _ApplySmartAssumptionInput,
+    _ApplySmartAssumptionTool,
+    _CreateConversionPlanInput,
+    _CreateConversionPlanTool,
+    _CreateLlmConversionPlanInput,
+    _CreateLlmConversionPlanTool,
+    _GenerateBlockDefinitionsInput,
+    _GenerateBlockDefinitionsTool,
+    _GenerateEntityDefinitionsInput,
+    _GenerateEntityDefinitionsTool,
+    _GenerateItemDefinitionsInput,
+    _GenerateItemDefinitionsTool,
+    _GenerateRecipeDefinitionsInput,
+    _GenerateRecipeDefinitionsTool,
+    _GetAssumptionConflictsInput,
+    _GetAssumptionConflictsTool,
+    _ValidateBedrockCompatibilityInput,
+    _ValidateBedrockCompatibilityTool,
+)
+from agents.bedrock_builder import (
+    BedrockBuilderAgent,
+    _BuildBedrockStructureInput,
+    _BuildBedrockStructureTool,
+    _ConvertAssetsInput,
+    _ConvertAssetsTool,
+    _GenerateBlockDefinitionsInput as _BuilderGenerateBlockDefinitionsInput,
+    _GenerateBlockDefinitionsTool as _BuilderGenerateBlockDefinitionsTool,
+    _PackageAddonInput,
+    _PackageAddonTool,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Architect: instance / schema identity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def architect():
+    """Reset Architect singleton so each test gets a clean engine."""
+    BedrockArchitectAgent._instance = None
+    return BedrockArchitectAgent.get_instance()
+
+
+class TestArchitectInstancesAreTypedBaseTools:
+    """Verify the class-attribute aliases are typed BaseTool instances."""
+
+    @pytest.mark.parametrize(
+        "tool_attr,expected_class,expected_schema",
+        [
+            ("analyze_java_feature_tool", _AnalyzeJavaFeatureTool, _AnalyzeJavaFeatureInput),
+            ("apply_smart_assumption_tool", _ApplySmartAssumptionTool, _ApplySmartAssumptionInput),
+            ("create_conversion_plan_tool", _CreateConversionPlanTool, _CreateConversionPlanInput),
+            (
+                "get_assumption_conflicts_tool",
+                _GetAssumptionConflictsTool,
+                _GetAssumptionConflictsInput,
+            ),
+            (
+                "validate_bedrock_compatibility_tool",
+                _ValidateBedrockCompatibilityTool,
+                _ValidateBedrockCompatibilityInput,
+            ),
+            (
+                "generate_block_definitions_tool",
+                _GenerateBlockDefinitionsTool,
+                _GenerateBlockDefinitionsInput,
+            ),
+            (
+                "generate_item_definitions_tool",
+                _GenerateItemDefinitionsTool,
+                _GenerateItemDefinitionsInput,
+            ),
+            (
+                "generate_recipe_definitions_tool",
+                _GenerateRecipeDefinitionsTool,
+                _GenerateRecipeDefinitionsInput,
+            ),
+            (
+                "generate_entity_definitions_tool",
+                _GenerateEntityDefinitionsTool,
+                _GenerateEntityDefinitionsInput,
+            ),
+            (
+                "create_llm_conversion_plan_tool",
+                _CreateLlmConversionPlanTool,
+                _CreateLlmConversionPlanInput,
+            ),
+        ],
+    )
+    def test_class_attr_is_typed_basetool(self, tool_attr, expected_class, expected_schema):
+        tool_instance = getattr(BedrockArchitectAgent, tool_attr)
+        assert isinstance(tool_instance, BaseTool), tool_attr
+        assert isinstance(tool_instance, expected_class), tool_attr
+        assert tool_instance.args_schema is expected_schema, tool_attr
+        assert issubclass(tool_instance.args_schema, BaseModel), tool_attr
+        # Tool name mirrors the legacy @tool wrapper name.
+        assert tool_instance.name == tool_attr, tool_attr
+
+    def test_get_tools_returns_ten_typed_basetools(self, architect):
+        tools = architect.get_tools()
+        assert len(tools) == 10
+        assert all(isinstance(t, BaseTool) for t in tools)
+        assert all(t.args_schema is not None for t in tools)
+        names = [t.name for t in tools]
+        assert names == [
+            "analyze_java_feature_tool",
+            "apply_smart_assumption_tool",
+            "create_conversion_plan_tool",
+            "get_assumption_conflicts_tool",
+            "validate_bedrock_compatibility_tool",
+            "generate_block_definitions_tool",
+            "generate_item_definitions_tool",
+            "generate_recipe_definitions_tool",
+            "generate_entity_definitions_tool",
+            "create_llm_conversion_plan_tool",
+        ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Architect: schema validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestArchitectSchemaValidation:
+    """args_schema rejects empty strings and extra fields at validation time."""
+
+    @pytest.mark.parametrize(
+        "schema_class,field_name",
+        [
+            (_AnalyzeJavaFeatureInput, "feature_data"),
+            (_ApplySmartAssumptionInput, "assumption_data"),
+            (_GetAssumptionConflictsInput, "conflict_data"),
+            (_ValidateBedrockCompatibilityInput, "compatibility_data"),
+            (_GenerateBlockDefinitionsInput, "block_data"),
+            (_GenerateItemDefinitionsInput, "item_data"),
+            (_GenerateRecipeDefinitionsInput, "recipe_data"),
+            (_GenerateEntityDefinitionsInput, "entity_data"),
+            (_CreateLlmConversionPlanInput, "plan_data"),
+        ],
+    )
+    def test_min_length_rejects_empty_string(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: ""})
+
+    @pytest.mark.parametrize(
+        "schema_class,field_name",
+        [
+            (_AnalyzeJavaFeatureInput, "feature_data"),
+            (_ApplySmartAssumptionInput, "assumption_data"),
+            (_CreateConversionPlanInput, "plan_data"),
+            (_GetAssumptionConflictsInput, "conflict_data"),
+            (_ValidateBedrockCompatibilityInput, "compatibility_data"),
+            (_GenerateBlockDefinitionsInput, "block_data"),
+            (_GenerateItemDefinitionsInput, "item_data"),
+            (_GenerateRecipeDefinitionsInput, "recipe_data"),
+            (_GenerateEntityDefinitionsInput, "entity_data"),
+            (_CreateLlmConversionPlanInput, "plan_data"),
+        ],
+    )
+    def test_extra_fields_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: "{}", "rogue": True})
+
+    @pytest.mark.parametrize(
+        "schema_class,field_name",
+        [
+            (_AnalyzeJavaFeatureInput, "feature_data"),
+            (_ApplySmartAssumptionInput, "assumption_data"),
+            (_CreateConversionPlanInput, "plan_data"),
+            (_GetAssumptionConflictsInput, "conflict_data"),
+            (_ValidateBedrockCompatibilityInput, "compatibility_data"),
+            (_GenerateBlockDefinitionsInput, "block_data"),
+            (_GenerateItemDefinitionsInput, "item_data"),
+            (_GenerateRecipeDefinitionsInput, "recipe_data"),
+            (_GenerateEntityDefinitionsInput, "entity_data"),
+            (_CreateLlmConversionPlanInput, "plan_data"),
+        ],
+    )
+    def test_missing_required_field_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({})
+
+    def test_create_conversion_plan_accepts_list(self):
+        # plan_data is typed as Any to preserve legacy str-or-list semantics.
+        schema = _CreateConversionPlanInput.model_validate({"plan_data": [{"feature_id": "x"}]})
+        assert schema.plan_data == [{"feature_id": "x"}]
+
+    def test_create_conversion_plan_accepts_string(self):
+        schema = _CreateConversionPlanInput.model_validate({"plan_data": "[]"})
+        assert schema.plan_data == "[]"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Architect: invoke smoke tests (typed dict shape)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestArchitectInvokeRoundtrips:
+    """invoke({"<name>_data": ...}) returns the same JSON the impl would produce."""
+
+    def test_analyze_java_feature_invoke_basic(self, architect):
+        feature_data = json.dumps({"feature_id": "x", "feature_type": "block", "name": "X"})
+        with patch.object(architect.smart_assumption_engine, "analyze_feature") as mock:
+            result = MagicMock()
+            result.applied_assumption = None
+            result.conflicting_assumptions = []
+            result.conflict_resolution_reason = None
+            mock.return_value = result
+            out = json.loads(
+                BedrockArchitectAgent.analyze_java_feature_tool.invoke(
+                    {"feature_data": feature_data}
+                )
+            )
+        assert out["feature_id"] == "x"
+        assert "directly convertible" in out["recommendation"]
+
+    def test_get_assumption_conflicts_invoke(self, architect):
+        with patch.object(architect.smart_assumption_engine, "get_conflict_analysis") as mock:
+            mock.return_value = {"conflicts": []}
+            out = json.loads(
+                BedrockArchitectAgent.get_assumption_conflicts_tool.invoke(
+                    {"conflict_data": json.dumps({"feature_type": "block"})}
+                )
+            )
+        assert "conflicts" in out
+
+    def test_generate_block_definitions_invoke(self, architect):
+        block_data = json.dumps({"id": "test_block", "name": "Test Block"})
+        out = json.loads(
+            BedrockArchitectAgent.generate_block_definitions_tool.invoke({"block_data": block_data})
+        )
+        assert out["success"] is True
+        assert out["component_type"] == "block"
+
+    def test_generate_block_definitions_invalid_json_returns_error(self, architect):
+        out = json.loads(
+            BedrockArchitectAgent.generate_block_definitions_tool.invoke({"block_data": "not json"})
+        )
+        assert out["success"] is False
+        assert "Invalid JSON" in out["error"]
+
+    def test_validate_bedrock_compatibility_invoke(self, architect):
+        compat = json.dumps(
+            {
+                "components": [
+                    {
+                        "original_feature_id": "c1",
+                        "impact_level": "high",
+                        "assumption_type": "dimension",
+                    }
+                ]
+            }
+        )
+        out = json.loads(
+            BedrockArchitectAgent.validate_bedrock_compatibility_tool.invoke(
+                {"compatibility_data": compat}
+            )
+        )
+        assert out["is_compatible"] is True
+        assert len(out["component_validations"]) == 1
+        assert any("dimension" in w.lower() for w in out["warnings"])
+
+    def test_create_conversion_plan_invoke_with_list(self, architect):
+        with (
+            patch.object(architect.smart_assumption_engine, "analyze_feature") as mock_a,
+            patch.object(architect.smart_assumption_engine, "apply_assumption") as mock_app,
+            patch.object(
+                architect.smart_assumption_engine, "generate_assumption_report"
+            ) as mock_rep,
+        ):
+            ar = MagicMock()
+            ar.applied_assumption = MagicMock()
+            mock_a.return_value = ar
+            comp = MagicMock()
+            comp.original_feature_id = "f1"
+            comp.original_feature_type = "block"
+            comp.assumption_type = "x"
+            comp.bedrock_equivalent = "y"
+            comp.impact_level = "low"
+            comp.user_explanation = "e"
+            comp.technical_notes = "n"
+            mock_app.return_value = comp
+            rep = MagicMock()
+            rep.assumptions_applied = []
+            mock_rep.return_value = rep
+
+            # Pass a Python list, not a JSON string — exercises the Any branch.
+            out = json.loads(
+                BedrockArchitectAgent.create_conversion_plan_tool.invoke(
+                    {"plan_data": [{"feature_id": "f1", "feature_type": "block"}]}
+                )
+            )
+        assert out["success"] is True
+        assert out["conversion_plan_components"] == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Builder: instance / schema identity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def builder():
+    BedrockBuilderAgent._instance = None
+    return BedrockBuilderAgent.get_instance()
+
+
+class TestBuilderInstancesAreTypedBaseTools:
+    """Verify the class-attribute aliases on BedrockBuilderAgent."""
+
+    @pytest.mark.parametrize(
+        "tool_attr,expected_class,expected_schema_name",
+        [
+            (
+                "build_bedrock_structure_tool",
+                _BuildBedrockStructureTool,
+                "_BuildBedrockStructureInput",
+            ),
+            (
+                "generate_block_definitions_tool",
+                _BuilderGenerateBlockDefinitionsTool,
+                "_GenerateBlockDefinitionsInput",
+            ),
+            ("convert_assets_tool", _ConvertAssetsTool, "_ConvertAssetsInput"),
+            ("package_addon_tool", _PackageAddonTool, "_PackageAddonInput"),
+        ],
+    )
+    def test_class_attr_is_typed_basetool(self, tool_attr, expected_class, expected_schema_name):
+        tool_instance = getattr(BedrockBuilderAgent, tool_attr)
+        assert isinstance(tool_instance, BaseTool), tool_attr
+        assert isinstance(tool_instance, expected_class), tool_attr
+        assert tool_instance.args_schema is not None, tool_attr
+        assert tool_instance.args_schema.__name__ == expected_schema_name, tool_attr
+        assert tool_instance.name == tool_attr, tool_attr
+
+    def test_get_tools_returns_four_typed_basetools(self, builder):
+        tools = builder.get_tools()
+        assert len(tools) == 4
+        assert all(isinstance(t, BaseTool) for t in tools)
+        assert all(t.args_schema is not None for t in tools)
+        assert [t.name for t in tools] == [
+            "build_bedrock_structure_tool",
+            "generate_block_definitions_tool",
+            "convert_assets_tool",
+            "package_addon_tool",
+        ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Builder: schema validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuilderSchemaValidation:
+    @pytest.mark.parametrize(
+        "schema_class,field_name",
+        [
+            (_BuildBedrockStructureInput, "structure_data"),
+            (_BuilderGenerateBlockDefinitionsInput, "block_data"),
+            (_ConvertAssetsInput, "asset_data"),
+            (_PackageAddonInput, "package_data"),
+        ],
+    )
+    def test_min_length_rejects_empty_string(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: ""})
+
+    @pytest.mark.parametrize(
+        "schema_class,field_name",
+        [
+            (_BuildBedrockStructureInput, "structure_data"),
+            (_BuilderGenerateBlockDefinitionsInput, "block_data"),
+            (_ConvertAssetsInput, "asset_data"),
+            (_PackageAddonInput, "package_data"),
+        ],
+    )
+    def test_extra_fields_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: "{}", "rogue": True})
+
+    @pytest.mark.parametrize(
+        "schema_class",
+        [
+            _BuildBedrockStructureInput,
+            _BuilderGenerateBlockDefinitionsInput,
+            _ConvertAssetsInput,
+            _PackageAddonInput,
+        ],
+    )
+    def test_missing_required_field_rejected(self, schema_class):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Builder: invoke smoke tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuilderInvokeRoundtrips:
+    def test_build_bedrock_structure_invoke(self):
+        out = json.loads(
+            BedrockBuilderAgent.build_bedrock_structure_tool.invoke({"structure_data": "{}"})
+        )
+        assert out == {"success": True, "message": "Structure created"}
+
+    def test_generate_block_definitions_invoke(self):
+        out = json.loads(
+            BedrockBuilderAgent.generate_block_definitions_tool.invoke({"block_data": "{}"})
+        )
+        assert out == {"success": True, "message": "Block definitions generated"}
+
+    def test_convert_assets_invoke(self):
+        out = json.loads(BedrockBuilderAgent.convert_assets_tool.invoke({"asset_data": "{}"}))
+        assert out == {"success": True, "message": "Assets converted"}
+
+    def test_package_addon_invoke(self):
+        out = json.loads(BedrockBuilderAgent.package_addon_tool.invoke({"package_data": "{}"}))
+        assert out == {"success": True, "message": "Addon packaged"}
+
+    def test_invoke_with_empty_string_raises(self):
+        with pytest.raises(ValidationError):
+            BedrockBuilderAgent.build_bedrock_structure_tool.invoke({"structure_data": ""})
+
+    def test_invoke_missing_field_raises(self):
+        with pytest.raises(ValidationError):
+            BedrockBuilderAgent.convert_assets_tool.invoke({})
+
+    def test_invoke_extra_field_raises(self):
+        with pytest.raises(ValidationError):
+            BedrockBuilderAgent.package_addon_tool.invoke({"package_data": "{}", "rogue": True})


### PR DESCRIPTION
## What
Convert all 14 LangChain tools in `bedrock_architect.py` (10) and `bedrock_builder.py` (4) from untyped `@tool` decorators to typed `BaseTool` subclasses with explicit `args_schema` Pydantic models.

## Why
Part of the typed-args migration tracked in `.planning/notes/2026-05-14-followups.md`. Eliminates a category of runtime `KeyError` / `TypeError` failures when LangGraph dispatches malformed tool calls — Pydantic validation now happens at the boundary, with structured error messages for both human reviewers and LLM retry loops.

## Scope (disjoint from sibling A-slices)
- `ai-engine/agents/bedrock_architect.py` — 10 typed tools
- `ai-engine/agents/bedrock_builder.py` — 4 typed tools
- `ai-engine/tests/unit/test_bedrock_architect_builder_typed.py` — new file, 72 tests

## Verification
- 72 new typed-tool tests pass
- 25 baseline `bedrock_*` tests unchanged → still pass
- Total ai-engine unit suite: 978/978 passing locally

## Sibling PRs (parallel-safe — disjoint write scopes)
- A4b: typed packaging_agent
- A5: typed recipe converter
- A6: typed java_analyzer/tools.py (last A-slice)

## Follow-up
A separate "E" PR will re-run `scripts/portkit_skeletonize.py` after A4a–A6 all land, refreshing `ai-engine/SKELETON.md` to reflect the new typed surface in one canonical commit.