### PR TITLE
fix(security): sanitize user-controlled data in console.log to prevent log injection (CodeQL #76,#77,#78)

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 /**
  * Dashboard Page - Day 5 Enhancement
+import { sanitizeForLog } from '../utils/sanitizeLog';
  * Comprehensive dashboard with conversion, history, and management features
  */
 
@@ -26,7 +27,7 @@ export const Dashboard: React.FC = () => {
   // Handle conversion start with filename
   const handleConversionStart = useCallback(
     (jobId: string, filename: string) => {
-      console.log('Conversion started:', jobId, 'File:', filename);
+      console.log('Conversion started:', sanitizeForLog(jobId), 'File:', sanitizeForLog(filename));
 
       // Add to history with filename
       addConversion({
@@ -46,7 +47,7 @@ export const Dashboard: React.FC = () => {
   // Handle conversion completion
   const handleConversionComplete = useCallback(
     (jobId: string) => {
-      console.log('Conversion completed:', jobId);
+      console.log('Conversion completed:', sanitizeForLog(jobId));
 
       // Update conversion status
       updateConversion(jobId, {
@@ -64,7 +65,7 @@ export const Dashboard: React.FC = () => {
   // Handle conversion failure
   const handleConversionFailed = useCallback(
     (jobId: string, error: string) => {
-      console.log('Conversion failed:', jobId, 'Error:', error);
+      console.log('Conversion failed:', sanitizeForLog(jobId), 'Error:', sanitizeForLog(error));
 
       // Update conversion status
       updateConversion(jobId, {

--- a/frontend/src/pages/EditorPage.tsx
+++ b/frontend/src/pages/EditorPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react'; // Added useCallback
 import { useParams, useLocation } from 'react-router-dom';
+import { sanitizeForLog } from '../utils/sanitizeLog';
 import { EditorProvider, useEditorContext } from '../context/EditorContext';
 import * as api from '../services/api'; // Added api import
 import {
@@ -38,7 +39,7 @@ const EditorPageContent: React.FC = () => {
   useEffect(() => {
     if (addonId && !isBehaviorEditorMode) {
       console.log(
-        `EditorPage: useEffect detected addonId: ${addonId}, calling loadAddon.`
+        `EditorPage: useEffect detected addonId: ${sanitizeForLog(addonId)}, calling loadAddon.`
       );
       loadAddon(addonId);
     }

--- a/frontend/src/pages/ResultsPage.tsx
+++ b/frontend/src/pages/ResultsPage.tsx
@@ -1,5 +1,6 @@
 /**
  * Results Page for portkit Beta
+import { sanitizeForLog } from '../utils/sanitizeLog';
  * Display conversion results and download options
  */
 
@@ -81,7 +82,7 @@ export const ResultsPage: React.FC = () => {
   const handleFeedback = async (type: 'thumbs_up' | 'thumbs_down') => {
     setFeedback(type);
     // TODO: Submit feedback to API
-    console.log('Feedback submitted:', type, jobId);
+    console.log('Feedback submitted:', type, sanitizeForLog(jobId));
   };
 
   if (loading) {

--- a/frontend/src/utils/sanitizeLog.ts
+++ b/frontend/src/utils/sanitizeLog.ts
@@ -1,0 +1,10 @@
+/**
+ * Sanitizes user-controlled values before logging to prevent log injection.
+ * Strips control characters (newlines, carriage returns, tabs) that could
+ * be used to forge log entries.
+ */
+export function sanitizeForLog(value: unknown): string {
+  if (value == null) return '';
+  const str = String(value);
+  return str.replace(/[\r\n\t]/g, ' ');
+}


### PR DESCRIPTION
- Add sanitizeForLog utility that strips CR/LF/TAB from values
- Apply to Dashboard.tsx (jobId, filename, error in conversion callbacks)
- Apply to EditorPage.tsx (addonId from URL params)
- Apply to ResultsPage.tsx (jobId from URL params)
