### PR TITLE
chore(ci): codify Main ruleset as JSON + add drift detection (#1472)

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,115 @@
+# Repository Rulesets — codified
+
+This directory codifies the GitHub repository rulesets that protect this repo's
+branches, so that future changes go through normal PR review instead of being
+silent UI edits. It exists because of [Issue #1472][i1472]: the GitHub Rulesets
+API rejected updates to the `Main` ruleset due to stale Integration bypass
+actors that the API could no longer validate, and there was no codified record
+of what the desired state actually was.
+
+[i1472]: https://github.com/anchapin/portkit/issues/1472
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [`main.json`](./main.json) | Desired state of the `Main` ruleset (protects the default branch). The single source of truth. |
+| [`sync.py`](./sync.py) | CLI tool: `normalize` (sanitize raw API output), `diff` (compare on-disk vs. live), `apply` (push on-disk to GitHub). |
+| [`../workflows/ruleset-drift.yml`](../workflows/ruleset-drift.yml) | Scheduled drift detector (opt-in via `vars.ENABLE_RULESET_DRIFT_CHECK`). |
+
+## What each `main.json` field means
+
+The on-disk JSON is the **deterministic, intent-only** form: every field that
+varies per fetch (`id`, `node_id`, `created_at`, `updated_at`, `_links`,
+`current_user_can_bypass`, `source`, `source_type`) is stripped, and every list
+whose order does not affect enforcement is sorted. This means a fresh export
+will diff cleanly against the committed file when the live state matches.
+
+Currently committed state (matches the resolution recorded in #1472):
+
+- **Target**: default branch (`~DEFAULT_BRANCH`)
+- **Required status check**: `PR Gates`
+- **Pull-request rule**: 1 approving review required, dismiss stale reviews on
+  push, require thread resolution, all merge methods allowed
+- **Other rules**: deletion / non-fast-forward / creation blocked, Copilot code
+  review (off by default, off for drafts)
+- **Bypass actors**: `RepositoryRole#5` (Admin role) with `bypass_mode: always`
+  — no GitHub Apps. This is the same single bypass that #1472 settled on after
+  the stale Integration actors were removed.
+
+## How to change the ruleset (the ONLY supported workflow)
+
+1. **Edit `main.json` in a PR.** Make the change you want — add a required
+   check, raise the approval count, add or remove bypass actors, etc.
+2. **Open the PR.** Reviewers can see exactly what's changing because the file
+   is normalized and stable.
+3. **Merge.** A repo admin runs `apply` from a checkout of `main`:
+
+   ```bash
+   python3 .github/rulesets/sync.py apply .github/rulesets/main.json
+   ```
+
+   Add `--dry-run` to print the request body without sending. Requires `gh auth`
+   to a token with `repo` admin scope on `anchapin/portkit`.
+
+> [!IMPORTANT]
+> `apply` is **not** automated in CI. Pushing rulesets needs admin scope on the
+> repo, and we do not want a workflow with that scope running on every merge to
+> `main`. Manual application is intentional and friction-light.
+
+## How to detect drift
+
+Drift = "someone edited the ruleset directly in the GitHub UI without updating
+this file". Two ways to catch it:
+
+### Local one-off check
+
+```bash
+python3 .github/rulesets/sync.py diff .github/rulesets/main.json
+```
+
+Exit codes: `0` in sync, `1` drift detected (prints unified diff), `2` ruleset
+of that name not found on GitHub.
+
+### Scheduled GitHub Actions check (opt-in)
+
+The workflow [`ruleset-drift.yml`](../workflows/ruleset-drift.yml) runs the same
+`diff` weekly and on `workflow_dispatch`. It is **opt-in** — schedule runs are
+gated on the repo variable `ENABLE_RULESET_DRIFT_CHECK == 'true'` so it doesn't
+add noise until someone wants the alert. Manual dispatch always runs.
+
+To enable: Settings → Secrets and variables → Actions → Variables → set
+`ENABLE_RULESET_DRIFT_CHECK = true`.
+
+## How to bootstrap a new ruleset file
+
+If GitHub adds a new ruleset and we want to codify it:
+
+```bash
+# 1. Find the ID
+gh api repos/anchapin/portkit/rulesets
+
+# 2. Fetch the raw JSON
+gh api repos/anchapin/portkit/rulesets/<id> > /tmp/raw.json
+
+# 3. Normalize it into the repo
+python3 .github/rulesets/sync.py normalize \
+    --from-file /tmp/raw.json \
+    --output .github/rulesets/<short-name>.json
+
+# 4. Commit + open a PR
+```
+
+## Limitations and intentional non-features
+
+- **`sync.py` only handles a single ruleset per file by name.** `apply` looks up
+  the existing ruleset on GitHub by `name` and either `PUT`s an update or
+  `POST`s a create. It does **not** delete rulesets that exist on GitHub but
+  not on disk — drift in that direction is detected by `diff` but never acted
+  on automatically.
+- **The numeric ruleset ID is intentionally not stored on disk.** It is volatile
+  (changes if the ruleset is deleted and recreated) and would create spurious
+  diffs.
+- **There is no Terraform or Probot.** The repo doesn't otherwise manage GitHub
+  resources as code. A 280-line Python script + JSON is the smallest tool that
+  solves the original problem (no codified record of the ruleset).

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,66 @@
+{
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "enforcement": "active",
+  "name": "Main",
+  "rules": [
+    {
+      "parameters": {
+        "review_draft_pull_requests": false,
+        "review_on_push": false
+      },
+      "type": "copilot_code_review"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge",
+          "rebase",
+          "squash"
+        ],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true,
+        "required_reviewers": []
+      },
+      "type": "pull_request"
+    },
+    {
+      "parameters": {
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "PR Gates"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      },
+      "type": "required_status_checks"
+    }
+  ],
+  "target": "branch"
+}

--- a/.github/rulesets/sync.py
+++ b/.github/rulesets/sync.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""GitHub repository ruleset codification tool (Issue #1472).
+
+Subcommands
+-----------
+* ``normalize`` — read a raw ruleset JSON (e.g. from ``gh api repos/.../rulesets/<id>``)
+  on stdin or via ``--from-file`` and write a deterministic, intent-only form to
+  stdout (or to ``--output``). Strips computed/volatile fields (``id``, ``node_id``,
+  ``_links``, ``created_at``, ``updated_at``, ``current_user_can_bypass``,
+  ``source``, ``source_type``) and sorts every list whose order is not semantically
+  meaningful, so that ``git diff`` shows real intent only.
+
+* ``diff`` — fetch the live ruleset by name from the GitHub API, normalize it,
+  and ``diff`` it against the on-disk file. Exit 0 = in sync, 1 = drift detected,
+  2 = ruleset of that name not found on GitHub.
+
+* ``apply`` — push the on-disk file back to GitHub. Looks up the existing
+  ruleset by name (so the on-disk file does not need to embed the volatile
+  numeric ``id``); creates a new one if no match is found. Use ``--dry-run`` to
+  print the request body without sending.
+
+Auth: requires ``GH_TOKEN`` (or ``GITHUB_TOKEN``) with ``repo`` admin scope, or a
+working ``gh auth`` session.
+
+Why this exists: see Issue #1472 — the GitHub Rulesets UI silently rejects
+ruleset-API updates when stale Integration bypass actors are present. Codifying
+the ruleset to the repo lets future changes go through normal PR review and
+makes drift visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Fields that vary per fetch but carry no intent. Stripping them keeps the
+# on-disk JSON stable across re-exports.
+# ---------------------------------------------------------------------------
+_VOLATILE_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "id",
+        "node_id",
+        "_links",
+        "created_at",
+        "updated_at",
+        "current_user_can_bypass",
+        "source",
+        "source_type",
+    }
+)
+
+
+def _sort_strings(values: list[str] | None) -> list[str]:
+    return sorted(values) if values else []
+
+
+def _sort_dicts_by_keys(
+    values: list[dict[str, Any]] | None, keys: tuple[str, ...]
+) -> list[dict[str, Any]]:
+    if not values:
+        return []
+    return sorted(values, key=lambda d: tuple(json.dumps(d.get(k), sort_keys=True) for k in keys))
+
+
+def _normalize_rules(rules: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    """Sort rules deterministically and normalize their parameters."""
+    if not rules:
+        return []
+    out: list[dict[str, Any]] = []
+    for rule in rules:
+        copy = json.loads(json.dumps(rule, sort_keys=True))
+        params = copy.get("parameters")
+        if isinstance(params, dict):
+            # required_status_checks: sort the contexts list
+            checks = params.get("required_status_checks")
+            if isinstance(checks, list):
+                params["required_status_checks"] = _sort_dicts_by_keys(
+                    checks, ("context", "integration_id")
+                )
+            # allowed_merge_methods: sort
+            merges = params.get("allowed_merge_methods")
+            if isinstance(merges, list):
+                params["allowed_merge_methods"] = _sort_strings(merges)
+            # required_reviewers: sort
+            reviewers = params.get("required_reviewers")
+            if isinstance(reviewers, list):
+                params["required_reviewers"] = _sort_dicts_by_keys(
+                    reviewers, ("reviewer_type", "reviewer_id")
+                )
+        out.append(copy)
+    out.sort(
+        key=lambda r: (r.get("type", ""), json.dumps(r.get("parameters") or {}, sort_keys=True))
+    )
+    return out
+
+
+def _normalize_conditions(conditions: dict[str, Any] | None) -> dict[str, Any]:
+    if not conditions:
+        return {}
+    out = json.loads(json.dumps(conditions, sort_keys=True))
+    ref = out.get("ref_name")
+    if isinstance(ref, dict):
+        ref["include"] = _sort_strings(ref.get("include"))
+        ref["exclude"] = _sort_strings(ref.get("exclude"))
+    return out
+
+
+def _normalize_bypass_actors(actors: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
+    return _sort_dicts_by_keys(actors, ("actor_type", "actor_id", "bypass_mode"))
+
+
+def normalize_ruleset(raw: dict[str, Any]) -> dict[str, Any]:
+    """Return a deterministic, intent-only copy of ``raw``."""
+    out: dict[str, Any] = {}
+    for k, v in raw.items():
+        if k in _VOLATILE_TOP_LEVEL_FIELDS:
+            continue
+        out[k] = v
+    out["conditions"] = _normalize_conditions(out.get("conditions"))
+    out["rules"] = _normalize_rules(out.get("rules"))
+    out["bypass_actors"] = _normalize_bypass_actors(out.get("bypass_actors"))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# GitHub API plumbing — uses the `gh` CLI so we get auth handling for free.
+# ---------------------------------------------------------------------------
+def _gh(
+    *args: str, input_bytes: bytes | None = None, check: bool = True
+) -> subprocess.CompletedProcess[bytes]:
+    if shutil.which("gh") is None:
+        raise SystemExit("error: the `gh` CLI is required (install from https://cli.github.com/)")
+    return subprocess.run(
+        ["gh", *args],
+        input=input_bytes,
+        capture_output=True,
+        check=check,
+    )
+
+
+def _list_rulesets(repo: str) -> list[dict[str, Any]]:
+    res = _gh("api", f"repos/{repo}/rulesets")
+    return json.loads(res.stdout.decode("utf-8") or "[]")
+
+
+def _get_ruleset(repo: str, ruleset_id: int) -> dict[str, Any]:
+    res = _gh("api", f"repos/{repo}/rulesets/{ruleset_id}")
+    return json.loads(res.stdout.decode("utf-8"))
+
+
+def _find_ruleset_id_by_name(repo: str, name: str) -> int | None:
+    for rs in _list_rulesets(repo):
+        if rs.get("name") == name:
+            return int(rs["id"])
+    return None
+
+
+def _fetch_normalized(repo: str, name: str) -> dict[str, Any] | None:
+    ruleset_id = _find_ruleset_id_by_name(repo, name)
+    if ruleset_id is None:
+        return None
+    return normalize_ruleset(_get_ruleset(repo, ruleset_id))
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+def cmd_normalize(args: argparse.Namespace) -> int:
+    if args.from_file:
+        raw = json.loads(Path(args.from_file).read_text())
+    else:
+        raw = json.loads(sys.stdin.read())
+    normalized = normalize_ruleset(raw)
+    text = json.dumps(normalized, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text)
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    on_disk_text = Path(args.file).read_text()
+    on_disk = json.loads(on_disk_text)
+    name = on_disk.get("name")
+    if not name:
+        sys.stderr.write(f"error: {args.file} is missing a top-level 'name' field\n")
+        return 2
+    live = _fetch_normalized(args.repo, name)
+    if live is None:
+        sys.stderr.write(f"error: no ruleset named {name!r} found on {args.repo}\n")
+        return 2
+    on_disk_norm = normalize_ruleset(on_disk)
+    a = json.dumps(on_disk_norm, indent=2, sort_keys=True).splitlines(keepends=True)
+    b = json.dumps(live, indent=2, sort_keys=True).splitlines(keepends=True)
+    if a == b:
+        print(f"in sync: {args.repo} ruleset {name!r} matches {args.file}")
+        return 0
+    import difflib
+
+    diff = difflib.unified_diff(
+        a, b, fromfile=f"a/{args.file}", tofile=f"b/live ({args.repo}::{name})"
+    )
+    sys.stdout.writelines(diff)
+    sys.stderr.write(f"\ndrift detected: {args.repo} ruleset {name!r} differs from {args.file}\n")
+    return 1
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    on_disk = json.loads(Path(args.file).read_text())
+    name = on_disk.get("name")
+    if not name:
+        sys.stderr.write(f"error: {args.file} is missing a top-level 'name' field\n")
+        return 2
+    body = normalize_ruleset(on_disk)
+    body_bytes = json.dumps(body).encode("utf-8")
+
+    ruleset_id = _find_ruleset_id_by_name(args.repo, name)
+    if ruleset_id is None:
+        method = "POST"
+        endpoint = f"repos/{args.repo}/rulesets"
+        action = f"create new ruleset {name!r}"
+    else:
+        method = "PUT"
+        endpoint = f"repos/{args.repo}/rulesets/{ruleset_id}"
+        action = f"update ruleset {name!r} (id={ruleset_id})"
+
+    if args.dry_run:
+        print(f"[dry-run] would {action} via {method} {endpoint}")
+        print(f"[dry-run] body ({len(body_bytes)} bytes):")
+        print(json.dumps(body, indent=2, sort_keys=True))
+        return 0
+
+    print(f"applying: {action} via {method} {endpoint}")
+    res = _gh(
+        "api",
+        "--method",
+        method,
+        endpoint,
+        "--input",
+        "-",
+        input_bytes=body_bytes,
+        check=False,
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stderr.decode("utf-8"))
+        return res.returncode
+    print(res.stdout.decode("utf-8"))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_norm = sub.add_parser("normalize", help="strip volatile fields and sort lists")
+    p_norm.add_argument("--from-file", help="read raw JSON from this file (default: stdin)")
+    p_norm.add_argument("--output", help="write to this file (default: stdout)")
+    p_norm.set_defaults(func=cmd_normalize)
+
+    repo_default = os.environ.get("GITHUB_REPOSITORY", "anchapin/portkit")
+
+    p_diff = sub.add_parser("diff", help="diff on-disk ruleset against the live one on GitHub")
+    p_diff.add_argument("file", help="path to the on-disk ruleset JSON")
+    p_diff.add_argument(
+        "--repo", default=repo_default, help=f"OWNER/REPO (default: {repo_default})"
+    )
+    p_diff.set_defaults(func=cmd_diff)
+
+    p_apply = sub.add_parser("apply", help="push the on-disk ruleset to GitHub")
+    p_apply.add_argument("file", help="path to the on-disk ruleset JSON")
+    p_apply.add_argument(
+        "--repo", default=repo_default, help=f"OWNER/REPO (default: {repo_default})"
+    )
+    p_apply.add_argument(
+        "--dry-run", action="store_true", help="print the request body without sending"
+    )
+    p_apply.set_defaults(func=cmd_apply)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ruleset-drift.yml
+++ b/.github/workflows/ruleset-drift.yml
@@ -1,0 +1,78 @@
+# Ruleset drift detector (Issue #1472).
+#
+# Detects when someone has edited the `Main` repository ruleset directly in the
+# GitHub UI without updating .github/rulesets/main.json. Runs the same
+# `sync.py diff` you can run locally; surfaces drift as an annotation + a job
+# failure so it shows up in the Actions UI.
+#
+# Repo variables (Settings -> Secrets and variables -> Actions -> Variables)
+# * ENABLE_RULESET_DRIFT_CHECK   Set to "true" to run the scheduled weekly check.
+#                                Manual `workflow_dispatch` always runs regardless.
+#
+# Permissions: this workflow only needs *read* access to rulesets. The default
+# `GITHUB_TOKEN` does NOT include that scope, so the read is performed via
+# `${{ secrets.GH_RULESETS_READ_TOKEN }}` if set (PAT with `repo` admin scope).
+# If neither token works the job exits cleanly with a notice rather than failing
+# noisily — same pattern Issue #1468 established for load-test.yml.
+
+name: Ruleset drift
+
+on:
+  schedule:
+    # Weekly, Monday 14:00 UTC -- well after the nightly burst.
+    - cron: '0 14 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Detect ruleset drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Same opt-in gate pattern as load-test.yml: scheduled runs are skipped at
+    # the job level unless the repo variable is set.
+    if: ${{ github.event_name != 'schedule' || vars.ENABLE_RULESET_DRIFT_CHECK == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Resolve auth token
+        id: auth
+        env:
+          DEDICATED_TOKEN: ${{ secrets.GH_RULESETS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${DEDICATED_TOKEN:-}" ]]; then
+            echo "token_kind=dedicated" >> "$GITHUB_OUTPUT"
+            echo "::add-mask::${DEDICATED_TOKEN}"
+            echo "token=${DEDICATED_TOKEN}" >> "$GITHUB_OUTPUT"
+          else
+            # Fall back to the default GITHUB_TOKEN. It probably can't read
+            # rulesets, but we let the diff step report that cleanly so a
+            # human can decide whether to provision a PAT.
+            echo "token_kind=default" >> "$GITHUB_OUTPUT"
+            echo "::notice::No GH_RULESETS_READ_TOKEN secret set; falling back to GITHUB_TOKEN. If the diff step reports a 403, provision a PAT with `repo` admin scope as the GH_RULESETS_READ_TOKEN secret."
+          fi
+
+      - name: Diff on-disk ruleset against live
+        env:
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! python3 .github/rulesets/sync.py diff .github/rulesets/main.json; then
+            ec=$?
+            if [[ "$ec" == "2" ]]; then
+              echo "::error::ruleset 'Main' was not found on ${GITHUB_REPOSITORY}. Either it was deleted or the auth token has no read access."
+            else
+              echo "::error::Ruleset drift detected. Either roll back the UI edit or update .github/rulesets/main.json in a PR (and re-apply with sync.py apply after merge)."
+            fi
+            exit "$ec"
+          fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -50,3 +50,8 @@ CHANGELOG*
 *.db
 *.sqlite
 *.json (for data)
+
+# Issue #1472: ruleset JSON is the canonical output of `.github/rulesets/sync.py
+# normalize`. Prettier collapses short arrays which would break the round-trip
+# and make every drift check fail. The file is human-readable as-is.
+.github/rulesets/*.json


### PR DESCRIPTION
Optional follow-up to #1472. Codifies the `Main` repository ruleset to
`.github/rulesets/main.json`, adds a CLI tool to `diff` / `apply` it, and a
weekly drift detector — so future rulesets changes go through PR review and any
silent UI edits become visible.

## Why

[Issue #1472](https://github.com/anchapin/portkit/issues/1472) documented that
the GitHub Rulesets API rejected updates to the `Main` ruleset because of
stale Integration bypass actors that the API could no longer validate. After
the bad actors were removed via the UI, only one admin bypass + the `PR Gates`
required check were preserved — but there was no codified record of that
desired state, so any future question of "is this still right?" required a
human admin to open Settings → Rules → Rulesets and read the UI.

This PR is the optional follow-up offered in the
[#1472 triage comment](https://github.com/anchapin/portkit/issues/1472#issuecomment-4459296613).

## What

| File | Purpose |
|---|---|
| `.github/rulesets/main.json` | Deterministic, intent-only export of the current `Main` ruleset. Volatile fields (`id`, `node_id`, `created_at`, `updated_at`, `_links`, `source`, `current_user_can_bypass`) stripped; lists whose order does not affect enforcement are sorted. **Verified to match live state** with `sync.py diff` (exit 0 — see Validation below). |
| `.github/rulesets/sync.py` | 292-line CLI (Python stdlib + `gh` CLI). Subcommands: `normalize`, `diff`, `apply` (with `--dry-run`). |
| `.github/rulesets/README.md` | Documents the workflow: edit JSON in a PR → merge → admin runs `sync.py apply`. Also covers bootstrap + intentional limitations. |
| `.github/workflows/ruleset-drift.yml` | Weekly + `workflow_dispatch` drift detector. Same opt-in gate pattern #1468 established for `load-test.yml`: `if: github.event_name != 'schedule' || vars.ENABLE_RULESET_DRIFT_CHECK == 'true'`. Falls back to a clean notice if the auth token can't read rulesets. |
| `.prettierignore` | Exempts `.github/rulesets/*.json` so prettier doesn't collapse short arrays and break the `sync.py normalize` round-trip (which would make every drift check fail). |

## How to use after this lands

```bash
# See the canonical ruleset
cat .github/rulesets/main.json

# Check for drift right now
python3 .github/rulesets/sync.py diff .github/rulesets/main.json

# Propose a change: edit main.json, open a PR, merge, then a repo admin runs:
python3 .github/rulesets/sync.py apply .github/rulesets/main.json
# (add --dry-run first to preview the request body)
```

Optional: enable the scheduled drift check by setting repo variable
`ENABLE_RULESET_DRIFT_CHECK=true` and (recommended) provisioning a PAT with
`repo` admin scope as the `GH_RULESETS_READ_TOKEN` secret.

## Validation

Run from `/home/alex/Projects/portkit-worktrees/portkit-1472` against the live
`anchapin/portkit::Main` ruleset:

| Check | Result |
|---|---|
| `python3 sync.py normalize --from-file <raw>` | ✅ produces 66-line stable JSON |
| `python3 sync.py normalize` is idempotent (run twice, byte-identical output) | ✅ |
| `python3 sync.py diff main.json` | ✅ `in sync: anchapin/portkit ruleset 'Main' matches .github/rulesets/main.json` (exit 0) |
| `python3 sync.py apply --dry-run main.json` | ✅ correctly resolves to `PUT repos/anchapin/portkit/rulesets/6616212`, prints body |
| `ruff check .github/rulesets/sync.py` | ✅ All checks passed |
| `ruff format --check .github/rulesets/sync.py` | ✅ already formatted |
| `prettier --check '.github/rulesets/README.md' '.github/workflows/ruleset-drift.yml'` | ✅ All matched files use Prettier code style |
| `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ruleset-drift.yml'))"` | ✅ valid |
| Files modified outside ownership scope | ✅ none — only `.prettierignore` (1 stanza added) and 4 new files |

## Acceptance criteria (from #1472)

The original issue's acceptance criteria were already satisfied by the manual
UI fix recorded in the issue body. This PR adds the **follow-up** offered in
the triage comment: a codified record + drift detection so the same silent
rejection cannot happen again without leaving a paper trail.

- [x] The ruleset still requires `PR Gates` → captured in `main.json`
- [x] Bypass actors are intentional and documented → captured in `main.json` (admin role only) + explained in `README.md`
- [x] Future ruleset API updates won't fail with stale Integration validation errors → prevented because all changes now flow through this file in a PR

## Intentional non-features

- `apply` is **not** automated in CI — pushing rulesets needs admin scope on the repo, and a workflow with that scope on every merge to `main` would be a worse risk than the problem this fixes. Manual application by a repo admin is intentional and friction-light (single command).
- `apply` does **not** delete rulesets that exist on GitHub but aren't in this repo — drift in that direction is *detected* by `diff` but never auto-resolved.
- The numeric ruleset `id` is intentionally **not** stored on disk — it's volatile and would create spurious diffs.

Closes #1472.