### PR TITLE
fix(security): pin pip >= 26.1 for CVE fixes (#1482)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Bandit
-        run: pip install --timeout=300 bandit
+        run: pip install --upgrade "pip>=26.1" && pip install --timeout=300 bandit
 
       - name: Run Bandit SAST
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy and install backend dependencies
 COPY backend/requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 
 # ============================================
@@ -37,7 +37,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy and install ai-engine dependencies
 COPY ai-engine/requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 
 # ============================================

--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -29,7 +29,7 @@ COPY ai-engine/requirements.txt /tmp/ai-engine-requirements.txt
 # Install all Python dependencies in one go to avoid conflicts
 # Build arg to force cache bust when dependencies change
 ARG CACHE_BUST=20250422_ssl
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+RUN pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel && \
     pip install --no-cache-dir -r /tmp/backend-requirements.txt && \
     pip install --no-cache-dir -r /tmp/ai-engine-requirements.txt
 

--- a/Dockerfile.fly.optimized
+++ b/Dockerfile.fly.optimized
@@ -44,7 +44,7 @@ RUN echo "# Combined requirements\n" \
 
 # Use cache mount for pip - massive speedup on subsequent builds
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel && \
     pip install --no-cache-dir -r /tmp/all-requirements.txt
 
 # =============================================================================

--- a/ai-engine/Dockerfile
+++ b/ai-engine/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy requirements first for better caching
 COPY requirements.txt /app/
+RUN pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code

--- a/ai-engine/Dockerfile.cpu
+++ b/ai-engine/Dockerfile.cpu
@@ -19,7 +19,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY pyproject.toml README.md /tmp/
 COPY . /tmp/
 
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel
 # Install all dependencies, including CPU-only extras, from pyproject.toml
 RUN pip install --no-cache-dir .[cpu-only]
 

--- a/ai-engine/services/Dockerfile.runpod
+++ b/ai-engine/services/Dockerfile.runpod
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install vLLM, transformers, huggingface libs
+RUN pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel
 RUN pip install --no-cache-dir \
         vllm>=0.6.0 \
         transformers>=4.44.0 \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy requirements and install dependencies
 COPY requirements.txt .
-RUN pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Production stage

--- a/docker/base-images/Dockerfile.python-base
+++ b/docker/base-images/Dockerfile.python-base
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/tmp/*
 
 # Upgrade pip and install build tools
-RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN python -m pip install --no-cache-dir --upgrade "pip>=26.1" setuptools wheel
 
 # Copy requirements from both services
 COPY ai-engine/requirements.txt /tmp/ai-engine-requirements.txt


### PR DESCRIPTION
- Replace unpinned 'pip install --upgrade pip' with 'pip>=26.1' across all
  Dockerfiles and the security workflow
- Add pip upgrade step to ai-engine/Dockerfile and runpod Dockerfile (previously missing)
- Covers: Dockerfile, Dockerfile.fly, Dockerfile.fly.optimized,
  backend/Dockerfile, ai-engine/Dockerfile, ai-engine/Dockerfile.cpu,
  ai-engine/services/Dockerfile.runpod, docker/base-images/Dockerfile.python-base,
  .github/workflows/security.yml
