### PR TITLE
chore(ci): align coverage thresholds with documented policy + add ratchet plan (#1471)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,8 +55,16 @@ env:
   NODE_VERSION: '20.19.0'
   PNPM_VERSION: '9'
   TESTING: 'true'
-  COVERAGE_THRESHOLD_BACKEND: '40'   # current honest baseline; raise gradually
-  COVERAGE_THRESHOLD_AI_ENGINE: '65'
+  # ---------------------------------------------------------------------------
+  # Coverage floors (CI-blocking minimums, NOT aspirational targets).
+  # Enforced floor as of 2026-05. Aspirational target: 80%.
+  # See docs/ci/coverage-policy.md for the ratchet plan + how to raise/lower.
+  # Raising a floor: PR that bumps the value here AND updates
+  # docs/ci/coverage-policy.md, with green CI. Lowering: rare; requires
+  # explicit justification + reviewer sign-off (see policy doc).
+  # ---------------------------------------------------------------------------
+  COVERAGE_FLOOR_BACKEND: '40'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
+  COVERAGE_FLOOR_AI_ENGINE: '65'    # ratchet milestones: 65 → 70 → 75 → 80
 
 jobs:
   # ===========================================================================
@@ -271,7 +279,7 @@ jobs:
             -n auto --dist=loadscope \
             -q --tb=short --timeout=60 \
             --cov=src --cov-report=xml --cov-report=term \
-            --cov-fail-under=${{ env.COVERAGE_THRESHOLD_BACKEND }} \
+            --cov-fail-under=${{ env.COVERAGE_FLOOR_BACKEND }} \
             --ignore=src/tests/unit/test_task_worker_coverage.py \
             --ignore=src/tests/unit/test_performance_api.py
 
@@ -328,7 +336,7 @@ jobs:
             -q --tb=short --timeout=120 \
             -m 'not slow and not ai and not real_service and not docker and not e2e' \
             --cov=. --cov-report=xml \
-            --cov-fail-under=${{ env.COVERAGE_THRESHOLD_AI_ENGINE }}
+            --cov-fail-under=${{ env.COVERAGE_FLOOR_AI_ENGINE }}
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ pnpm run format:backend       # Ruff format + lint --fix
 
 **Framework**: pytest with pytest-asyncio
 
-**Coverage**: 80%+ required for PR merges
+**Coverage**: enforced floor of 40% backend / 65% ai-engine (CI-blocking, set in `.github/workflows/pr.yml` as `COVERAGE_FLOOR_BACKEND` / `COVERAGE_FLOOR_AI_ENGINE`). Target 80% per ratchet plan in [`docs/ci/coverage-policy.md`](docs/ci/coverage-policy.md). PRs should maintain or improve coverage on changed code.
 
 **Test Database**: Use `./scripts/test-db.sh {start|stop|reset}`
 

--- a/docs/ci/coverage-policy.md
+++ b/docs/ci/coverage-policy.md
@@ -1,0 +1,223 @@
+# Coverage Policy & Ratchet Plan
+
+> **Status**: active as of 2026-05.
+> **Owners**: CI / Platform.
+> **Source of truth for thresholds**: [`.github/workflows/pr.yml`](../../.github/workflows/pr.yml) (`env.COVERAGE_FLOOR_BACKEND`, `env.COVERAGE_FLOOR_AI_ENGINE`).
+
+This document explains **why** the CI-enforced coverage floors do not match the
+"80%+" target stated in `AGENTS.md` historically, and **how** we close that gap
+over time without flipping coverage from a useful signal into a blocker that
+gets routinely bypassed.
+
+---
+
+## TL;DR
+
+| Component   | Enforced floor (CI-blocking) | Aspirational target |
+|-------------|------------------------------|---------------------|
+| `backend`   | **40%**                      | 80%                 |
+| `ai-engine` | **65%**                      | 80%                 |
+| `frontend`  | not enforced (vitest run, no `--coverage` gate) | 80% |
+
+The floors are the **minimum** a PR must keep coverage at to merge. They are
+not the goal — they are the worst we are willing to ship today. The ratchet
+plan below moves them upward toward the 80% target on a predictable cadence.
+
+---
+
+## Why a floor instead of a single target?
+
+A single hard target of 80% has historically led to one of three outcomes in
+this repo:
+
+1. **The number is bypassed.** Reviewers wave PRs through with
+   `--cov-fail-under=0`-style overrides because the threshold is unrealistic
+   for the current code shape. Coverage stops being a gate.
+2. **PRs add throwaway tests** to satisfy the percentage without exercising
+   real behaviour. Coverage goes up; quality does not.
+3. **Coverage-improvement work gets blocked** because the very PR that adds
+   tests to a previously-untested module temporarily *lowers* the global
+   percentage (denominator grows faster than the numerator on the first
+   commit), so the gate fails.
+
+A **floor + ratchet** model avoids all three: the floor is set just below
+current measured coverage, so ordinary PRs pass; the ratchet schedule
+documents exactly when and how the floor moves up; lowering the floor is
+deliberately friction-heavy so it is not the path of least resistance.
+
+---
+
+## Current enforced thresholds
+
+These are the values enforced today in CI via `pytest --cov-fail-under`:
+
+```yaml
+# .github/workflows/pr.yml
+env:
+  COVERAGE_FLOOR_BACKEND: '40'      # backend/src
+  COVERAGE_FLOOR_AI_ENGINE: '65'    # ai-engine
+```
+
+If a PR drops coverage below these, the `backend-tests` / `ai-engine-tests`
+job fails, which fails the `PR Gates` aggregator, which blocks merge.
+
+---
+
+## Ratchet milestones
+
+The plan is to walk the floors upward in fixed steps, re-evaluating actual
+coverage between each step. **The milestones below are the *target floors*,
+not the dates** — we promote when the codebase is sustainably above the next
+milestone, not on a calendar.
+
+### Backend (`backend/src`)
+
+| Milestone | Floor | Promotion criterion (see "Cadence") |
+|-----------|-------|-------------------------------------|
+| M0 (today)| 40%   | baseline                            |
+| M1        | 50%   | sustained ≥55% on `main` for ≥4 weeks |
+| M2        | 60%   | sustained ≥65% on `main` for ≥4 weeks |
+| M3        | 70%   | sustained ≥75% on `main` for ≥4 weeks |
+| M4        | 80%   | sustained ≥82% on `main` for ≥4 weeks; matches `AGENTS.md` target |
+
+### AI engine (`ai-engine`)
+
+| Milestone | Floor | Promotion criterion |
+|-----------|-------|---------------------|
+| M0 (today)| 65%   | baseline            |
+| M1        | 70%   | sustained ≥75% on `main` for ≥4 weeks |
+| M2        | 75%   | sustained ≥80% on `main` for ≥4 weeks |
+| M3        | 80%   | sustained ≥82% on `main` for ≥4 weeks; matches `AGENTS.md` target |
+
+### Frontend (`frontend`)
+
+Frontend tests run in CI (`pnpm run test:ci`) but coverage is not gated.
+A future ratchet for the frontend will be added once a baseline is
+established; until then the 80% target is purely aspirational for the
+frontend. Tracking issue: TBD.
+
+---
+
+## Cadence
+
+> **Rule of thumb**: raise the floor by **+10 percentage points (pp)** at most
+> **once per quarter**, and only when measured coverage on `main` has been
+> **≥5pp above the next milestone for at least 4 consecutive weeks**.
+
+Concretely:
+
+- Once per quarter, the on-call maintainer (or anyone) opens an issue titled
+  `coverage: ratchet review YYYY-Qn` and pastes the last 4 weeks of coverage
+  numbers from the `backend-coverage` and `ai-engine-coverage` artifacts on
+  `main`.
+- If both numbers comfortably clear the next milestone, open the bump PR (see
+  below).
+- If only one component clears, bump only that one.
+- If neither clears, no change — file follow-up issues for the gap modules.
+
+The +10pp / 4-week buffer rule prevents thrashing: a single lucky PR cannot
+ratchet the floor; the floor only moves when the team has *durably* improved
+coverage and would not regress on a routine refactor.
+
+---
+
+## How to propose a raise
+
+1. Open a PR that:
+   - Bumps the value of `COVERAGE_FLOOR_BACKEND` and/or
+     `COVERAGE_FLOOR_AI_ENGINE` in `.github/workflows/pr.yml`.
+   - Updates the "Current enforced thresholds" section above to match.
+   - Strikes through (or replaces) the relevant row in the milestone table
+     with a "✅ promoted YYYY-MM-DD" note.
+   - Optionally updates `AGENTS.md` if the new floor reaches the 80% target.
+2. CI must be green on that PR with the new, higher floor — that is the
+   verification that the codebase actually sustains the new floor today.
+3. Reviewer: confirms the milestone criterion is met (link to the 4-week
+   coverage history in the PR description).
+4. Merge. The next PR onward enforces the new floor.
+
+A raise PR is **scope `chore(ci)` or `chore(docs,ci)`**. It does not need
+new tests; the test work that produced the higher coverage should already be
+on `main`.
+
+---
+
+## How to lower (rare)
+
+Lowering a floor is intentionally rare and high-friction. It is appropriate
+in cases such as:
+
+- A large module is **deleted** (denominator shrinks; numerator
+  proportionally less, so percentage drops) and we cannot land replacement
+  tests in the same PR.
+- A **legitimate refactor** introduces a previously-untested integration
+  layer that we plan to test in a follow-up PR with a tracking issue.
+- A **flaky** coverage measurement is causing repeated false-negative gate
+  failures on otherwise-correct PRs (in this case, fix the flake instead if
+  at all possible).
+
+To lower:
+
+1. Open a PR that:
+   - Lowers the value in `.github/workflows/pr.yml`.
+   - Updates the "Current enforced thresholds" table above.
+   - Adds a dated entry to the **"Lowering log"** section below explaining
+     the reason and the tracking issue for restoring the floor.
+2. PR description must include:
+   - The reason (link to the deletion/refactor PR or flake report).
+   - A concrete plan and target date for restoring the previous floor.
+   - Explicit reviewer sign-off from a CODEOWNER for `.github/workflows/`.
+3. Open a follow-up issue labelled `ci`, `coverage`, and `tech-debt`
+   referencing the lowered floor and the restoration target. Link it from
+   the lowering log entry.
+
+### Lowering log
+
+_(empty — no floors have been lowered)_
+
+---
+
+## How a PR currently fails the gate
+
+The relevant CI lines (paraphrased) are:
+
+```bash
+# backend
+python -m pytest src/tests/unit/ \
+  --cov=src --cov-report=xml --cov-report=term \
+  --cov-fail-under=${COVERAGE_FLOOR_BACKEND}
+
+# ai-engine
+python -m pytest tests/ \
+  --cov=. --cov-report=xml \
+  --cov-fail-under=${COVERAGE_FLOOR_AI_ENGINE}
+```
+
+If total coverage falls below the floor, `pytest` exits non-zero, the job
+fails, and the `PR Gates` aggregator (`pr-gates` job in `pr.yml`) reports
+failure to the branch-protection check, blocking merge.
+
+---
+
+## What this policy is *not*
+
+- **Not a per-file rule.** A new file at 0% coverage will not fail the gate
+  on its own; only the aggregate percentage matters. Reviewers should still
+  push back on PRs that add untested code.
+- **Not a per-PR diff rule.** Diff coverage (Option C in the original RFC)
+  is intentionally not used today because it is sensitive to renames /
+  whitespace / vendored code in this repo. We may revisit if/when a stable
+  diff-coverage tool is wired in.
+- **Not a substitute for code review.** Coverage is a floor on test
+  *execution*, not on test *quality*. A reviewer can still block a PR that
+  has high coverage but weak assertions.
+
+---
+
+## Cross-references
+
+- `.github/workflows/pr.yml` — where the floors are enforced.
+- `AGENTS.md` — repository contributor guide; testing section links here.
+- `pytest.ini` — project-wide pytest defaults (parallelism, markers).
+- `backend/coverage.xml` / `ai-engine/coverage.xml` — per-run coverage
+  artifacts uploaded by the `backend-tests` and `ai-engine-tests` jobs.


### PR DESCRIPTION
Closes #1471.

## Why

Repository contributor guidance (`AGENTS.md`) said **"Coverage: 80%+ required for PR merges"**, but the consolidated PR pipeline in `.github/workflows/pr.yml` enforced much lower floors (`backend=40%`, `ai-engine=65%`) via `COVERAGE_THRESHOLD_BACKEND` / `COVERAGE_THRESHOLD_AI_ENGINE`. The two statements directly contradicted each other, leaving contributors and reviewers with no clear, enforceable rule.

A previous attempt to "just bump CI to 80%" would have broken every PR overnight; a previous attempt to "just lower the docs to 40%" would have abandoned the 80% goal. Neither is acceptable.

## What — Option A from issue #1471 (ratchet plan)

This PR adopts **Option A: ratchet thresholds up over time, document a plan with milestones.** It is a docs + CI policy change only — no source or test files are touched, and the enforced numeric thresholds stay at their current values (40 / 65) so CI behaviour is identical for ordinary PRs today.

### `.github/workflows/pr.yml`
- Renames the env vars to express the actual semantics:
  - `COVERAGE_THRESHOLD_BACKEND`   → `COVERAGE_FLOOR_BACKEND`
  - `COVERAGE_THRESHOLD_AI_ENGINE` → `COVERAGE_FLOOR_AI_ENGINE`
- Repo-wide grep confirmed these env vars were only referenced inside `pr.yml` itself (2 use sites, both updated). Other workflows are unaffected.
- Adds an inline comment block above the env vars stating the floor-vs-target distinction, the date the floor was set, and a pointer to the policy doc.

### `AGENTS.md`
- Replaces the contradictory "80%+ required for PR merges" sentence with the actual floors, links to the new policy doc, and preserves 80% as the explicit long-term target.

### `docs/ci/coverage-policy.md` (new)
- Current enforced floors and the rationale for using a *floor* model over a single hard target.
- Ratchet milestones:
  - **backend**: 40 → 50 → 60 → 70 → 80
  - **ai-engine**: 65 → 70 → 75 → 80
- Cadence rule: at most **+10pp per quarter**, only when measured coverage on `main` has been **≥5pp above the next milestone for ≥4 consecutive weeks** (prevents a single lucky PR from ratcheting the floor).
- "How to propose a raise" — concrete PR checklist; bumping CI is the verification that the codebase actually sustains the new floor.
- "How to lower (rare)" — high-friction process requiring a CODEOWNER sign-off, a tracking issue, and a dated entry in a lowering log embedded in the doc.
- Explicitly notes that frontend coverage is not gated yet, and that diff coverage (Option C) is deferred.

## Acceptance criteria

- [x] `AGENTS.md` / repo docs and `pr.yml` no longer contradict each other.
- [x] The selected threshold policy (Option A, floor + ratchet) is documented at `docs/ci/coverage-policy.md`.
- [x] CI remains stable for ordinary PRs — numeric floors unchanged; only env var names + comments + docs are modified.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))"` ✅
- Grep confirms zero stale `COVERAGE_THRESHOLD_*` references in the repo.
- `pr.yml` env block now contains exactly two `COVERAGE_FLOOR_*` definitions, each referenced exactly once in a `--cov-fail-under` flag.

## Files touched

- `.github/workflows/pr.yml` (env vars renamed, comment block added)
- `AGENTS.md` (testing/coverage section)
- `docs/ci/coverage-policy.md` (new)

## Out of scope (intentionally)

- `frontend/`, `backend/`, `ai-engine/` source/tests — untouched.
- `.github/workflows/nightly.yml`, `load-test.yml`, other workflows — untouched.
- `CLAUDE.md` line 146 ("Coverage: 80%+ required for merges.") — outside the write scope for this issue. A follow-up `docs(claude)` PR can align that line with the new policy doc once this lands.