### PR TITLE
fix(ci): repair post-merge deploy failures from PR 1463

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 # Cancel in-progress builds for same branch (saves CI costs)
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 'on':
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
           - service: backend
-            path: .
+            path: ./backend
             dockerfile: ./backend/Dockerfile
             tag-suffix: backend
           - service: ai-engine
@@ -48,7 +48,7 @@ jobs:
             dockerfile: ./ai-engine/Dockerfile
             tag-suffix: ai-engine
           - service: frontend
-            path: .
+            path: ./frontend
             dockerfile: ./frontend/Dockerfile
             tag-suffix: frontend
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Deploy PortKit
 
 # Cancel in-progress builds for same branch (saves CI costs)
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 'on':
@@ -406,7 +406,8 @@ jobs:
         with:
           status: ${{ job.status }}
           channel: '#deployments'
-          webhook_url: ${{ secrets.SLACK_WEBHOOK }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         if: always()
 
       - name: Record deployment time

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -44,10 +44,28 @@ jobs:
             api_url: https://api.portkit.cloud
 
     steps:
+      - name: Determine whether this matrix target should deploy
+        id: should_deploy
+        run: |
+          deploy=false
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ matrix.environment }}" = "${{ inputs.environment }}" ]; then
+            deploy=true
+          elif [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ "${{ matrix.environment }}" = "staging" ] && [ "${{ github.ref }}" = "refs/heads/staging" ]; then
+            deploy=true
+          elif [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ "${{ matrix.environment }}" = "production" ] && { [ "${{ github.ref }}" = "refs/heads/main" ] || [[ "${{ github.ref }}" == refs/tags/* ]]; }; then
+            deploy=true
+          fi
+          echo "deploy=$deploy" >> "$GITHUB_OUTPUT"
+          if [ "$deploy" != "true" ]; then
+            echo "Skipping ${{ matrix.environment }} for ${{ github.ref }} (${{ github.event_name }})"
+          fi
+
       - name: Checkout code
+        if: steps.should_deploy.outputs.deploy == 'true'
         uses: actions/checkout@v6
 
       - name: Initialize deployment performance tracking
+        if: steps.should_deploy.outputs.deploy == 'true'
         id: deploy_metrics
         run: |
           echo "DEPLOY_START=$(date +%s)" >> $GITHUB_ENV
@@ -55,6 +73,7 @@ jobs:
           echo "App: ${{ matrix.app_name }}"
 
       - name: Deploy to Fly.io
+        if: steps.should_deploy.outputs.deploy == 'true'
         uses: superfly/flyctl-actions@master
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
@@ -62,11 +81,13 @@ jobs:
           args: "deploy --app ${{ matrix.app_name }} --remote-only"
 
       - name: Wait for deployment to complete
+        if: steps.should_deploy.outputs.deploy == 'true'
         run: |
           echo "Waiting for Fly.io deployment to complete..."
           sleep 30
 
       - name: Health check
+        if: steps.should_deploy.outputs.deploy == 'true'
         env:
           API_URL: ${{ matrix.api_url }}
         run: |
@@ -85,7 +106,7 @@ jobs:
           exit 1
 
       - name: Run smoke tests
-        if: ${{ !inputs.skip_tests }}
+        if: steps.should_deploy.outputs.deploy == 'true' && !inputs.skip_tests
         env:
           API_URL: ${{ matrix.api_url }}
         run: |
@@ -106,7 +127,7 @@ jobs:
           echo "✓ Smoke tests passed"
 
       - name: Record deployment time
-        if: always()
+        if: always() && steps.should_deploy.outputs.deploy == 'true'
         run: |
           DEPLOY_END=$(date +%s)
           DEPLOY_START=${{ env.DEPLOY_START }}
@@ -119,7 +140,7 @@ jobs:
           fi
 
       - name: Notify deployment status
-        if: always()
+        if: always() && steps.should_deploy.outputs.deploy == 'true'
         uses: actions/github-script@v9
         with:
           script: |

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -43,8 +43,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf python3 /usr/bin/python
 
-# Copy Python packages from consolidated builder (NOT binaries - use production stage's Python)
-# Debian system Python looks in /usr/lib/python3.X/dist-packages, not site-packages
+# Copy Python packages from consolidated builder (NOT binaries - use production stage's Python).
+# fly-startup.sh sets PYTHONPATH=/usr/local/lib/python3.11/dist-packages, so packages
+# from the python:3.11-slim builder's site-packages must land at that exact path.
 COPY --from=python-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/dist-packages
 
 # Copy application code

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -16,7 +16,7 @@ RUN npm run build
 # Python dependencies build stage (consolidates all Python deps)
 # Note: Using Python 3.11 to match Debian bookworm's Python version
 # Debian bookworm-slim ships with Python 3.11.2, so we must build packages for 3.11
-FROM python:3.14-slim AS python-builder
+FROM python:3.11-slim AS python-builder
 WORKDIR /tmp
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc g++ curl libmagic1 ffmpeg && \
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy Python packages from consolidated builder (NOT binaries - use production stage's Python)
 # Debian system Python looks in /usr/lib/python3.X/dist-packages, not site-packages
-COPY --from=python-builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/dist-packages
+COPY --from=python-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/dist-packages
 
 # Copy application code
 COPY backend/ /app/backend/

--- a/Dockerfile.fly.optimized
+++ b/Dockerfile.fly.optimized
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.npm \
 # =============================================================================
 # Stage 2: Python dependencies (with cache mount for pip)
 # =============================================================================
-FROM python:3.14-slim AS python-builder
+FROM python:3.11-slim AS python-builder
 WORKDIR /tmp
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf python3 /usr/bin/python
 
 # Copy Python packages from builder (using correct Python 3.11 path)
-COPY --from=python-builder /usr/local/lib/python3.13/site-packages /usr/lib/python3.13/site-packages
+COPY --from=python-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/dist-packages
 
 # Copy application source code
 COPY backend/ /app/backend/


### PR DESCRIPTION
## Summary

Fixes the post-merge CI/deploy failures triggered after PR #1463 landed.

PR #1463 itself merged with all PR checks green, but the push-to-main workflows exposed separate deploy/build issues:

1. `CD` failed backend/frontend Docker builds.
2. `Deploy PortKit` was cancelled by a concurrency collision with `CD`.
3. `Deploy to Fly.io` failed staging unauthorized and production Docker build.

## Fixes

### CD Docker build contexts

`cd.yml` used root context for backend/frontend:

- backend: `context: .`, `file: ./backend/Dockerfile`
- frontend: `context: .`, `file: ./frontend/Dockerfile`

But those Dockerfiles expect service-local paths:

- `backend/Dockerfile` has `COPY requirements.txt .`
- `frontend/Dockerfile` has `COPY nginx.conf /etc/nginx/nginx.conf`

So main failed with missing `/requirements.txt` and missing `/nginx.conf`.

Changed contexts to:

- backend: `./backend`
- frontend: `./frontend`

### Workflow concurrency collision

`cd.yml` and `deploy.yml` both used:

```yaml
group: deploy-${{ github.ref }}
```

So a push to `main` could cancel one workflow from the other. Changed both to:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
```

### Fly.io Python copy path

`Dockerfile.fly` used `python:3.14-slim` but copied:

```dockerfile
/usr/local/lib/python3.13/site-packages
```

into a Debian bookworm runtime whose startup path is Python 3.11. That caused:

```text
failed to walk ... /usr/local/lib/python3.13: no such file or directory
```

Changed Fly builder to `python:3.11-slim` and copy to:

```dockerfile
/usr/local/lib/python3.11/dist-packages
```

Same correction applied to `Dockerfile.fly.optimized`.

### Fly.io environment gating

`fly-deploy.yml` deployed both staging and production on every main push. Staging failed unauthorized when the token only had production access. Now:

- `main` deploys production only
- `staging` deploys staging only
- manual dispatch deploys only the selected environment

### Deploy PortKit Slack action warning/future failure

`8398a7/action-slack@v3` does not support `webhook_url` as an input. Moved the webhook to env as `SLACK_WEBHOOK_URL`, which actionlint expects.

## Validation

- `actionlint` clean for changed workflows (`cd.yml`, `fly-deploy.yml`, `deploy.yml`)
- `docker buildx build --check` passes for:
  - `backend/Dockerfile` with `context=backend`
  - `frontend/Dockerfile` with `context=frontend`
  - `Dockerfile.fly` with root context

## Note

This is a follow-up to PR #1463. The PR pipeline stayed green; these were push-to-main deploy failures exposed after merge.
