### PR TITLE
fix(ci): nightly trivy-image (backend) context — same bug as PR #1464

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -157,7 +157,7 @@ jobs:
         include:
           - service: backend
             dockerfile: ./backend/Dockerfile
-            context: .
+            context: ./backend
           - service: ai-engine
             dockerfile: ./ai-engine/Dockerfile
             context: ./ai-engine


### PR DESCRIPTION
Single-line fix. PR #1464 fixed cd.yml::Build backend by switching context from root `.` to `./backend` because `backend/Dockerfile` expects service-local context (`COPY requirements.txt .`). I missed the same bug in `nightly.yml::trivy-image (backend)`.

**Symptom on the PR #1466 merge nightly run:**

```
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: '/requirements.txt': not found
Path does not exist: trivy-backend.sarif
```

ai-engine and frontend matrix entries already use `./service` contexts; only backend was wrong.

Verified: `docker buildx build --check -f backend/Dockerfile backend` passes.