### PR TITLE
refactor(ai-engine): typed args_schema for packaging_agent (A4b)

### DIFF
--- a/ai-engine/agents/packaging_agent.py
+++ b/ai-engine/agents/packaging_agent.py
@@ -5,21 +5,41 @@ This module is now a thin wrapper that imports from the packaging/ subpackage.
 All implementation details have been moved to ai-engine/agents/packaging/.
 
 Per issue #1278: Split packaging_agent.py (42K) + packaging_validator.py (31K) into packaging/ subpackage
+
+Phase 8 A4b (refs #1201): the legacy ``@tool @staticmethod`` wrappers have
+been replaced with typed :class:`langchain_core.tools.BaseTool` subclasses,
+each declaring an explicit Pydantic ``args_schema``. The single-string
+``<name>_data`` shape is preserved so chat models and existing call sites
+continue to invoke ``PackagingAgent.<tool_name>.invoke({...})`` without
+changes. Folds in two pre-existing follow-ups:
+
+* Item 9 from .planning/notes/2026-05-14-followups.md: removes two F401
+  unused imports (``ManifestGenerator``, ``PackagingCoordinator``) from the
+  ``agents.packaging`` import block.
+* Drive-by: fixes ``logger = __name__`` (a string!) to
+  ``logger = logging.getLogger(__name__)`` so the ``except``-branch
+  ``logger.error(...)`` calls actually log instead of raising
+  ``AttributeError``. Same flavor of latent-logger fix as PR #1450 did
+  for ``multimodal_search_engine.py``.
 """
 
-from langchain_core.tools import tool
+import json
+import logging
+from pathlib import Path
+from typing import Any, ClassVar
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
 
 from agents.packaging import (
     Bundler,
     FolderBuilder,
-    ManifestGenerator,
-    PackagingCoordinator,
     PackagingValidator,
 )
 from agents.packaging.manifest import ManifestGenerator as _ManifestGenerator
 from models.smart_assumptions import SmartAssumptionEngine
 
-logger = __name__
+logger = logging.getLogger(__name__)
 
 
 class PackagingAgent:
@@ -153,9 +173,7 @@ class PackagingAgent:
         """Build the final mcaddon package."""
         return self.bundler.build_mcaddon(build_data)
 
-    def build_mcaddon_mvp(
-        self, temp_dir: str, output_path: str, mod_name: str = None
-    ):
+    def build_mcaddon_mvp(self, temp_dir: str, output_path: str, mod_name: str = None):
         """Build .mcaddon file from temp directory structure for MVP pipeline."""
         return self.bundler.build_mcaddon_mvp(temp_dir, output_path, mod_name)
 
@@ -163,46 +181,39 @@ class PackagingAgent:
         """Validate a created .mcaddon file."""
         return self.bundler._validate_mcaddon_file(mcaddon_path)
 
-    @tool
     @staticmethod
-    def analyze_conversion_components_tool(component_data: str) -> str:
+    def _analyze_conversion_components(component_data: str) -> str:
         """Analyze conversion components for packaging."""
         agent = PackagingAgent.get_instance()
         return agent.analyze_conversion_components(component_data)
 
-    @tool
     @staticmethod
-    def create_package_structure_tool(structure_data: str) -> str:
+    def _create_package_structure(structure_data: str) -> str:
         """Create package structure for Bedrock addon."""
         agent = PackagingAgent.get_instance()
         return agent.create_package_structure(structure_data)
 
-    @tool
     @staticmethod
-    def generate_manifests_tool(manifest_data: str) -> str:
+    def _generate_manifests(manifest_data: str) -> str:
         """Generate manifest files for the addon."""
         agent = PackagingAgent.get_instance()
         return agent.generate_manifests(manifest_data)
 
-    @tool
     @staticmethod
-    def validate_package_tool(validation_data: str) -> str:
+    def _validate_package(validation_data: str) -> str:
         """Validate the package structure."""
         agent = PackagingAgent.get_instance()
         return agent.validate_package(validation_data)
 
-    @tool
     @staticmethod
-    def build_mcaddon_tool(build_data: str) -> str:
+    def _build_mcaddon(build_data: str) -> str:
         """Build the final mcaddon package."""
         agent = PackagingAgent.get_instance()
         return agent.build_mcaddon(build_data)
 
-    @tool
     @staticmethod
-    def generate_enhanced_manifests_tool(mod_data: str) -> str:
+    def _generate_enhanced_manifests(mod_data: str) -> str:
         """Generate enhanced Bedrock manifests using the new manifest generator."""
-        import json
 
         try:
             agent = PackagingAgent.get_instance()
@@ -227,11 +238,9 @@ class PackagingAgent:
             logger.error(f"Enhanced manifest generation error: {e}")
             return json.dumps({"success": False, "error": str(e)})
 
-    @tool
     @staticmethod
-    def generate_blocks_and_items_tool(conversion_data: str) -> str:
+    def _generate_blocks_and_items(conversion_data: str) -> str:
         """Generate Bedrock blocks and items from Java conversion data."""
-        import json
 
         try:
             agent = PackagingAgent.get_instance()
@@ -268,11 +277,9 @@ class PackagingAgent:
             logger.error(f"Block/item generation error: {e}")
             return json.dumps({"success": False, "error": str(e)})
 
-    @tool
     @staticmethod
-    def generate_entities_tool(entity_data: str) -> str:
+    def _generate_entities(entity_data: str) -> str:
         """Generate Bedrock entities from Java entity data."""
-        import json
 
         try:
             agent = PackagingAgent.get_instance()
@@ -299,11 +306,9 @@ class PackagingAgent:
             logger.error(f"Entity generation error: {e}")
             return json.dumps({"success": False, "error": str(e)})
 
-    @tool
     @staticmethod
-    def package_enhanced_addon_tool(package_data: str) -> str:
+    def _package_enhanced_addon(package_data: str) -> str:
         """Package addon using the enhanced file packager."""
-        import json
 
         try:
             agent = PackagingAgent.get_instance()
@@ -324,12 +329,9 @@ class PackagingAgent:
             logger.error(f"Enhanced packaging error: {e}")
             return json.dumps({"success": False, "error": str(e)})
 
-    @tool
     @staticmethod
-    def validate_enhanced_addon_tool(addon_path: str) -> str:
+    def _validate_enhanced_addon(addon_path: str) -> str:
         """Validate addon using the enhanced validator."""
-        import json
-        from pathlib import Path
 
         try:
             agent = PackagingAgent.get_instance()
@@ -360,12 +362,9 @@ class PackagingAgent:
             logger.error(f"Enhanced validation error: {e}")
             return json.dumps({"success": False, "error": str(e)})
 
-    @tool
     @staticmethod
-    def validate_mcaddon_structure_tool(mcaddon_path: str) -> str:
+    def _validate_mcaddon_structure(mcaddon_path: str) -> str:
         """Validate .mcaddon file structure using comprehensive validator."""
-        import json
-        from pathlib import Path
 
         try:
             agent = PackagingAgent.get_instance()
@@ -397,12 +396,9 @@ class PackagingAgent:
             logger.error(f"Structure validation error: {e}")
             return json.dumps({"success": False, "error": str(e)})
 
-    @tool
     @staticmethod
-    def validate_manifest_schema_tool(manifest_data: str) -> str:
+    def _validate_manifest_schema(manifest_data: str) -> str:
         """Validate a manifest.json against Bedrock JSON schema."""
-        import json
-        from pathlib import Path
 
         try:
             agent = PackagingAgent.get_instance()
@@ -442,12 +438,9 @@ class PackagingAgent:
             logger.error(f"Manifest schema validation error: {e}")
             return json.dumps({"success": False, "error": str(e)})
 
-    @tool
     @staticmethod
-    def generate_validation_report_tool(mcaddon_path: str) -> str:
+    def _generate_validation_report(mcaddon_path: str) -> str:
         """Generate a human-readable validation report for .mcaddon file."""
-        import json
-        from pathlib import Path
 
         try:
             agent = PackagingAgent.get_instance()
@@ -470,3 +463,341 @@ class PackagingAgent:
         except Exception as e:
             logger.error(f"Report generation error: {e}")
             return json.dumps({"success": False, "error": str(e)})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed args_schema models — one per LangChain tool wrapper
+#
+# Each schema preserves the legacy single-string ``<name>_data`` (or path)
+# shape so existing call sites continue to invoke
+# ``PackagingAgent.<tool_name>.invoke({"<name>_data": "..."})`` without
+# changes. ``extra="forbid"`` makes hallucinated extra fields fail loud at
+# validation, and ``min_length=1`` rejects empty strings.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _AnalyzeConversionComponentsInput(BaseModel):
+    """Args for :class:`_AnalyzeConversionComponentsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    component_data: str = Field(
+        min_length=1,
+        description="JSON string describing the components to analyze for packaging.",
+    )
+
+
+class _CreatePackageStructureInput(BaseModel):
+    """Args for :class:`_CreatePackageStructureTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    structure_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock package structure to create.",
+    )
+
+
+class _GenerateManifestsInput(BaseModel):
+    """Args for :class:`_GenerateManifestsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    manifest_data: str = Field(
+        min_length=1,
+        description="JSON string describing the manifest data to generate.",
+    )
+
+
+class _ValidatePackageInput(BaseModel):
+    """Args for :class:`_ValidatePackageTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    validation_data: str = Field(
+        min_length=1,
+        description="JSON string describing the package data to validate.",
+    )
+
+
+class _BuildMcaddonInput(BaseModel):
+    """Args for :class:`_BuildMcaddonTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    build_data: Any = Field(
+        description=(
+            "JSON string or dict describing the addon to bundle into a "
+            ".mcaddon file. ``Any`` preserves the legacy build_data shape."
+        ),
+    )
+
+
+class _GenerateEnhancedManifestsInput(BaseModel):
+    """Args for :class:`_GenerateEnhancedManifestsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mod_data: str = Field(
+        min_length=1,
+        description="JSON string describing the mod data for the enhanced manifest generator.",
+    )
+
+
+class _GenerateBlocksAndItemsInput(BaseModel):
+    """Args for :class:`_GenerateBlocksAndItemsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    conversion_data: str = Field(
+        min_length=1,
+        description=(
+            "JSON string with blocks/items/recipes lists to convert into Bedrock JSON definitions."
+        ),
+    )
+
+
+class _GenerateEntitiesInput(BaseModel):
+    """Args for :class:`_GenerateEntitiesTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    entity_data: str = Field(
+        min_length=1,
+        description="JSON string with an entities list to convert into Bedrock entity JSON.",
+    )
+
+
+class _PackageEnhancedAddonInput(BaseModel):
+    """Args for :class:`_PackageEnhancedAddonTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    package_data: str = Field(
+        min_length=1,
+        description="JSON string describing the enhanced addon to package.",
+    )
+
+
+class _ValidateEnhancedAddonInput(BaseModel):
+    """Args for :class:`_ValidateEnhancedAddonTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    addon_path: str = Field(
+        min_length=1,
+        description="Filesystem path to the addon directory or archive to validate.",
+    )
+
+
+class _ValidateMcaddonStructureInput(BaseModel):
+    """Args for :class:`_ValidateMcaddonStructureTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mcaddon_path: str = Field(
+        min_length=1,
+        description="Filesystem path to the .mcaddon archive to validate.",
+    )
+
+
+class _ValidateManifestSchemaInput(BaseModel):
+    """Args for :class:`_ValidateManifestSchemaTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    manifest_data: str = Field(
+        min_length=1,
+        description=(
+            "Either a filesystem path to a manifest.json file, or a JSON "
+            "string containing the manifest data."
+        ),
+    )
+
+
+class _GenerateValidationReportInput(BaseModel):
+    """Args for :class:`_GenerateValidationReportTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mcaddon_path: str = Field(
+        min_length=1,
+        description="Filesystem path to the .mcaddon archive to validate and report on.",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed BaseTool subclasses — replace the previous @tool @staticmethod wrappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BasePackagingTool(BaseTool):
+    """Common scaffolding for Packaging Agent typed tool wrappers."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _AnalyzeConversionComponentsTool(_BasePackagingTool):
+    name: str = "analyze_conversion_components_tool"
+    description: str = (
+        "Analyze conversion components for packaging. "
+        "Args: component_data (str, required) — JSON describing the components."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _AnalyzeConversionComponentsInput
+
+    def _run(self, component_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._analyze_conversion_components(component_data)
+
+
+class _CreatePackageStructureTool(_BasePackagingTool):
+    name: str = "create_package_structure_tool"
+    description: str = (
+        "Create the Bedrock package structure on disk. "
+        "Args: structure_data (str, required) — JSON describing the structure."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _CreatePackageStructureInput
+
+    def _run(self, structure_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._create_package_structure(structure_data)
+
+
+class _GenerateManifestsTool(_BasePackagingTool):
+    name: str = "generate_manifests_tool"
+    description: str = (
+        "Generate Bedrock manifest files for the addon. "
+        "Args: manifest_data (str, required) — JSON describing the manifest data."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateManifestsInput
+
+    def _run(self, manifest_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._generate_manifests(manifest_data)
+
+
+class _ValidatePackageTool(_BasePackagingTool):
+    name: str = "validate_package_tool"
+    description: str = (
+        "Validate the package structure. "
+        "Args: validation_data (str, required) — JSON describing the package."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ValidatePackageInput
+
+    def _run(self, validation_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._validate_package(validation_data)
+
+
+class _BuildMcaddonTool(_BasePackagingTool):
+    name: str = "build_mcaddon_tool"
+    description: str = (
+        "Bundle the package into a .mcaddon file. "
+        "Args: build_data (str or dict, required) — JSON describing the addon."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _BuildMcaddonInput
+
+    def _run(self, build_data: Any) -> str:  # type: ignore[override]
+        return PackagingAgent._build_mcaddon(build_data)
+
+
+class _GenerateEnhancedManifestsTool(_BasePackagingTool):
+    name: str = "generate_enhanced_manifests_tool"
+    description: str = (
+        "Generate enhanced Bedrock manifests via the new manifest generator. "
+        "Args: mod_data (str, required) — JSON describing the mod."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateEnhancedManifestsInput
+
+    def _run(self, mod_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._generate_enhanced_manifests(mod_data)
+
+
+class _GenerateBlocksAndItemsTool(_BasePackagingTool):
+    name: str = "generate_blocks_and_items_tool"
+    description: str = (
+        "Generate Bedrock blocks, items, and recipes from Java conversion data. "
+        "Args: conversion_data (str, required) — JSON with blocks/items/recipes."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateBlocksAndItemsInput
+
+    def _run(self, conversion_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._generate_blocks_and_items(conversion_data)
+
+
+class _GenerateEntitiesTool(_BasePackagingTool):
+    name: str = "generate_entities_tool"
+    description: str = (
+        "Generate Bedrock entities from Java entity data. "
+        "Args: entity_data (str, required) — JSON with entities list."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateEntitiesInput
+
+    def _run(self, entity_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._generate_entities(entity_data)
+
+
+class _PackageEnhancedAddonTool(_BasePackagingTool):
+    name: str = "package_enhanced_addon_tool"
+    description: str = (
+        "Package an addon via the enhanced file packager. "
+        "Args: package_data (str, required) — JSON describing the addon."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _PackageEnhancedAddonInput
+
+    def _run(self, package_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._package_enhanced_addon(package_data)
+
+
+class _ValidateEnhancedAddonTool(_BasePackagingTool):
+    name: str = "validate_enhanced_addon_tool"
+    description: str = (
+        "Validate an addon via the enhanced validator. "
+        "Args: addon_path (str, required) — filesystem path to the addon."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ValidateEnhancedAddonInput
+
+    def _run(self, addon_path: str) -> str:  # type: ignore[override]
+        return PackagingAgent._validate_enhanced_addon(addon_path)
+
+
+class _ValidateMcaddonStructureTool(_BasePackagingTool):
+    name: str = "validate_mcaddon_structure_tool"
+    description: str = (
+        "Validate the .mcaddon file structure via the comprehensive validator. "
+        "Args: mcaddon_path (str, required) — filesystem path to the .mcaddon."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ValidateMcaddonStructureInput
+
+    def _run(self, mcaddon_path: str) -> str:  # type: ignore[override]
+        return PackagingAgent._validate_mcaddon_structure(mcaddon_path)
+
+
+class _ValidateManifestSchemaTool(_BasePackagingTool):
+    name: str = "validate_manifest_schema_tool"
+    description: str = (
+        "Validate a manifest.json against the Bedrock JSON schema. "
+        "Args: manifest_data (str, required) — file path or raw JSON."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ValidateManifestSchemaInput
+
+    def _run(self, manifest_data: str) -> str:  # type: ignore[override]
+        return PackagingAgent._validate_manifest_schema(manifest_data)
+
+
+class _GenerateValidationReportTool(_BasePackagingTool):
+    name: str = "generate_validation_report_tool"
+    description: str = (
+        "Generate a human-readable validation report for a .mcaddon file. "
+        "Args: mcaddon_path (str, required) — filesystem path to the .mcaddon."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateValidationReportInput
+
+    def _run(self, mcaddon_path: str) -> str:  # type: ignore[override]
+        return PackagingAgent._generate_validation_report(mcaddon_path)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level tool instances — preserved as class attributes on
+# PackagingAgent so the existing access patterns
+# (``PackagingAgent.<tool_name>`` and ``agent.<tool_name>``) both continue
+# to work unchanged for call sites and tests.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+PackagingAgent.analyze_conversion_components_tool = _AnalyzeConversionComponentsTool()
+PackagingAgent.create_package_structure_tool = _CreatePackageStructureTool()
+PackagingAgent.generate_manifests_tool = _GenerateManifestsTool()
+PackagingAgent.validate_package_tool = _ValidatePackageTool()
+PackagingAgent.build_mcaddon_tool = _BuildMcaddonTool()
+PackagingAgent.generate_enhanced_manifests_tool = _GenerateEnhancedManifestsTool()
+PackagingAgent.generate_blocks_and_items_tool = _GenerateBlocksAndItemsTool()
+PackagingAgent.generate_entities_tool = _GenerateEntitiesTool()
+PackagingAgent.package_enhanced_addon_tool = _PackageEnhancedAddonTool()
+PackagingAgent.validate_enhanced_addon_tool = _ValidateEnhancedAddonTool()
+PackagingAgent.validate_mcaddon_structure_tool = _ValidateMcaddonStructureTool()
+PackagingAgent.validate_manifest_schema_tool = _ValidateManifestSchemaTool()
+PackagingAgent.generate_validation_report_tool = _GenerateValidationReportTool()

--- a/ai-engine/tests/unit/test_packaging_agent_typed.py
+++ b/ai-engine/tests/unit/test_packaging_agent_typed.py
@@ -1,0 +1,245 @@
+"""Tests for the typed BaseTool wrappers in agents/packaging_agent.py.
+
+These wrappers replace the previous bare ``@tool @staticmethod`` decorators
+(Phase 8 A4b, refs #1201). Each tool now exposes an explicit Pydantic
+``args_schema`` so chat models with native tool-calling can invoke it with
+validated arguments rather than an opaque single string.
+
+Pattern matches PR #1453 (qa typed args) and the A4a refactor: the legacy
+``<name>_data: str`` shape is preserved end-to-end so existing call sites
+and the existing coverage suite (``tests/test_packaging_agent.py``) pass
+unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ValidationError
+
+from agents.packaging_agent import (
+    PackagingAgent,
+    _AnalyzeConversionComponentsInput,
+    _AnalyzeConversionComponentsTool,
+    _BuildMcaddonInput,
+    _BuildMcaddonTool,
+    _CreatePackageStructureInput,
+    _CreatePackageStructureTool,
+    _GenerateBlocksAndItemsInput,
+    _GenerateBlocksAndItemsTool,
+    _GenerateEnhancedManifestsInput,
+    _GenerateEnhancedManifestsTool,
+    _GenerateEntitiesInput,
+    _GenerateEntitiesTool,
+    _GenerateManifestsInput,
+    _GenerateManifestsTool,
+    _GenerateValidationReportInput,
+    _GenerateValidationReportTool,
+    _PackageEnhancedAddonInput,
+    _PackageEnhancedAddonTool,
+    _ValidateEnhancedAddonInput,
+    _ValidateEnhancedAddonTool,
+    _ValidateManifestSchemaInput,
+    _ValidateManifestSchemaTool,
+    _ValidateMcaddonStructureInput,
+    _ValidateMcaddonStructureTool,
+    _ValidatePackageInput,
+    _ValidatePackageTool,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Identity: each class-attribute alias is the corresponding typed BaseTool
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def agent():
+    """Reset the singleton so each test gets a fresh agent."""
+    PackagingAgent._instance = None
+    return PackagingAgent.get_instance()
+
+
+_TOOL_TABLE = [
+    (
+        "analyze_conversion_components_tool",
+        _AnalyzeConversionComponentsTool,
+        _AnalyzeConversionComponentsInput,
+    ),
+    (
+        "create_package_structure_tool",
+        _CreatePackageStructureTool,
+        _CreatePackageStructureInput,
+    ),
+    ("generate_manifests_tool", _GenerateManifestsTool, _GenerateManifestsInput),
+    ("validate_package_tool", _ValidatePackageTool, _ValidatePackageInput),
+    ("build_mcaddon_tool", _BuildMcaddonTool, _BuildMcaddonInput),
+    (
+        "generate_enhanced_manifests_tool",
+        _GenerateEnhancedManifestsTool,
+        _GenerateEnhancedManifestsInput,
+    ),
+    (
+        "generate_blocks_and_items_tool",
+        _GenerateBlocksAndItemsTool,
+        _GenerateBlocksAndItemsInput,
+    ),
+    ("generate_entities_tool", _GenerateEntitiesTool, _GenerateEntitiesInput),
+    (
+        "package_enhanced_addon_tool",
+        _PackageEnhancedAddonTool,
+        _PackageEnhancedAddonInput,
+    ),
+    (
+        "validate_enhanced_addon_tool",
+        _ValidateEnhancedAddonTool,
+        _ValidateEnhancedAddonInput,
+    ),
+    (
+        "validate_mcaddon_structure_tool",
+        _ValidateMcaddonStructureTool,
+        _ValidateMcaddonStructureInput,
+    ),
+    (
+        "validate_manifest_schema_tool",
+        _ValidateManifestSchemaTool,
+        _ValidateManifestSchemaInput,
+    ),
+    (
+        "generate_validation_report_tool",
+        _GenerateValidationReportTool,
+        _GenerateValidationReportInput,
+    ),
+]
+
+
+class TestClassAttrIsTypedBaseTool:
+    @pytest.mark.parametrize("tool_attr,expected_class,expected_schema", _TOOL_TABLE)
+    def test_alias_is_basetool_subclass(self, tool_attr, expected_class, expected_schema):
+        tool_instance = getattr(PackagingAgent, tool_attr)
+        assert isinstance(tool_instance, BaseTool), tool_attr
+        assert isinstance(tool_instance, expected_class), tool_attr
+        assert tool_instance.args_schema is expected_schema, tool_attr
+        assert issubclass(tool_instance.args_schema, BaseModel), tool_attr
+        # Tool name mirrors the legacy @tool wrapper name.
+        assert tool_instance.name == tool_attr, tool_attr
+
+    def test_get_tools_returns_thirteen_typed_basetools(self, agent):
+        tools = agent.get_tools()
+        assert len(tools) == 13
+        assert all(isinstance(t, BaseTool) for t in tools)
+        assert all(t.args_schema is not None for t in tools)
+        names = [t.name for t in tools]
+        assert names == [name for name, *_ in _TOOL_TABLE]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Schema validation: empty strings rejected, extra fields rejected
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# Schemas with a min_length=1 string field.
+_MIN_LENGTH_SCHEMAS = [
+    (_AnalyzeConversionComponentsInput, "component_data"),
+    (_CreatePackageStructureInput, "structure_data"),
+    (_GenerateManifestsInput, "manifest_data"),
+    (_ValidatePackageInput, "validation_data"),
+    (_GenerateEnhancedManifestsInput, "mod_data"),
+    (_GenerateBlocksAndItemsInput, "conversion_data"),
+    (_GenerateEntitiesInput, "entity_data"),
+    (_PackageEnhancedAddonInput, "package_data"),
+    (_ValidateEnhancedAddonInput, "addon_path"),
+    (_ValidateMcaddonStructureInput, "mcaddon_path"),
+    (_ValidateManifestSchemaInput, "manifest_data"),
+    (_GenerateValidationReportInput, "mcaddon_path"),
+]
+
+# All schemas (including the Any-typed _BuildMcaddonInput).
+_ALL_SCHEMAS = _MIN_LENGTH_SCHEMAS + [(_BuildMcaddonInput, "build_data")]
+
+
+class TestSchemaValidation:
+    @pytest.mark.parametrize("schema_class,field_name", _MIN_LENGTH_SCHEMAS)
+    def test_min_length_rejects_empty_string(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: ""})
+
+    @pytest.mark.parametrize("schema_class,field_name", _ALL_SCHEMAS)
+    def test_extra_fields_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: "{}", "rogue": True})
+
+    @pytest.mark.parametrize("schema_class,field_name", _ALL_SCHEMAS)
+    def test_missing_required_field_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({})
+
+    def test_build_mcaddon_accepts_string(self):
+        # _BuildMcaddonInput preserves Any-typed build_data legacy shape.
+        schema = _BuildMcaddonInput.model_validate({"build_data": "{}"})
+        assert schema.build_data == "{}"
+
+    def test_build_mcaddon_accepts_dict(self):
+        schema = _BuildMcaddonInput.model_validate({"build_data": {"key": "value"}})
+        assert schema.build_data == {"key": "value"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# invoke() rejects bad shapes at the BaseTool layer (i.e. validation runs
+# before _run is called)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInvokeValidationGuards:
+    def test_invoke_with_empty_string_raises(self):
+        with pytest.raises(ValidationError):
+            PackagingAgent.analyze_conversion_components_tool.invoke({"component_data": ""})
+
+    def test_invoke_missing_field_raises(self):
+        with pytest.raises(ValidationError):
+            PackagingAgent.create_package_structure_tool.invoke({})
+
+    def test_invoke_extra_field_raises(self):
+        with pytest.raises(ValidationError):
+            PackagingAgent.generate_entities_tool.invoke({"entity_data": "{}", "rogue": True})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Drive-by guards: F401 cleanup + logger fix
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDriveByCleanups:
+    """Item 9 cleanup folded into A4b: F401 imports removed; logger fixed."""
+
+    def test_no_unused_imports_for_manifest_generator(self):
+        # ``ManifestGenerator`` was an F401 in the previous import.
+        # The module currently imports the alias ``_ManifestGenerator`` only.
+        import agents.packaging_agent as mod
+
+        assert not hasattr(mod, "ManifestGenerator"), (
+            "ManifestGenerator should not be re-exported from packaging_agent "
+            "after the A4b F401 cleanup"
+        )
+
+    def test_no_unused_imports_for_packaging_coordinator(self):
+        import agents.packaging_agent as mod
+
+        assert not hasattr(mod, "PackagingCoordinator"), (
+            "PackagingCoordinator should not be re-exported from "
+            "packaging_agent after the A4b F401 cleanup"
+        )
+
+    def test_logger_is_logger_instance_not_string(self):
+        # Pre-existing bug: ``logger = __name__`` produced a str, so the
+        # error-branch ``logger.error(...)`` calls would raise AttributeError.
+        # A4b fixes this by binding ``logger = logging.getLogger(__name__)``.
+        import logging
+
+        from agents.packaging_agent import logger
+
+        assert isinstance(logger, logging.Logger), (
+            f"logger should be a logging.Logger, got {type(logger).__name__}"
+        )
+        # And the logger-name matches the module — a sanity check.
+        assert logger.name == "agents.packaging_agent"


### PR DESCRIPTION
## What
Convert all 13 LangChain tools in `packaging_agent.py` from untyped `@tool` decorators to typed `BaseTool` subclasses with explicit `args_schema` Pydantic models. Folds in two drive-by cleanups (see below).

## Why
Part of the typed-args migration tracked in `.planning/notes/2026-05-14-followups.md`. Pydantic validation at the LangGraph dispatch boundary replaces hand-rolled JSON parsing in tool bodies; structured errors flow to both reviewers and LLM retry loops.

## Scope (disjoint from sibling A-slices)
- `ai-engine/agents/packaging_agent.py` — 13 typed tools
- `ai-engine/tests/unit/test_packaging_agent_typed.py` — new file, 60 tests

## Drive-by cleanups (folded in)
1. **Item 9 from followups**: removed F401 unused-import warnings on `ManifestGenerator` and `PackagingCoordinator` re-exports.
2. **Latent logger bug**: fixed `logger = __name__` → `logger = logging.getLogger(__name__)` (the previous form had a string assigned where a Logger was expected, producing AttributeError on first `.info()` call — never tripped because no test path exercised it).

## Verification
- 60 new typed-tool tests pass
- 28 baseline packaging tests unchanged → still pass

## Sibling PRs (parallel-safe — disjoint write scopes)
- A4a: typed bedrock_architect + bedrock_builder
- A5: typed recipe converter
- A6: typed java_analyzer/tools.py (last A-slice)