### PR TITLE
refactor(ai-engine): typed args_schema for java_analyzer tools (A6 — last A-slice)

### DIFF
--- a/ai-engine/agents/java_analyzer/tools.py
+++ b/ai-engine/agents/java_analyzer/tools.py
@@ -6,9 +6,10 @@ import json
 import os
 import zipfile
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Any, ClassVar, Dict, List, Union
 
-from langchain_core.tools import tool
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
 
 from utils.logging_config import get_agent_logger
 
@@ -21,9 +22,8 @@ class JavaAnalyzerTools:
     def __init__(self, agent_instance=None):
         self.agent_instance = agent_instance
 
-    @tool
     @staticmethod
-    def analyze_mod_structure_tool(mod_data: Union[str, Dict]) -> str:
+    def _analyze_mod_structure(mod_data: Union[str, Dict]) -> str:
         """
         Analyze the overall structure of a Java mod.
 
@@ -345,9 +345,8 @@ class JavaAnalyzerTools:
             logger.error(f"Mod structure analysis error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def extract_mod_metadata_tool(mod_data: Union[str, Dict]) -> str:
+    def _extract_mod_metadata(mod_data: Union[str, Dict]) -> str:
         """
         Extract metadata from mod files.
 
@@ -452,9 +451,8 @@ class JavaAnalyzerTools:
             logger.error(f"Metadata extraction error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def identify_features_tool(mod_data: Union[str, Dict]) -> str:
+    def _identify_features(mod_data: Union[str, Dict]) -> str:
         """
         Identify features in the mod.
 
@@ -571,9 +569,8 @@ class JavaAnalyzerTools:
             logger.error(f"Feature identification error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def analyze_dependencies_tool(mod_data: Union[str, Dict]) -> str:
+    def _analyze_dependencies(mod_data: Union[str, Dict]) -> str:
         """
         Analyze mod dependencies.
 
@@ -633,9 +630,8 @@ class JavaAnalyzerTools:
             logger.error(f"Dependency analysis error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def extract_assets_tool(mod_data: Union[str, Dict]) -> str:
+    def _extract_assets(mod_data: Union[str, Dict]) -> str:
         """
         Extract assets from the mod.
 
@@ -772,9 +768,8 @@ class JavaAnalyzerTools:
             logger.error(f"Asset extraction error: {e}")
             return json.dumps(error_response)
 
-    @tool
     @staticmethod
-    def analyze_complexity_with_llm_tool(analysis_data: str) -> str:
+    def _analyze_complexity_with_llm(analysis_data: str) -> str:
         """
         Use LLM to analyze Java mod complexity and identify Bedrock-incompatible patterns.
 
@@ -837,3 +832,188 @@ class JavaAnalyzerTools:
             error_response = {"success": False, "error": f"LLM analysis failed: {str(e)}"}
             logger.error(f"LLM complexity analysis error: {e}")
             return json.dumps(error_response)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed args_schema models — one per LangChain tool wrapper
+#
+# Phase 8 A6 (refs #1201). Each schema preserves the legacy single-arg
+# ``mod_data: Union[str, Dict]`` (or ``analysis_data: str``) shape so chat
+# models and existing call sites continue to invoke
+# ``JavaAnalyzerAgent.<tool_name>.invoke({...})`` without changes. Five of
+# the six tools accept either a JSON string or a dict, mirroring the
+# legacy ``Union[str, Dict]`` typing on the static methods. The sixth
+# (``analyze_complexity_with_llm_tool``) requires a JSON string only.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _AnalyzeModStructureInput(BaseModel):
+    """Args for :class:`_AnalyzeModStructureTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mod_data: Any = Field(
+        description=(
+            "JSON string or dict containing ``mod_path`` and analysis options. "
+            "``Any`` preserves the legacy ``Union[str, Dict]`` calling shape."
+        ),
+    )
+
+
+class _ExtractModMetadataInput(BaseModel):
+    """Args for :class:`_ExtractModMetadataTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mod_data: Any = Field(
+        description="JSON string or dict containing ``mod_path``.",
+    )
+
+
+class _IdentifyFeaturesInput(BaseModel):
+    """Args for :class:`_IdentifyFeaturesTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mod_data: Any = Field(
+        description="JSON string or dict containing ``mod_path`` and feature options.",
+    )
+
+
+class _AnalyzeDependenciesInput(BaseModel):
+    """Args for :class:`_AnalyzeDependenciesTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mod_data: Any = Field(
+        description=(
+            "JSON string or dict containing ``mod_path`` and an optional "
+            "``metadata.dependencies`` list."
+        ),
+    )
+
+
+class _ExtractAssetsInput(BaseModel):
+    """Args for :class:`_ExtractAssetsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    mod_data: Any = Field(
+        description=(
+            "JSON string or dict containing ``mod_path``, ``output_dir``, and "
+            "optional ``asset_types`` filter."
+        ),
+    )
+
+
+class _AnalyzeComplexityWithLlmInput(BaseModel):
+    """Args for :class:`_AnalyzeComplexityWithLlmTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    analysis_data: str = Field(
+        min_length=1,
+        description=(
+            "JSON string with the prior analysis output to be reasoned about "
+            "by the LLM-augmented complexity analyzer."
+        ),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed BaseTool subclasses — replace the previous @tool @staticmethod wrappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BaseJavaAnalyzerTool(BaseTool):
+    """Common scaffolding for Java Analyzer typed tool wrappers."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _AnalyzeModStructureTool(_BaseJavaAnalyzerTool):
+    name: str = "analyze_mod_structure_tool"
+    description: str = (
+        "Analyze the overall structure of a Java mod (mod type, framework, "
+        "file inventory, complexity assessment). "
+        "Args: mod_data (str or dict, required) — mod_path and options."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _AnalyzeModStructureInput
+
+    def _run(self, mod_data: Any) -> str:  # type: ignore[override]
+        return JavaAnalyzerTools._analyze_mod_structure(mod_data)
+
+
+class _ExtractModMetadataTool(_BaseJavaAnalyzerTool):
+    name: str = "extract_mod_metadata_tool"
+    description: str = (
+        "Extract metadata from a Java mod's manifest "
+        "(fabric.mod.json, mods.toml, mcmod.info). "
+        "Args: mod_data (str or dict, required) — mod_path."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ExtractModMetadataInput
+
+    def _run(self, mod_data: Any) -> str:  # type: ignore[override]
+        return JavaAnalyzerTools._extract_mod_metadata(mod_data)
+
+
+class _IdentifyFeaturesTool(_BaseJavaAnalyzerTool):
+    name: str = "identify_features_tool"
+    description: str = (
+        "Identify mod features (blocks, items, entities, recipes, events) "
+        "from source/jar inspection. "
+        "Args: mod_data (str or dict, required) — mod_path and options."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _IdentifyFeaturesInput
+
+    def _run(self, mod_data: Any) -> str:  # type: ignore[override]
+        return JavaAnalyzerTools._identify_features(mod_data)
+
+
+class _AnalyzeDependenciesTool(_BaseJavaAnalyzerTool):
+    name: str = "analyze_dependencies_tool"
+    description: str = (
+        "Analyze a mod's declared and detected dependencies, including "
+        "Bedrock-portability assessment. "
+        "Args: mod_data (str or dict, required) — mod_path + optional metadata."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _AnalyzeDependenciesInput
+
+    def _run(self, mod_data: Any) -> str:  # type: ignore[override]
+        return JavaAnalyzerTools._analyze_dependencies(mod_data)
+
+
+class _ExtractAssetsTool(_BaseJavaAnalyzerTool):
+    name: str = "extract_assets_tool"
+    description: str = (
+        "Extract assets (textures, models, sounds) from a Java mod. "
+        "Args: mod_data (str or dict, required) — mod_path, output_dir, "
+        "optional asset_types filter."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ExtractAssetsInput
+
+    def _run(self, mod_data: Any) -> str:  # type: ignore[override]
+        return JavaAnalyzerTools._extract_assets(mod_data)
+
+
+class _AnalyzeComplexityWithLlmTool(_BaseJavaAnalyzerTool):
+    name: str = "analyze_complexity_with_llm_tool"
+    description: str = (
+        "Use the LLM to reason about an analysis's complexity. "
+        "Args: analysis_data (str, required) — JSON of prior analysis."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _AnalyzeComplexityWithLlmInput
+
+    def _run(self, analysis_data: str) -> str:  # type: ignore[override]
+        return JavaAnalyzerTools._analyze_complexity_with_llm(analysis_data)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level tool instances — preserved as class attributes on
+# JavaAnalyzerTools so the ``JavaAnalyzerAgent`` class-attribute aliases in
+# ``agents/java_analyzer/java_analyzer.py``
+# (``extract_mod_metadata_tool = JavaAnalyzerTools.extract_mod_metadata_tool``)
+# resolve to the new typed BaseTool instances at import time.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+JavaAnalyzerTools.analyze_mod_structure_tool = _AnalyzeModStructureTool()
+JavaAnalyzerTools.extract_mod_metadata_tool = _ExtractModMetadataTool()
+JavaAnalyzerTools.identify_features_tool = _IdentifyFeaturesTool()
+JavaAnalyzerTools.analyze_dependencies_tool = _AnalyzeDependenciesTool()
+JavaAnalyzerTools.extract_assets_tool = _ExtractAssetsTool()
+JavaAnalyzerTools.analyze_complexity_with_llm_tool = _AnalyzeComplexityWithLlmTool()

--- a/ai-engine/tests/test_agents_unit.py
+++ b/ai-engine/tests/test_agents_unit.py
@@ -144,9 +144,9 @@ class TestJavaAnalyzerAgent:
 
     def test_analyze_mod_structure_tool(self, agent, mock_jar_path):
         """Test the analyze_mod_structure_tool"""
-        # Tools are LangChain `@tool`-decorated callables, invoke via .invoke or .func
+        # Tools are typed BaseTool subclasses (post-A6); invoke via .invoke({...}).
         tool = agent.analyze_mod_structure_tool
-        result = tool.func(str(mock_jar_path))
+        result = tool.invoke({"mod_data": str(mock_jar_path)})
         result_data = json.loads(result)
 
         assert result_data.get("success")
@@ -154,9 +154,9 @@ class TestJavaAnalyzerAgent:
 
     def test_extract_assets_tool(self, agent, mock_jar_path):
         """Test the extract_assets_tool"""
-        # Tools are LangChain `@tool`-decorated callables, invoke via .invoke or .func
+        # Tools are typed BaseTool subclasses (post-A6); invoke via .invoke({...}).
         tool = agent.extract_assets_tool
-        result = tool.func(str(mock_jar_path))
+        result = tool.invoke({"mod_data": str(mock_jar_path)})
         result_data = json.loads(result)
 
         assert result_data.get("success")

--- a/ai-engine/tests/test_java_analyzer_coverage.py
+++ b/ai-engine/tests/test_java_analyzer_coverage.py
@@ -24,7 +24,9 @@ class TestJavaAnalyzerCoverage:
     def test_get_tools(self, analyzer):
         tools = analyzer.get_tools()
         assert len(tools) > 0
-        assert any("analyze_mod_structure_tool" in str(t) for t in tools)
+        # Typed BaseTool subclasses set name explicitly; str() yields a Pydantic
+        # repr that does not contain the snake_case name.
+        assert any(t.name == "analyze_mod_structure_tool" for t in tools)
 
     def test_get_file_size(self, analyzer):
         with tempfile.NamedTemporaryFile() as tmp:

--- a/ai-engine/tests/unit/test_java_analyzer_comprehensive.py
+++ b/ai-engine/tests/unit/test_java_analyzer_comprehensive.py
@@ -1,9 +1,7 @@
 import pytest
 import json
-import os
 import zipfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import patch
 from agents.java_analyzer import JavaAnalyzerAgent
 
 
@@ -24,7 +22,7 @@ class TestJavaAnalyzerAgentComprehensive:
         jar_data = json.dumps({"mod_path": str(jar_path)})
 
         # We need to bypass the Tool wrapper
-        result_json = agent.extract_mod_metadata_tool.func(jar_data)
+        result_json = agent.extract_mod_metadata_tool.invoke({"mod_data": jar_data})
         result = json.loads(result_json)
 
         assert result["success"] is True
@@ -40,7 +38,7 @@ class TestJavaAnalyzerAgentComprehensive:
 
         source_data = json.dumps({"mod_path": str(source_path)})
 
-        result_json = agent.extract_mod_metadata_tool.func(source_data)
+        result_json = agent.extract_mod_metadata_tool.invoke({"mod_data": source_data})
         result = json.loads(result_json)
 
         assert result["success"] is True
@@ -56,7 +54,7 @@ class TestJavaAnalyzerAgentComprehensive:
 
         mod_data = json.dumps({"mod_path": str(jar_path)})
 
-        result_json = agent.identify_features_tool.func(mod_data)
+        result_json = agent.identify_features_tool.invoke({"mod_data": mod_data})
         result = json.loads(result_json)
 
         assert result["success"] is True
@@ -72,7 +70,7 @@ class TestJavaAnalyzerAgentComprehensive:
         )
 
         with patch("agents.java_analyzer.Path.exists", return_value=True):
-            result_json = agent.analyze_dependencies_tool.func(mod_data)
+            result_json = agent.analyze_dependencies_tool.invoke({"mod_data": mod_data})
             result = json.loads(result_json)
 
             assert result["success"] is True
@@ -87,7 +85,7 @@ class TestJavaAnalyzerAgentComprehensive:
         output_dir = tmp_path / "extracted"
         mod_data = json.dumps({"mod_path": str(jar_path), "output_dir": str(output_dir)})
 
-        result_json = agent.extract_assets_tool.func(mod_data)
+        result_json = agent.extract_assets_tool.invoke({"mod_data": mod_data})
         result = json.loads(result_json)
 
         assert result["success"] is True

--- a/ai-engine/tests/unit/test_java_analyzer_tools_typed.py
+++ b/ai-engine/tests/unit/test_java_analyzer_tools_typed.py
@@ -1,0 +1,201 @@
+"""Tests for the typed BaseTool wrappers in agents/java_analyzer/tools.py.
+
+These wrappers replace the previous bare ``@tool @staticmethod`` decorators
+(Phase 8 A6 — last A-slice, refs #1201). Each tool now exposes an explicit
+Pydantic ``args_schema`` so chat models with native tool-calling can invoke
+it with validated arguments rather than an opaque single string-or-dict.
+
+Pattern matches PR #1453 (qa typed args), the A4a/A4b/A5 refactors, and is
+the final A-slice required before the E (skeleton-regen) follow-up can
+land.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ValidationError
+
+from agents.java_analyzer import JavaAnalyzerAgent
+from agents.java_analyzer.tools import (
+    JavaAnalyzerTools,
+    _AnalyzeComplexityWithLlmInput,
+    _AnalyzeComplexityWithLlmTool,
+    _AnalyzeDependenciesInput,
+    _AnalyzeDependenciesTool,
+    _AnalyzeModStructureInput,
+    _AnalyzeModStructureTool,
+    _ExtractAssetsInput,
+    _ExtractAssetsTool,
+    _ExtractModMetadataInput,
+    _ExtractModMetadataTool,
+    _IdentifyFeaturesInput,
+    _IdentifyFeaturesTool,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Identity & schema
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def agent():
+    """Reset the singleton so each test gets a fresh agent."""
+    JavaAnalyzerAgent._instance = None
+    return JavaAnalyzerAgent.get_instance()
+
+
+_TOOL_TABLE = [
+    ("analyze_mod_structure_tool", _AnalyzeModStructureTool, _AnalyzeModStructureInput),
+    ("extract_mod_metadata_tool", _ExtractModMetadataTool, _ExtractModMetadataInput),
+    ("identify_features_tool", _IdentifyFeaturesTool, _IdentifyFeaturesInput),
+    ("analyze_dependencies_tool", _AnalyzeDependenciesTool, _AnalyzeDependenciesInput),
+    ("extract_assets_tool", _ExtractAssetsTool, _ExtractAssetsInput),
+    (
+        "analyze_complexity_with_llm_tool",
+        _AnalyzeComplexityWithLlmTool,
+        _AnalyzeComplexityWithLlmInput,
+    ),
+]
+
+
+class TestClassAttrIsTypedBaseTool:
+    @pytest.mark.parametrize("tool_attr,expected_class,expected_schema", _TOOL_TABLE)
+    def test_alias_on_tools_namespace(self, tool_attr, expected_class, expected_schema):
+        # Bound on JavaAnalyzerTools (the tool-module class).
+        tool_instance = getattr(JavaAnalyzerTools, tool_attr)
+        assert isinstance(tool_instance, BaseTool), tool_attr
+        assert isinstance(tool_instance, expected_class), tool_attr
+        assert tool_instance.args_schema is expected_schema, tool_attr
+        assert issubclass(tool_instance.args_schema, BaseModel), tool_attr
+        assert tool_instance.name == tool_attr, tool_attr
+
+    @pytest.mark.parametrize("tool_attr,expected_class,_schema", _TOOL_TABLE)
+    def test_alias_on_agent_namespace(self, tool_attr, expected_class, _schema):
+        # JavaAnalyzerAgent re-exposes them via class attributes that
+        # reference JavaAnalyzerTools.<name>_tool at class-body time.
+        # Identity must hold so .invoke({...}) on either alias hits the
+        # same singleton.
+        agent_attr = getattr(JavaAnalyzerAgent, tool_attr)
+        tools_attr = getattr(JavaAnalyzerTools, tool_attr)
+        assert agent_attr is tools_attr, tool_attr
+        assert isinstance(agent_attr, expected_class), tool_attr
+
+    def test_get_tools_returns_six_typed_basetools(self, agent):
+        tools = agent.get_tools()
+        assert len(tools) == 6
+        assert all(isinstance(t, BaseTool) for t in tools)
+        assert all(t.args_schema is not None for t in tools)
+        names = [t.name for t in tools]
+        assert names == [name for name, *_ in _TOOL_TABLE]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Schema validation
+#
+# Five of the six tools accept Any (Union[str, Dict] in the legacy shape) for
+# their mod_data field, so empty-string rejection is only meaningful on
+# _AnalyzeComplexityWithLlmInput.analysis_data.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_ALL_FIELD_TABLE = [
+    (_AnalyzeModStructureInput, "mod_data"),
+    (_ExtractModMetadataInput, "mod_data"),
+    (_IdentifyFeaturesInput, "mod_data"),
+    (_AnalyzeDependenciesInput, "mod_data"),
+    (_ExtractAssetsInput, "mod_data"),
+    (_AnalyzeComplexityWithLlmInput, "analysis_data"),
+]
+
+
+class TestSchemaValidation:
+    def test_min_length_rejects_empty_string_on_llm_tool(self):
+        with pytest.raises(ValidationError):
+            _AnalyzeComplexityWithLlmInput.model_validate({"analysis_data": ""})
+
+    @pytest.mark.parametrize("schema_class,field_name", _ALL_FIELD_TABLE)
+    def test_extra_fields_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({field_name: "{}", "rogue": True})
+
+    @pytest.mark.parametrize("schema_class,field_name", _ALL_FIELD_TABLE)
+    def test_missing_required_field_rejected(self, schema_class, field_name):
+        with pytest.raises(ValidationError):
+            schema_class.model_validate({})
+
+    @pytest.mark.parametrize(
+        "schema_class",
+        [
+            _AnalyzeModStructureInput,
+            _ExtractModMetadataInput,
+            _IdentifyFeaturesInput,
+            _AnalyzeDependenciesInput,
+            _ExtractAssetsInput,
+        ],
+    )
+    def test_mod_data_accepts_string_or_dict(self, schema_class):
+        # Legacy Union[str, Dict] shape preserved via Any-typed field.
+        s = schema_class.model_validate({"mod_data": '{"mod_path": "x"}'})
+        assert s.mod_data == '{"mod_path": "x"}'
+        d = schema_class.model_validate({"mod_data": {"mod_path": "x"}})
+        assert d.mod_data == {"mod_path": "x"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# invoke() validation guards (validation runs before _run is called)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInvokeValidationGuards:
+    def test_invoke_with_empty_string_on_llm_tool_raises(self):
+        with pytest.raises(ValidationError):
+            JavaAnalyzerAgent.analyze_complexity_with_llm_tool.invoke({"analysis_data": ""})
+
+    def test_invoke_missing_field_raises(self):
+        with pytest.raises(ValidationError):
+            JavaAnalyzerAgent.extract_mod_metadata_tool.invoke({})
+
+    def test_invoke_extra_field_raises(self):
+        with pytest.raises(ValidationError):
+            JavaAnalyzerAgent.analyze_dependencies_tool.invoke({"mod_data": "{}", "rogue": True})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Round-trip smoke: nonexistent mod_path → impl returns a structured error
+# but does not raise. Exercises every tool's .invoke({...}) shape so the
+# BaseTool→args_schema→_run→staticmethod plumbing is end-to-end verified
+# without paying the cost of building a real fixture jar (the existing
+# test_java_analyzer_comprehensive.py does that for 5 of 6 tools).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInvokeRoundtripsWithNonexistentPath:
+    """Nonexistent mod_path returns a structured-error JSON, no exception."""
+
+    @pytest.mark.parametrize(
+        "tool_attr",
+        [
+            "analyze_mod_structure_tool",
+            "extract_mod_metadata_tool",
+            "identify_features_tool",
+            "analyze_dependencies_tool",
+            "extract_assets_tool",
+        ],
+    )
+    def test_invoke_with_nonexistent_path(self, tool_attr):
+        import json
+
+        tool_instance = getattr(JavaAnalyzerAgent, tool_attr)
+        out = tool_instance.invoke(
+            {"mod_data": json.dumps({"mod_path": "/nonexistent/path/to/mod.jar"})}
+        )
+        # Must return a JSON string, never raise.
+        parsed = json.loads(out)
+        # Every impl returns either {"success": True, ...} or
+        # {"success": False, "error": "..."} — pick whichever the impl chose.
+        assert isinstance(parsed, dict), tool_attr
+        # Sanity: the tool didn't get a half-applied schema (extract_assets,
+        # for instance, might still report structure even on nonexistent path).
+        assert "success" in parsed or "error" in parsed, tool_attr


### PR DESCRIPTION
## What
Convert all 6 LangChain tools in `agents/java_analyzer/tools.py` from untyped `@tool` decorators to typed `BaseTool` subclasses with explicit `args_schema` Pydantic models. **This is the last A-slice in the typed-args migration.**

## Why
Part of the typed-args migration tracked in `.planning/notes/2026-05-14-followups.md`. Completes the conversion across all six agent families: search (A1), logic_translator (A2), steering (A2.5), qa (A3), bedrock (A4a), packaging (A4b), recipe (A5), java_analyzer (A6).

## Scope (disjoint from sibling A-slices)
- `ai-engine/agents/java_analyzer/tools.py` — 6 typed tools
- `ai-engine/tests/unit/test_java_analyzer_tools_typed.py` — new file, 39 tests
- `ai-engine/tests/unit/test_java_analyzer_comprehensive.py` — 5 tests updated from `.func(<str>)` to `.invoke({\"mod_data\": <str>})` shape; 4 pre-existing F401s cleaned up as drive-by

## Verification
- 39 new typed-tool tests pass
- 5 updated baseline tests pass under new invocation shape

## Follow-up
After this lands, the **E** PR will re-run `scripts/portkit_skeletonize.py` to refresh `ai-engine/SKELETON.md` with the full typed surface across A4a–A6 in one canonical commit.

## Sibling PRs (parallel-safe — disjoint write scopes)
- A4a: typed bedrock_architect + bedrock_builder
- A4b: typed packaging_agent
- A5: typed recipe converter