### PR TITLE
fix(backend): replace Celery --concurrency with --autoscale=8,2

### DIFF
--- a/backend/src/services/celery_config.py
+++ b/backend/src/services/celery_config.py
@@ -49,7 +49,8 @@ celery_app.conf.update(
     task_track_started=True,
     task_time_limit=3600,
     task_soft_time_limit=3300,
-    worker_prefetch_multiplier=4,
+    worker_autoscale=(8, 2),
+    worker_prefetch_multiplier=1,
     worker_max_tasks_per_child=1000,
     result_expires=86400,
     task_routes={

--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ primary_region = 'iad'
 
 [processes]
   app = '/startup.sh'
-  worker = "sh -c 'cd /app/backend && PYTHONPATH=/usr/lib/python3.11/site-packages:/app/backend/src python -m celery -A src.services.celery_config worker --loglevel=info'"
+  worker = "sh -c 'cd /app/backend && PYTHONPATH=/usr/lib/python3.11/site-packages:/app/backend/src python -m celery -A src.services.celery_config worker --loglevel=info --autoscale=8,2'"
 
 [[mounts]]
   source = 'portkit_data'


### PR DESCRIPTION
## Summary

Replaces fixed Celery worker concurrency with dynamic autoscaling (closes #1492).

### Changes
- **fly.toml**: Added `--autoscale=8,2` to the Celery worker command (max 8 workers, min 2)
- **celery_config.py**: Added `worker_autoscale=(8, 2)` config and reduced `worker_prefetch_multiplier` from 4 to 1 for better autoscaling behavior

### Why
Autoscaling allows the worker pool to shrink during idle periods (saving resources) and grow up to 8 during peak load, instead of always running a fixed 4 workers.

### Testing
- [x] Config changes are syntactically valid
- [ ] Deploy to staging and verify worker starts correctly
- [ ] Monitor worker pool scaling under load