### PR TITLE
fix(tests): seed mock auth user for real-PostgreSQL integration tests (#1470)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -356,17 +356,17 @@ jobs:
         # The pytest-asyncio event-loop bug (NullPool fix) and the duplicate
         # ix_user_credits_user_id index were both resolved; this job is now
         # blocking. test_ai_engine_contract.py runs against the
-        # `mock-ai-engine.py` started above (issue #1469). One pre-existing
-        # test is still deselected because it has an unrelated FK-violation
-        # bug independent of this work:
-        #   * test_create_conversion_large_file_validation
+        # `mock-ai-engine.py` started above (issue #1469).
+        # test_create_conversion_large_file_validation FK violation fixed in
+        # #1470 (mock auth user is now seeded into the users table by the
+        # shared client fixture), so the previous --deselect is no longer
+        # needed.
         env:
           TEST_AI_ENGINE_URL: 'http://127.0.0.1:8080'
           AI_ENGINE_MOCK: '1'
         run: |
           cd backend
           python -m pytest src/tests/integration/ \
-            --deselect=src/tests/integration/test_conversions_api_v1.py::TestConversionsAPI::test_create_conversion_large_file_validation \
             -q --tb=short --timeout=180 --no-cov -o "addopts="
       - name: AI-engine integration (real services)
         run: |

--- a/backend/src/tests/conftest.py
+++ b/backend/src/tests/conftest.py
@@ -336,6 +336,87 @@ def reset_storage_env():
 # with explicit control over when environment is set vs when it's cleaned up
 
 
+def _run_async_in_sync_fixture(coro):
+    """Run an async coroutine from a sync pytest fixture without polluting
+    the global event loop (kept compatible with pytest-asyncio's
+    function-scoped loops).
+    """
+    import asyncio
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _seed_mock_auth_user(session_maker, user_id):
+    """Idempotently insert the mocked auth user (Issue #1470).
+
+    The shared ``client`` fixture overrides ``get_current_user`` with a
+    MagicMock whose ``.id`` is a fixed UUID. Code paths that write
+    FK-constrained rows referencing ``users.id`` (e.g. ``usage_records``
+    via ``MeteringService.get_or_create_usage_record``) require this row
+    to actually exist when running against real PostgreSQL.
+    """
+    from sqlalchemy import select
+    from db.models import User
+
+    async def _seed():
+        async with session_maker() as session:
+            existing = await session.execute(select(User).where(User.id == user_id))
+            if existing.scalar_one_or_none() is not None:
+                return  # Pre-existing row from a prior run — reuse it.
+            session.add(
+                User(
+                    id=user_id,
+                    email="test@example.com",
+                    password_hash="$2b$12$test_hash_for_testing_only",
+                    is_verified=True,
+                    subscription_tier="free",
+                )
+            )
+            try:
+                await session.commit()
+            except Exception:
+                # Race with another fixture invocation seeding the same row,
+                # or a stale row left behind. Either way the row exists now,
+                # which is all the FK constraint cares about.
+                await session.rollback()
+
+    _run_async_in_sync_fixture(_seed())
+
+
+def _cleanup_mock_auth_user(session_maker, user_id):
+    """Remove the seeded mock auth user (Issue #1470).
+
+    The FK on ``usage_records.user_id`` is ``ON DELETE CASCADE``, so any
+    rows the test created via ``MeteringService`` are cleaned up
+    transitively. Best-effort: failures here must not mask the test
+    result, so we swallow exceptions.
+    """
+    from sqlalchemy import delete
+    from db.models import UsageRecord, User
+
+    async def _cleanup():
+        async with session_maker() as session:
+            try:
+                # Explicit delete of usage_records first — defensive against
+                # any DB whose FK does not honour ON DELETE CASCADE (e.g. a
+                # SQLite engine without PRAGMA foreign_keys=ON registered).
+                await session.execute(delete(UsageRecord).where(UsageRecord.user_id == user_id))
+                await session.execute(delete(User).where(User.id == user_id))
+                await session.commit()
+            except Exception:
+                await session.rollback()
+
+    try:
+        _run_async_in_sync_fixture(_cleanup())
+    except Exception:
+        # Swallow — cleanup must never fail a passing test.
+        pass
+
+
 @pytest.fixture
 def client():
     """Create a test client for the FastAPI app with clean database per test."""
@@ -373,6 +454,7 @@ def client():
         # exercise authentication. We auto-bypass ``get_current_user`` so they
         # keep working; tests that need to assert auth behaviour explicitly
         # remove this override.
+        _mock_user_id = None
         try:
             from api._authz import get_current_user as _authz_get_current_user
             import uuid as _uuid
@@ -380,20 +462,38 @@ def client():
             # Issue #1417: id must be a UUID instance (not str) so the SQLAlchemy
             # UUID column processor's ``.hex`` access works in code paths that
             # query by user_id (e.g. metering_service).
+            _mock_user_id = _uuid.UUID("11111111-1111-4111-a111-111111111111")
             _test_user = MagicMock()
-            _test_user.id = _uuid.UUID("11111111-1111-4111-a111-111111111111")
+            _test_user.id = _mock_user_id
             _test_user.email = "test@example.com"
             _test_user.subscription_tier = "free"
             app.dependency_overrides[_authz_get_current_user] = lambda: _test_user
         except ImportError:  # pragma: no cover - defensive
             pass
 
-        # Create TestClient - init_db will be mocked since we already initialized it
-        with TestClient(app) as test_client:
-            yield test_client
+        # Issue #1470: Seed the mocked auth user into the real database so
+        # FK-constrained writes (e.g. metering_service writing usage_records,
+        # which has ``user_id REFERENCES users.id``) don't blow up under
+        # real PostgreSQL. SQLite previously tolerated the dangling reference
+        # because PRAGMA foreign_keys=ON is defined in this conftest but
+        # never registered as an event listener — the nightly real-services
+        # job surfaced the bug. Idempotent: an existing row from a prior
+        # crashed run is reused. Teardown deletes the row (cascades to
+        # usage_records via ON DELETE CASCADE on the FK) to keep tests
+        # isolated.
+        if _mock_user_id is not None:
+            _seed_mock_auth_user(test_session_maker, _mock_user_id)
 
-        # Clean up dependency override
-        app.dependency_overrides.clear()
+        try:
+            # Create TestClient - init_db will be mocked since we already initialized it
+            with TestClient(app) as test_client:
+                yield test_client
+        finally:
+            if _mock_user_id is not None:
+                _cleanup_mock_auth_user(test_session_maker, _mock_user_id)
+
+            # Clean up dependency override
+            app.dependency_overrides.clear()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Why

`backend/src/tests/integration/test_conversions_api_v1.py::TestConversionsAPI::test_create_conversion_large_file_validation` was excluded from the nightly real-services job because it failed with:

```
sqlalchemy.exc.IntegrityError: ForeignKeyViolationError:
insert or update on table "usage_records" violates foreign key constraint
"usage_records_user_id_fkey"
DETAIL:  Key (user_id)=(11111111-1111-4111-a111-111111111111) is not present
in table "users".
```

That exclusion masks every other regression that *this same test* (and any other ``client``-fixture test that triggers metering) might catch on real PostgreSQL — a class of bugs we want the nightly to surface, not skip.

## Root cause

The shared ``client`` fixture in ``backend/src/tests/conftest.py`` overrides ``get_current_user`` with a ``MagicMock`` whose ``.id`` is the fixed UUID ``11111111-1111-4111-a111-111111111111``, but never inserts a corresponding row in the ``users`` table.

Two factors hid the bug from the SQLite PR-time path:

1. ``MeteringService.get_or_create_usage_record`` (called from ``POST /api/v1/conversions`` *before* file-type validation) writes a ``usage_records`` row keyed by ``user.id`` — and ``usage_records.user_id`` is ``REFERENCES users.id ON DELETE CASCADE``.
2. ``conftest.py`` defines ``_set_sqlite_pragma`` to enable ``PRAGMA foreign_keys=ON`` for SQLite, but that callback is **never registered as an SQLAlchemy ``event.listen`` listener**, so SQLite silently runs with FKs *off*. Real PostgreSQL has no such escape hatch.

## Fix

Modify the ``client`` fixture to seed the mock user idempotently on setup and remove it on teardown (cascades to ``usage_records``):

- ``_seed_mock_auth_user(...)`` — SELECT-then-INSERT, swallowing race-condition IntegrityErrors so two parallel test orchestrators (or a leftover row from a crashed prior run) cannot wedge the suite.
- ``_cleanup_mock_auth_user(...)`` — best-effort DELETE in a ``finally`` block; explicitly nukes ``usage_records`` first so we don't depend on ``ON DELETE CASCADE`` if a future engine config (or a SQLite-with-FK-off run) skips it.
- ``_run_async_in_sync_fixture(...)`` helper runs async DB work from the sync fixture inside a fresh, ephemeral event loop so we don't pollute pytest-asyncio's function-scoped loops.

### Why this option (vs the alternatives the issue lists)

| Option | Verdict | Reason |
|---|---|---|
| **Seed the user in the fixture (this PR)** | ✅ chosen | Single point of fix; protects every ``client``-using test from the same FK class of bug; zero application-code changes. |
| Switch the test to ``auth_headers`` / a DB-backed user fixture | ⚠️ rejected | Only fixes one test, leaves the same FK landmine for every other ``client``-using test that ever calls a metered endpoint. |
| Validate file size *before* the metering write | ❌ rejected | Reorders production validation flow so that free-tier users could probe quotas with malformed uploads without the metering counter incrementing. Behaviour change with security/billing implications, way out of scope for a test-fixture bug. |

## Evidence

Run against real PostgreSQL 15 + Redis 7 (Docker) using the same command shape as the nightly job, full integration suite minus ``test_ai_engine_contract.py`` (the other excluded test, owned by Worker-1469):

| | ``main`` | this branch |
|---|---|---|
| Real PG + Redis integration suite | **1 failed**, 173 passed, 49 skipped (FK violation) | **0 failed**, 174 passed, 49 skipped |
| SQLite-default integration suite (PR path) | 132 passed, 91 skipped | 132 passed, 91 skipped (byte-identical) |
| Unit suite | 3 failed (pre-existing, unrelated), 3445 passed, 85 skipped | 3 failed (same 3, pre-existing), 3445 passed, 85 skipped |

The 3 unit failures (``test_export_zip_sanitization``, ``test_get_job_success``, ``test_get_job_invalid_uuid``) reproduce on ``main`` with identical counts and are order-dependent failures unrelated to this work.

## Files changed

- ``backend/src/tests/conftest.py`` — fixture seed/cleanup + helpers (~106 LOC, 0 deletions of existing logic).
- ``.github/workflows/nightly.yml`` — drop the ``--deselect=...test_create_conversion_large_file_validation`` line and update the surrounding comment.

## Acceptance criteria

- [x] Test passes with ``TEST_DATABASE_URL=postgresql+asyncpg://...`` and ``USE_REAL_SERVICES=1``.
- [x] Nightly ``--deselect=...test_create_conversion_large_file_validation`` removed.
- [x] No regression in the SQLite PR integration path (132/132 still pass).
- [x] No regression in the broader real-services suite (174/174 pass with this PR vs 173/174 on main).

Closes #1470