### PR TITLE
fix(frontend): bump dompurify 3.4.0 → 3.4.3 for CVE remediation (#1481)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "pnpm": {
     "overrides": {
       "form-data@>=4.0.0 <4.0.4": ">=4.0.4",
-      "dompurify": "3.4.0",
+      "dompurify": "3.4.3",
       "uuid": "11.1.1",
       "postcss": "8.5.10",
       "lodash-es": "4.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   form-data@>=4.0.0 <4.0.4: '>=4.0.4'
-  dompurify: 3.4.0
+  dompurify: 3.4.3
   uuid: 11.1.1
   postcss: 8.5.10
   lodash-es: 4.18.1
@@ -2872,8 +2872,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.4.3:
+    resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -7995,7 +7995,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.0:
+  dompurify@3.4.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9216,7 +9216,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.0
+      dompurify: 3.4.3
       katex: 0.16.45
       khroma: 2.1.0
       lodash-es: 4.18.1
@@ -9266,7 +9266,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.0
+      dompurify: 3.4.3
       marked: 14.0.0
 
   mrmime@2.0.1: {}


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update pnpm override for dompurify from 3.4.0 to 3.4.3 and refresh the lockfile accordingly.