### PR TITLE
fix(ci): run AI engine contract tests in nightly (#1469)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -329,18 +329,43 @@ jobs:
         run: |
           timeout 60 bash -c 'until nc -z localhost 5434; do sleep 1; done'
           timeout 60 bash -c 'until nc -z localhost 6380; do sleep 1; done'
+      - name: Start mock AI engine (#1469)
+        # Spin up the in-repo `mock-ai-engine.py` (FastAPI + uvicorn — both
+        # already in backend/requirements.lock) so test_ai_engine_contract.py
+        # has a deterministic HTTP target. The mock validates request shape
+        # and returns canned responses, so no external or paid model call is
+        # ever made. The real ai-engine is not used here because its API is
+        # mounted at /api/v1/convert (versioned) while the contract tests
+        # POST to /convert (unversioned) — see Dockerfile.mock-ai for the
+        # original intent of this mock.
+        run: |
+          nohup python -m uvicorn mock-ai-engine:app \
+            --host 127.0.0.1 --port 8080 > "$RUNNER_TEMP/mock-ai.log" 2>&1 &
+          echo "MOCK_AI_PID=$!" >> "$GITHUB_ENV"
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/health >/dev/null 2>&1; then
+              echo "mock ai-engine ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::mock ai-engine failed to become healthy in 30s"
+          tail -n 100 "$RUNNER_TEMP/mock-ai.log" >&2 || true
+          exit 1
       - name: Backend integration (real postgres + redis)
         # The pytest-asyncio event-loop bug (NullPool fix) and the duplicate
         # ix_user_credits_user_id index were both resolved; this job is now
-        # blocking. Two pre-existing tests are excluded because they require
-        # services we do not run in CI:
-        #   * test_ai_engine_contract.py — needs the ai-engine HTTP service
-        #   * test_create_conversion_large_file_validation — pre-existing
-        #     FK-violation bug independent of this work
+        # blocking. test_ai_engine_contract.py runs against the
+        # `mock-ai-engine.py` started above (issue #1469). One pre-existing
+        # test is still deselected because it has an unrelated FK-violation
+        # bug independent of this work:
+        #   * test_create_conversion_large_file_validation
+        env:
+          TEST_AI_ENGINE_URL: 'http://127.0.0.1:8080'
+          AI_ENGINE_MOCK: '1'
         run: |
           cd backend
           python -m pytest src/tests/integration/ \
-            --ignore=src/tests/integration/test_ai_engine_contract.py \
             --deselect=src/tests/integration/test_conversions_api_v1.py::TestConversionsAPI::test_create_conversion_large_file_validation \
             -q --tb=short --timeout=180 --no-cov -o "addopts="
       - name: AI-engine integration (real services)
@@ -349,6 +374,19 @@ jobs:
           python -m pytest tests/integration/ \
             -q --tb=short --timeout=300 --no-cov \
             -m 'not slow and not ai' || true
+      - name: Stop mock AI engine (#1469)
+        if: always()
+        run: |
+          if [ -n "${MOCK_AI_PID:-}" ]; then
+            kill "$MOCK_AI_PID" 2>/dev/null || true
+          fi
+          # Best-effort cleanup of any stragglers.
+          pkill -f "uvicorn mock-ai-engine:app" 2>/dev/null || true
+          if [ -f "$RUNNER_TEMP/mock-ai.log" ]; then
+            echo "::group::mock-ai-engine log tail"
+            tail -n 200 "$RUNNER_TEMP/mock-ai.log" || true
+            echo "::endgroup::"
+          fi
 
   # ===========================================================================
   # Aggregate

--- a/backend/src/tests/integration/test_ai_engine_contract.py
+++ b/backend/src/tests/integration/test_ai_engine_contract.py
@@ -1,134 +1,117 @@
 """
 Real-service integration tests for AI Engine contract testing.
 
-These tests verify that the AI Engine API contract is respected
-without hitting the real model endpoint. When AI_ENGINE_MOCK=1,
-a mock server is used that returns valid response shapes.
+These tests verify that the AI Engine HTTP API contract is respected
+without ever invoking a real model. Nightly CI starts the in-repo
+``mock-ai-engine.py`` (a tiny FastAPI app that returns canned responses
+and validates request shape) on http://127.0.0.1:8080 and exposes its URL
+via ``TEST_AI_ENGINE_URL``. The mock makes no outbound calls and requires
+no API keys, so the contract suite is deterministic and free.
 
-To run:
-    AI_ENGINE_MOCK=1 pytest tests/integration/test_ai_engine_contract.py -v
-    # or with full real services:
-    USE_REAL_SERVICES=1 TEST_AI_ENGINE_URL=http://localhost:8080 pytest tests/integration/test_ai_engine_contract.py -v
+Why a mock instead of the real ai-engine?
+    The real ``ai-engine/main.py`` exposes its conversion API at
+    ``/api/v1/convert`` (versioned), while these contract tests POST to
+    ``/convert`` (unversioned). Running the real engine would 404 those
+    requests, fail the contract assertions, and pull in heavy LLM
+    dependencies. The repo's ``mock-ai-engine.py`` was authored
+    specifically for this contract surface (see ``Dockerfile.mock-ai``).
+
+To run locally::
+
+    # Terminal 1: start the mock
+    python -m uvicorn mock-ai-engine:app --host 127.0.0.1 --port 8080
+
+    # Terminal 2: run the contract tests
+    USE_REAL_SERVICES=1 TEST_AI_ENGINE_URL=http://127.0.0.1:8080 \
+        pytest backend/src/tests/integration/test_ai_engine_contract.py -v
 """
 
-import pytest
 import os
 
+import httpx
+import pytest
 
 pytestmark = pytest.mark.real_service
 
 
 class TestAIEngineContract:
-    """Contract tests for AI Engine API."""
+    """Contract tests for AI Engine HTTP API."""
 
     @pytest.fixture
-    def ai_engine_url(self):
-        """Get AI Engine URL from environment."""
+    def ai_engine_url(self) -> str:
+        """Get AI Engine URL from environment (default: localhost:8080)."""
         return os.getenv("TEST_AI_ENGINE_URL", "http://localhost:8080")
 
     @pytest.mark.asyncio
-    async def test_ai_engine_health_check(self, ai_engine_url):
-        """Test that AI Engine health endpoint responds."""
-        import aiohttp
-
+    async def test_ai_engine_health_check(self, ai_engine_url: str) -> None:
+        """AI Engine ``/health`` endpoint must respond."""
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"{ai_engine_url}/health", timeout=aiohttp.ClientTimeout(total=5)
-                ) as resp:
-                    # Should return 200 or 404 (if health endpoint doesn't exist)
-                    assert resp.status in [200, 404, 500]
-        except aiohttp.ClientError:
-            pytest.skip("AI Engine not available at {ai_engine_url}")
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(f"{ai_engine_url}/health")
+        except httpx.RequestError:
+            pytest.skip(f"AI Engine not available at {ai_engine_url}")
+        # 200 = healthy; 404/500 tolerated for ai-engine variants without /health.
+        assert resp.status_code in (200, 404, 500)
 
     @pytest.mark.asyncio
-    async def test_ai_engine_convert_endpoint_exists(self, ai_engine_url):
-        """Test that the convert endpoint exists and returns expected structure."""
-        import aiohttp
-        import json
-
+    async def test_ai_engine_convert_endpoint_exists(self, ai_engine_url: str) -> None:
+        """The ``/convert`` endpoint must accept a well-formed payload."""
         payload = {
             "file_path": "/tmp/test.jar",
             "target_version": "1.20.0",
             "options": {"assumptions": "conservative"},
         }
-
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{ai_engine_url}/convert",
-                    json=payload,
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    # We expect either:
-                    # - 200 with success response
-                    # - 400 with validation error
-                    # - 500 with error
-                    # What matters is the API shape is consistent
-                    assert resp.status in [200, 400, 500, 502, 503]
-
-                    # If we got a response, verify it's valid JSON
-                    text = await resp.text()
-                    try:
-                        data = json.loads(text)
-                        # Response should be a dict
-                        assert isinstance(data, dict)
-                    except json.JSONDecodeError:
-                        # Some error responses might be plain text
-                        pass
-        except aiohttp.ClientError:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.post(f"{ai_engine_url}/convert", json=payload)
+        except httpx.RequestError:
             pytest.skip(f"AI Engine not available at {ai_engine_url}")
+
+        # Contract: a known status that signals "endpoint exists and parsed input".
+        assert resp.status_code in (200, 400, 500, 502, 503)
+
+        # If a body was returned, it should be a JSON object.
+        if resp.content:
+            try:
+                data = resp.json()
+                assert isinstance(data, dict)
+            except ValueError:
+                # Some error responses are plain text — that's acceptable.
+                pass
 
     @pytest.mark.asyncio
-    async def test_ai_engine_validates_input(self, ai_engine_url):
-        """Test that AI Engine validates required fields."""
-        import aiohttp
-
-        # Missing required fields
-        invalid_payload = {
-            "file_path": "/tmp/test.jar"
-            # Missing target_version
-        }
-
+    async def test_ai_engine_validates_input(self, ai_engine_url: str) -> None:
+        """``/convert`` must reject payloads missing required fields."""
+        invalid_payload = {"file_path": "/tmp/test.jar"}  # missing target_version
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(
-                    f"{ai_engine_url}/convert",
-                    json=invalid_payload,
-                    timeout=aiohttp.ClientTimeout(total=10),
-                ) as resp:
-                    # Should return 400 Bad Request for invalid input
-                    assert resp.status in [400, 422, 500]
-        except aiohttp.ClientError:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(f"{ai_engine_url}/convert", json=invalid_payload)
+        except httpx.RequestError:
             pytest.skip(f"AI Engine not available at {ai_engine_url}")
+
+        # Should refuse with 4xx; 500 tolerated for engines that fail internally.
+        assert resp.status_code in (400, 422, 500)
 
 
 class TestConversionPipelineContract:
     """Contract tests for conversion pipeline integration."""
 
-    def test_conversion_request_structure(self):
-        """Test that conversion request has correct structure."""
+    def test_conversion_request_structure(self) -> None:
+        """ConversionRequest accepts the canonical fields."""
         from src.main import ConversionRequest
 
-        # Valid request
-        req = ConversionRequest(
-            file_id="test-file-id",
-            target_version="1.20.0",
-        )
+        req = ConversionRequest(file_id="test-file-id", target_version="1.20.0")
         assert req.file_id == "test-file-id"
         assert req.target_version == "1.20.0"
 
-    def test_conversion_options_structure(self):
-        """Test that conversion options have correct defaults."""
+    def test_conversion_options_structure(self) -> None:
+        """ConversionRequest accepts an options dict."""
         from src.main import ConversionRequest
 
         req = ConversionRequest(
             file_id="test-file-id",
             target_version="1.20.0",
-            options={
-                "assumptions": "conservative",
-                "target_version": "1.20.0",
-            },
+            options={"assumptions": "conservative", "target_version": "1.20.0"},
         )
         assert req.options is not None
 
@@ -136,29 +119,22 @@ class TestConversionPipelineContract:
 class TestAIEngineFallbackBehavior:
     """Tests for AI Engine fallback behavior when unavailable."""
 
-    def test_conversion_service_has_fallback(self):
-        """Test that conversion service has fallback when AI engine unavailable."""
-        from services.conversion_service import ConversionService
+    def test_conversion_service_has_fallback(self) -> None:
+        """ConversionService source must contain error-handling for AI calls."""
         import inspect
 
-        # Check if service has fallback/error handling
-        source = inspect.getsource(ConversionService)
+        from services.conversion_service import ConversionService
 
-        # Should have try/except for AI engine calls
+        source = inspect.getsource(ConversionService)
         assert "try:" in source or "except" in source or "fallback" in source.lower()
 
-    def test_conversion_returns_error_on_ai_failure(self):
-        """Test that conversion returns proper error when AI fails."""
-        # This tests the error handling path
-        # When AI engine is unavailable, should return proper error
-
-        # The main.py has try_ai_engine_or_fallback function
-        from src.main import try_ai_engine_or_fallback
+    def test_conversion_returns_error_on_ai_failure(self) -> None:
+        """``try_ai_engine_or_fallback`` must handle errors gracefully."""
         import inspect
 
-        source = inspect.getsource(try_ai_engine_or_fallback)
+        from src.main import try_ai_engine_or_fallback
 
-        # Should handle errors gracefully
+        source = inspect.getsource(try_ai_engine_or_fallback)
         assert "except" in source or "error" in source.lower() or "fallback" in source.lower()
 
 
@@ -166,51 +142,46 @@ class TestRealFileProcessingWithAI:
     """Integration tests for file processing with AI Engine (when available)."""
 
     @pytest.fixture
-    def sample_jar_bytes(self):
+    def sample_jar_bytes(self) -> bytes:
         """Create sample JAR bytes for testing."""
         import io
-        import zipfile
         import json
+        import zipfile
 
         buffer = io.BytesIO()
         with zipfile.ZipFile(buffer, "w") as zf:
             zf.writestr("META-INF/MANIFEST.MF", "Manifest-Version: 1.0\n")
-            zf.writestr(
-                "mod.json",
-                json.dumps(
-                    {
-                        "name": "TestMod",
-                        "version": "1.0.0",
-                    }
-                ),
-            )
+            zf.writestr("mod.json", json.dumps({"name": "TestMod", "version": "1.0.0"}))
         return buffer.getvalue()
 
-    def test_file_processor_handles_jar_bytes(self, sample_jar_bytes):
-        """Test that file processor can handle JAR bytes."""
+    @pytest.mark.xfail(
+        reason=(
+            "Pre-existing latent bug surfaced by un-ignoring this file in nightly: "
+            "FileHandler does not expose a public detect_content_type() method. "
+            "Tracked separately from #1469 — fix or rework should land in a follow-up."
+        ),
+        strict=False,
+    )
+    def test_file_processor_handles_jar_bytes(self, sample_jar_bytes: bytes) -> None:
+        """FileHandler must classify JAR bytes as a known archive type."""
         from services.file_handler import FileHandler
 
         handler = FileHandler()
-
-        # Should be able to identify as JAR
-        # Note: This tests the file handler, not the AI
         content_type = handler.detect_content_type(sample_jar_bytes)
-        # JAR files are ZIP-based
-        assert content_type in [
+        assert content_type in (
             "application/java-archive",
             "application/zip",
             "binary/octet-stream",
-        ]
+        )
 
-    def test_mod_json_extraction_from_bytes(self, sample_jar_bytes):
-        """Test extracting mod.json from JAR bytes."""
+    def test_mod_json_extraction_from_bytes(self, sample_jar_bytes: bytes) -> None:
+        """``mod.json`` should round-trip through the JAR archive."""
         import io
-        import zipfile
         import json
+        import zipfile
 
         buffer = io.BytesIO(sample_jar_bytes)
         with zipfile.ZipFile(buffer, "r") as zf:
             with zf.open("mod.json") as f:
                 mod_data = json.load(f)
-
         assert mod_data["name"] == "TestMod"

--- a/backend/src/tests/integration/test_ai_engine_contract.py
+++ b/backend/src/tests/integration/test_ai_engine_contract.py
@@ -27,11 +27,12 @@ To run locally::
 """
 
 import os
+from pathlib import Path
 
 import httpx
 import pytest
 
-pytestmark = pytest.mark.real_service
+pytestmark = [pytest.mark.integration, pytest.mark.real_service]
 
 
 class TestAIEngineContract:
@@ -154,25 +155,21 @@ class TestRealFileProcessingWithAI:
             zf.writestr("mod.json", json.dumps({"name": "TestMod", "version": "1.0.0"}))
         return buffer.getvalue()
 
-    @pytest.mark.xfail(
-        reason=(
-            "Pre-existing latent bug surfaced by un-ignoring this file in nightly: "
-            "FileHandler does not expose a public detect_content_type() method. "
-            "Tracked separately from #1469 — fix or rework should land in a follow-up."
-        ),
-        strict=False,
-    )
-    def test_file_processor_handles_jar_bytes(self, sample_jar_bytes: bytes) -> None:
-        """FileHandler must classify JAR bytes as a known archive type."""
+    @pytest.mark.asyncio
+    async def test_file_processor_handles_jar_bytes(
+        self, sample_jar_bytes: bytes, tmp_path: Path
+    ) -> None:
+        """FileHandler must validate JAR bytes when written to disk."""
         from services.file_handler import FileHandler
 
+        jar_path = tmp_path / "test.jar"
+        jar_path.write_bytes(sample_jar_bytes)
+
         handler = FileHandler()
-        content_type = handler.detect_content_type(sample_jar_bytes)
-        assert content_type in (
-            "application/java-archive",
-            "application/zip",
-            "binary/octet-stream",
-        )
+        validation = await handler.validate_jar(str(jar_path))
+
+        assert validation.is_valid is True
+        assert validation.errors == []
 
     def test_mod_json_extraction_from_bytes(self, sample_jar_bytes: bytes) -> None:
         """``mod.json`` should round-trip through the JAR archive."""


### PR DESCRIPTION
## Why

`backend/src/tests/integration/test_ai_engine_contract.py` was excluded from the nightly **Real-services integration (postgres + redis)** job via `--ignore=`, because the job started only PostgreSQL and Redis while the contract tests need an AI Engine-compatible HTTP target. That meant nightly never validated the AI Engine HTTP contract.

## What

- Added `Start mock AI engine (#1469)` to `nightly.yml::integration-real-services`.
  - Boots the in-repo `mock-ai-engine.py` with `uvicorn` on `127.0.0.1:8080`.
  - Waits for `/health` with a 30-second budget.
  - Uses only already-installed dependencies (`fastapi`/`uvicorn` from backend deps).
- Added backend-step env:
  - `TEST_AI_ENGINE_URL=http://127.0.0.1:8080`
  - `AI_ENGINE_MOCK=1`
- Removed `--ignore=src/tests/integration/test_ai_engine_contract.py` from the nightly backend integration pytest command.
- Added `Stop mock AI engine (#1469)` teardown with `if: always()`.
- Updated `test_ai_engine_contract.py`:
  - uses `httpx.AsyncClient` instead of `aiohttp` because backend test conftest stubs `aiohttp` during pytest configuration;
  - adds explicit `integration` + `real_service` markers;
  - updates the file-handling check to use the real async `FileHandler.validate_jar()` API, so the targeted contract file now fully passes.

## Option chosen

Hybrid of the issue options: **Option A's CI background HTTP service**, but using the repo's existing lightweight mock (`mock-ai-engine.py`) instead of the full real `ai-engine/main.py`.

This minimizes flake risk and external dependencies because the real ai-engine exposes conversion at `/api/v1/convert`, while this contract file exercises `/convert`. Starting the full engine would produce a 404 for the tested endpoint and pull in heavier runtime/LLM plumbing. The mock implements `/health` and `/convert`, validates payload shape, returns canned responses, and makes no external or paid model calls.

## Acceptance criteria

- [x] `test_ai_engine_contract.py` runs in nightly without being ignored.
- [x] No external paid model call is required.
- [x] Nightly `Real-services integration (postgres + redis)` remains green.

## Evidence

```text
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml')); print('YAML OK')"
YAML OK

$ python3 -m ruff check backend/src/tests/integration/test_ai_engine_contract.py
All checks passed!

$ USE_REAL_SERVICES=1 TEST_AI_ENGINE_URL=http://127.0.0.1:8080 AI_ENGINE_MOCK=1 \
    python3 -m pytest src/tests/integration/test_ai_engine_contract.py \
      -q --tb=short --timeout=180 --no-cov -o "addopts="
.........                                                                [100%]
9 passed in 1.50s
```

Closes #1469
