### PR TITLE
chore(ai-engine): clean up pre-existing ruff warnings (Item 9)

### DIFF
--- a/ai-engine/agents/fewshot_enhancer_agent.py
+++ b/ai-engine/agents/fewshot_enhancer_agent.py
@@ -11,7 +11,6 @@ Usage:
     result = agent.enhance(java_source="public class MyMod {}", instruction="Custom sword mod")
 """
 
-import logging
 import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional

--- a/ai-engine/tests/test_agent_orchestration_comprehensive.py
+++ b/ai-engine/tests/test_agent_orchestration_comprehensive.py
@@ -4,10 +4,8 @@ Tests RAG pipelines, agent coordination, and end-to-end conversions.
 """
 
 import pytest
-import json
 import asyncio
-from unittest.mock import Mock, AsyncMock, patch, MagicMock, call
-from typing import Dict, List, Any, Optional
+from unittest.mock import AsyncMock
 
 # Set up imports
 try:
@@ -293,10 +291,10 @@ class TestAgentErrorHandling:
     async def test_agent_timeout_handling(self, mock_java_analyzer):
         """Test handling agent timeout."""
         mock_java_analyzer.analyze_jar = AsyncMock(
-            side_effect=asyncio.TimeoutError("Analysis timed out")
+            side_effect=TimeoutError("Analysis timed out")
         )
         
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(TimeoutError):
             await asyncio.wait_for(
                 mock_java_analyzer.analyze_jar("/tmp/test.jar"),
                 timeout=0.1
@@ -522,7 +520,7 @@ class TestAgentMonitoring:
             execution_log.append({"agent": "analyzer", "status": "completed"})
             return result
         
-        result = await tracked_analyze("/tmp/test.jar")
+        await tracked_analyze("/tmp/test.jar")
         
         assert len(execution_log) == 2
         assert execution_log[0]["status"] == "started"


### PR DESCRIPTION
## What
Resolves the remaining piece of **Item 9** from `.planning/notes/2026-05-14-followups.md`. The packaging_agent.py F401s mentioned in the same item already landed via PR #1456 (A4b).

## Changes

**`agents/fewshot_enhancer_agent.py`** (1 fix, CI-visible):
- F401: removed unused `import logging` (the file uses `get_agent_logger` from `utils.logging_config`, never `logging` directly)

**`tests/test_agent_orchestration_comprehensive.py`** (11 fixes, repo-local clarity only — see CI note below):
- F401 ×9: removed unused `json`, `Mock`, `patch`, `MagicMock`, `call` (only `AsyncMock` is actually used), `Dict`, `List`, `Any`, `Optional`
- UP041 ×2: `asyncio.TimeoutError` → builtin `TimeoutError` on both the `raise` (autofixed) AND the `pytest.raises` (manual, for symmetry). Verified `asyncio.TimeoutError IS TimeoutError` in Python 3.11+ — same class.
- F841: dropped the unused `result =` capture on a `tracked_analyze` call. The test only asserts on `execution_log` (which the call mutates as a side effect), so the call is preserved but the dead variable assignment is gone.

## CI visibility note
`ai-engine/pyproject.toml` excludes `tests/` from the global ruff scan, so the 11 test-file fixes don't change the repo-wide error count — only the 1 fewshot fix moves the needle (98 → 97 errors total). The test-file fixes are still real cleanup: the file is shorter, easier to read, and self-consistent if anyone runs ruff directly against it.

## Verification
- `ruff check tests/test_agent_orchestration_comprehensive.py agents/fewshot_enhancer_agent.py` → "All checks passed!"
- `ruff check ai-engine/` global count: 98 → 97 (delta -1; rest are noqa'd by `tests/` exclusion)
- `pytest tests/test_agent_orchestration_comprehensive.py` → **32 passed**
- `from agents.fewshot_enhancer_agent import FewShotEnhancerAgent` imports cleanly

## Out of scope
The remaining 97 ruff errors in ai-engine are pre-existing tech debt across many files. Item 9 specifically called out `fewshot_enhancer_agent.py` + `test_agent_orchestration_comprehensive.py` + `packaging_agent.py` F401s; all three are now resolved. A broader ruff sweep should be its own dedicated effort.

## Summary by Sourcery

Clean up ruff warnings in the AI engine by removing unused code and aligning exception types in tests.

Enhancements:
- Remove unused logging import from the few-shot enhancer agent module to satisfy linting rules.

Tests:
- Simplify comprehensive agent orchestration tests by dropping unused imports and variables and by using the builtin TimeoutError consistently in timeout assertions.

Chores:
- Reduce the overall ruff warning count for the ai-engine package as part of ongoing lint cleanup.