### PR TITLE
refactor(ai-engine): typed args_schema for recipe converter (A5)

### DIFF
--- a/ai-engine/agents/recipe/__init__.py
+++ b/ai-engine/agents/recipe/__init__.py
@@ -15,9 +15,10 @@ Public API re-exports RecipeConverterAgent to maintain backwards compatibility.
 
 import json
 import logging
-from typing import Dict, List
+from typing import ClassVar, Dict, List
 
-from langchain_core.tools import tool
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
 
 from agents.recipe.tag_resolver import (
     FORGE_TAG_MAPPINGS,
@@ -313,7 +314,9 @@ class RecipeConverterAgent:
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a shapeless recipe to Bedrock format."""
-        return self._shapeless_converter.convert_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._shapeless_converter.convert_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_smelting_to_bedrock(
         self,
@@ -331,67 +334,89 @@ class RecipeConverterAgent:
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a stonecutter recipe to Bedrock format."""
-        return self._furnace_converter.convert_stonecutter_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._furnace_converter.convert_stonecutter_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_smithing_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a smithing recipe to Bedrock format."""
-        return self._furnace_converter.convert_smithing_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._furnace_converter.convert_smithing_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_cooking_pot_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Farmer's Delight cooking pot recipe to Bedrock format."""
-        return self._custom_converter.convert_cooking_pot_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_cooking_pot_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_cutting_board_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Farmer's Delight cutting board recipe to Bedrock format."""
-        return self._custom_converter.convert_cutting_board_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_cutting_board_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_mechanical_crafting_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Create mechanical crafting recipe to Bedrock format."""
-        return self._custom_converter.convert_mechanical_crafting_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_mechanical_crafting_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_pressing_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Create pressing recipe to Bedrock format."""
-        return self._custom_converter.convert_pressing_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_pressing_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_milling_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Create milling recipe to Bedrock format."""
-        return self._custom_converter.convert_milling_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_milling_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_crushing_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Create crushing recipe to Bedrock format."""
-        return self._custom_converter.convert_crushing_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_crushing_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_deploying_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Create deploying recipe to Bedrock format."""
-        return self._custom_converter.convert_deploying_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_deploying_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_splashing_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Create splashing recipe to Bedrock format."""
-        return self._custom_converter.convert_splashing_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_splashing_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _convert_compacting_to_bedrock(
         self, normalized_recipe: Dict, namespace: str, recipe_name: str
     ) -> Dict:
         """Convert a Create compacting recipe to Bedrock format."""
-        return self._custom_converter.convert_compacting_to_bedrock(normalized_recipe, namespace, recipe_name)
+        return self._custom_converter.convert_compacting_to_bedrock(
+            normalized_recipe, namespace, recipe_name
+        )
 
     def _create_manual_review_result(self, namespace: str, recipe_name: str, reason: str) -> Dict:
         """Create a result indicating the recipe requires manual review."""
@@ -469,9 +494,8 @@ class RecipeConverterAgent:
         """Add a custom Java to Bedrock item mapping."""
         self.custom_mappings[java_item_id] = bedrock_item_id
 
-    @tool
     @staticmethod
-    def convert_recipe_tool(recipe_json: str) -> str:
+    def _convert_recipe(recipe_json: str) -> str:
         """Convert a Java recipe to Bedrock format."""
         try:
             input_data = json.loads(recipe_json)
@@ -493,9 +517,8 @@ class RecipeConverterAgent:
         except Exception as e:
             return json.dumps({"success": False, "error": str(e)}, indent=2)
 
-    @tool
     @staticmethod
-    def convert_recipes_batch_tool(recipes_json: str) -> str:
+    def _convert_recipes_batch(recipes_json: str) -> str:
         """Convert multiple Java recipes to Bedrock format in batch."""
         try:
             recipes = json.loads(recipes_json)
@@ -523,9 +546,8 @@ class RecipeConverterAgent:
         except Exception as e:
             return json.dumps({"success": False, "error": str(e)}, indent=2)
 
-    @tool
     @staticmethod
-    def map_item_id_tool(item_mapping_json: str) -> str:
+    def _map_item_id(item_mapping_json: str) -> str:
         """Add custom Java to Bedrock item ID mappings."""
         try:
             mappings = json.loads(item_mapping_json)
@@ -544,9 +566,8 @@ class RecipeConverterAgent:
         except Exception as e:
             return json.dumps({"success": False, "error": str(e)}, indent=2)
 
-    @tool
     @staticmethod
-    def validate_recipe_tool(recipe_json: str) -> str:
+    def _validate_recipe(recipe_json: str) -> str:
         """Validate a Bedrock recipe for correctness."""
         try:
             recipe = json.loads(recipe_json)
@@ -614,6 +635,140 @@ class RecipeConverterAgent:
 
         except Exception as e:
             return json.dumps({"valid": False, "issues": [str(e)]}, indent=2)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed args_schema models — one per LangChain tool wrapper
+#
+# Phase 8 A5 (refs #1201). Each schema preserves the legacy single-string
+# JSON shape so chat models and existing call sites continue to invoke
+# ``RecipeConverterAgent.<tool_name>.invoke({...})`` (or the legacy
+# ``.run(<json_string>)``) without changes. ``extra="forbid"`` makes
+# hallucinated extra fields fail loud at validation, and ``min_length=1``
+# rejects empty strings.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _ConvertRecipeInput(BaseModel):
+    """Args for :class:`_ConvertRecipeTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    recipe_json: str = Field(
+        min_length=1,
+        description=(
+            "JSON string describing a single Java recipe to convert. May contain "
+            "an optional ``recipe_data``, ``namespace``, and ``recipe_name``."
+        ),
+    )
+
+
+class _ConvertRecipesBatchInput(BaseModel):
+    """Args for :class:`_ConvertRecipesBatchTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    recipes_json: str = Field(
+        min_length=1,
+        description="JSON-encoded list of Java recipes to convert in a batch.",
+    )
+
+
+class _MapItemIdInput(BaseModel):
+    """Args for :class:`_MapItemIdTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    item_mapping_json: str = Field(
+        min_length=1,
+        description=(
+            "JSON-encoded list of {java, bedrock} mappings, or dict of "
+            "{java_id: bedrock_id} mappings, to register on the converter."
+        ),
+    )
+
+
+class _ValidateRecipeInput(BaseModel):
+    """Args for :class:`_ValidateRecipeTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    recipe_json: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock recipe to validate.",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed BaseTool subclasses — replace the previous @tool @staticmethod wrappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BaseRecipeTool(BaseTool):
+    """Common scaffolding for Recipe Converter typed tool wrappers."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _ConvertRecipeTool(_BaseRecipeTool):
+    name: str = "convert_recipe_tool"
+    description: str = (
+        "Convert a single Java recipe to Bedrock JSON. "
+        "Args: recipe_json (str, required) — JSON describing the Java recipe, "
+        "optionally wrapped in {recipe_data, namespace, recipe_name}."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ConvertRecipeInput
+
+    def _run(self, recipe_json: str) -> str:  # type: ignore[override]
+        return RecipeConverterAgent._convert_recipe(recipe_json)
+
+
+class _ConvertRecipesBatchTool(_BaseRecipeTool):
+    name: str = "convert_recipes_batch_tool"
+    description: str = (
+        "Convert a batch of Java recipes to Bedrock JSON. "
+        "Args: recipes_json (str, required) — JSON list of Java recipes."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ConvertRecipesBatchInput
+
+    def _run(self, recipes_json: str) -> str:  # type: ignore[override]
+        return RecipeConverterAgent._convert_recipes_batch(recipes_json)
+
+
+class _MapItemIdTool(_BaseRecipeTool):
+    name: str = "map_item_id_tool"
+    description: str = (
+        "Register custom Java→Bedrock item-ID mappings on the converter. "
+        "Args: item_mapping_json (str, required) — JSON list or dict of mappings."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _MapItemIdInput
+
+    def _run(self, item_mapping_json: str) -> str:  # type: ignore[override]
+        return RecipeConverterAgent._map_item_id(item_mapping_json)
+
+
+class _ValidateRecipeTool(_BaseRecipeTool):
+    name: str = "validate_recipe_tool"
+    description: str = (
+        "Validate a Bedrock recipe against expected structure. "
+        "Args: recipe_json (str, required) — JSON of the Bedrock recipe."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ValidateRecipeInput
+
+    def _run(self, recipe_json: str) -> str:  # type: ignore[override]
+        return RecipeConverterAgent._validate_recipe(recipe_json)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level tool instances — preserved as class attributes on
+# RecipeConverterAgent so the existing access patterns
+# (``RecipeConverterAgent.<tool_name>`` and ``agent.<tool_name>``) both
+# continue to work unchanged for call sites and tests, including the
+# legacy ``tool_func.run(<json_string>)`` shape exercised by
+# ``tests/test_recipe_converter.py``.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+RecipeConverterAgent.convert_recipe_tool = _ConvertRecipeTool()
+RecipeConverterAgent.convert_recipes_batch_tool = _ConvertRecipesBatchTool()
+RecipeConverterAgent.map_item_id_tool = _MapItemIdTool()
+RecipeConverterAgent.validate_recipe_tool = _ValidateRecipeTool()
 
 
 __all__ = [

--- a/ai-engine/agents/recipe_converter.py
+++ b/ai-engine/agents/recipe_converter.py
@@ -6,11 +6,7 @@ DEPRECATED: Use agents.recipe package instead.
 This module is kept for backwards compatibility.
 """
 
-import json
 import logging
-from typing import Dict, List
-
-from langchain_core.tools import tool
 
 from agents.recipe import (
     FORGE_TAG_MAPPINGS,

--- a/ai-engine/tests/unit/test_recipe_typed.py
+++ b/ai-engine/tests/unit/test_recipe_typed.py
@@ -1,0 +1,236 @@
+"""Tests for the typed BaseTool wrappers in agents/recipe/__init__.py.
+
+These wrappers replace the previous bare ``@tool @staticmethod`` decorators
+(Phase 8 A5, refs #1201). Each tool now exposes an explicit Pydantic
+``args_schema`` so chat models with native tool-calling can invoke it with
+validated arguments rather than an opaque single string.
+
+Pattern matches PR #1453 (qa typed args) and the A4a/A4b refactors. The
+legacy single-string ``recipe_json`` / ``recipes_json`` /
+``item_mapping_json`` / ``recipe_json`` shape is preserved end-to-end so
+existing call sites and the existing coverage suites
+(``tests/test_recipe_converter.py`` and
+``tests/unit/test_recipe_converter.py``) pass unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ValidationError
+
+from agents.recipe import (
+    RecipeConverterAgent,
+    _ConvertRecipeInput,
+    _ConvertRecipesBatchInput,
+    _ConvertRecipesBatchTool,
+    _ConvertRecipeTool,
+    _MapItemIdInput,
+    _MapItemIdTool,
+    _ValidateRecipeInput,
+    _ValidateRecipeTool,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Identity & schema
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def agent():
+    """Reset the singleton so each test gets a fresh agent."""
+    RecipeConverterAgent._instance = None
+    return RecipeConverterAgent.get_instance()
+
+
+_TOOL_TABLE = [
+    ("convert_recipe_tool", _ConvertRecipeTool, _ConvertRecipeInput),
+    ("convert_recipes_batch_tool", _ConvertRecipesBatchTool, _ConvertRecipesBatchInput),
+    ("map_item_id_tool", _MapItemIdTool, _MapItemIdInput),
+    ("validate_recipe_tool", _ValidateRecipeTool, _ValidateRecipeInput),
+]
+
+
+class TestClassAttrIsTypedBaseTool:
+    @pytest.mark.parametrize("tool_attr,expected_class,expected_schema", _TOOL_TABLE)
+    def test_alias_is_basetool_subclass(self, tool_attr, expected_class, expected_schema):
+        tool_instance = getattr(RecipeConverterAgent, tool_attr)
+        assert isinstance(tool_instance, BaseTool), tool_attr
+        assert isinstance(tool_instance, expected_class), tool_attr
+        assert tool_instance.args_schema is expected_schema, tool_attr
+        assert issubclass(tool_instance.args_schema, BaseModel), tool_attr
+        assert tool_instance.name == tool_attr, tool_attr
+
+    def test_get_tools_returns_four_typed_basetools(self, agent):
+        tools = agent.get_tools()
+        assert len(tools) == 4
+        assert all(isinstance(t, BaseTool) for t in tools)
+        assert all(t.args_schema is not None for t in tools)
+        names = [t.name for t in tools]
+        assert names == [name for name, *_ in _TOOL_TABLE]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Schema validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_FIELD_TABLE = [
+    (_ConvertRecipeInput, "recipe_json"),
+    (_ConvertRecipesBatchInput, "recipes_json"),
+    (_MapItemIdInput, "item_mapping_json"),
+    (_ValidateRecipeInput, "recipe_json"),
+]
+
+
+class TestSchemaValidation:
+    @pytest.mark.parametrize("schema_class,field_name", _FIELD_TABLE)
+    def test_min_length_rejects_empty_string(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: ""})
+
+    @pytest.mark.parametrize("schema_class,field_name", _FIELD_TABLE)
+    def test_extra_fields_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: "{}", "rogue": True})
+
+    @pytest.mark.parametrize("schema_class,field_name", _FIELD_TABLE)
+    def test_missing_required_field_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# invoke() validation guards
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInvokeValidationGuards:
+    def test_invoke_with_empty_string_raises(self):
+        with pytest.raises(ValidationError):
+            RecipeConverterAgent.convert_recipe_tool.invoke({"recipe_json": ""})
+
+    def test_invoke_missing_field_raises(self):
+        with pytest.raises(ValidationError):
+            RecipeConverterAgent.validate_recipe_tool.invoke({})
+
+    def test_invoke_extra_field_raises(self):
+        with pytest.raises(ValidationError):
+            RecipeConverterAgent.map_item_id_tool.invoke({"item_mapping_json": "{}", "rogue": True})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# invoke() round-trip smoke tests — both the new `.invoke({...})` shape AND
+# the legacy `.run(<json_string>)` single-input shape exercised by
+# ``tests/test_recipe_converter.py`` continue to work.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInvokeRoundtrips:
+    def test_validate_recipe_tool_invoke_shape(self):
+        valid_recipe = {
+            "format_version": "1.20.10",
+            "minecraft:recipe_shaped": {
+                "description": {"identifier": "test:r1"},
+                "pattern": ["X"],
+                "key": {"X": {"item": "minecraft:stone"}},
+                "result": {"item": "minecraft:stone", "count": 1},
+            },
+        }
+        out = json.loads(
+            RecipeConverterAgent.validate_recipe_tool.invoke(
+                {"recipe_json": json.dumps(valid_recipe)}
+            )
+        )
+        assert out["valid"] is True
+
+    def test_validate_recipe_tool_legacy_run_single_input_shape(self):
+        # Legacy single-input ``.run(<json_string>)`` shape used by
+        # ``tests/test_recipe_converter.py``. LangChain BaseTool.run() with
+        # a single-field args_schema accepts a positional string.
+        valid_recipe = {
+            "format_version": "1.20.10",
+            "minecraft:recipe_shaped": {
+                "description": {"identifier": "test:r2"},
+                "pattern": ["X"],
+                "key": {"X": {"item": "minecraft:stone"}},
+                "result": {"item": "minecraft:stone", "count": 1},
+            },
+        }
+        out = json.loads(RecipeConverterAgent.validate_recipe_tool.run(json.dumps(valid_recipe)))
+        assert out["valid"] is True
+
+    def test_convert_recipes_batch_invoke(self):
+        recipes = [
+            {
+                "recipe_data": {
+                    "type": "minecraft:crafting_shaped",
+                    "pattern": ["X"],
+                    "key": {"X": {"item": "minecraft:stone"}},
+                    "result": {"item": "minecraft:stone"},
+                },
+                "namespace": "test_mod",
+            }
+        ]
+        out = json.loads(
+            RecipeConverterAgent.convert_recipes_batch_tool.invoke(
+                {"recipes_json": json.dumps(recipes)}
+            )
+        )
+        assert out["success"] is True
+        assert out["total_count"] == 1
+
+    def test_map_item_id_invoke_with_list(self):
+        mappings = [{"java": "minecraft:test", "bedrock": "minecraft:test_bedrock"}]
+        out = json.loads(
+            RecipeConverterAgent.map_item_id_tool.invoke(
+                {"item_mapping_json": json.dumps(mappings)}
+            )
+        )
+        assert out["success"] is True
+        # And confirm the mapping landed on the agent.
+        assert (
+            RecipeConverterAgent.get_instance().custom_mappings.get("minecraft:test")
+            == "minecraft:test_bedrock"
+        )
+
+    def test_convert_recipe_with_invalid_json_returns_error(self):
+        out = json.loads(
+            RecipeConverterAgent.convert_recipe_tool.invoke({"recipe_json": "not json"})
+        )
+        assert out["success"] is False
+        assert "error" in out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Drive-by: recipe_converter.py shim no longer F401-imports ``tool``
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRecipeConverterShimCleanup:
+    def test_shim_no_longer_reexports_tool(self):
+        # The deprecated shim ``agents.recipe_converter`` previously
+        # imported ``tool`` from langchain_core.tools but never used it
+        # (an F401 leftover from the pre-extraction refactor). The shim
+        # now imports only what it re-exports.
+        import agents.recipe_converter as shim
+
+        assert not hasattr(shim, "tool"), (
+            "agents.recipe_converter shim should no longer re-export `tool`"
+        )
+
+    def test_shim_still_reexports_public_api(self):
+        from agents.recipe_converter import (
+            CUSTOM_RECIPE_TYPES,
+            FORGE_TAG_MAPPINGS,
+            JAVA_TO_BEDROCK_ITEM_MAP,
+            RecipeConverterAgent as ShimRecipeConverterAgent,
+        )
+
+        assert ShimRecipeConverterAgent is RecipeConverterAgent
+        assert isinstance(FORGE_TAG_MAPPINGS, dict)
+        assert isinstance(JAVA_TO_BEDROCK_ITEM_MAP, dict)
+        assert CUSTOM_RECIPE_TYPES is not None


### PR DESCRIPTION
## What
Convert all 4 LangChain tools in `agents/recipe/__init__.py` from untyped `@tool` decorators to typed `BaseTool` subclasses with explicit `args_schema` Pydantic models. Drive-by F401 cleanup in the `recipe_converter.py` shim re-export.

## Why
Part of the typed-args migration tracked in `.planning/notes/2026-05-14-followups.md`.

## Scope (disjoint from sibling A-slices)
- `ai-engine/agents/recipe/__init__.py` — 4 typed tools
- `ai-engine/agents/recipe_converter.py` — F401 cleanup on shim re-exports
- `ai-engine/tests/unit/test_recipe_typed.py` — new file, 27 tests

## Backward compatibility
The legacy `tool_func.run(<json_string>)` invocation shape used by `tests/test_recipe_converter.py` continues to work — typed tools still expose `.run()` accepting a JSON string in addition to the new `.invoke({...})` dict shape.

## Verification
- 27 new typed-tool tests pass
- 94 baseline recipe tests unchanged → still pass

## Sibling PRs (parallel-safe — disjoint write scopes)
- A4a: typed bedrock_architect + bedrock_builder
- A4b: typed packaging_agent
- A6: typed java_analyzer/tools.py (last A-slice)