### PR TITLE
feat(infra): extract AI Engine to separate Fly.io app (portkit-ai-engine)

### DIFF
--- a/Dockerfile.fly
+++ b/Dockerfile.fly
@@ -1,5 +1,6 @@
 # Multi-stage Dockerfile optimized for Fly.io deployment
-# Builds all services in one container for simplified deployment
+# Builds backend + frontend services in one container
+# AI Engine can run in monolith mode or as a separate Fly.io app (portkit-ai-engine)
 
 # Frontend build stage
 FROM node:25-alpine AS frontend-builder
@@ -37,9 +38,9 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
 FROM debian:bookworm-slim
 WORKDIR /app
 
-# Install Nginx, Python, and build dependencies
+# Install Nginx, Python, gettext (for envsubst), and build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nginx curl postgresql-client redis python3 python3-pip python3-dev gcc g++ \
+    nginx curl postgresql-client redis python3 python3-pip python3-dev gcc g++ gettext-base \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf python3 /usr/bin/python
 
@@ -54,8 +55,8 @@ COPY ai-engine/ /app/ai-engine/
 COPY backend/src/alembic.ini /app/backend/alembic.ini
 COPY --from=frontend-builder /app/frontend/dist /usr/share/nginx/html
 
-# Copy nginx configuration
-COPY nginx-fly.conf /etc/nginx/nginx.conf
+# Copy nginx configuration template (envsubst renders it at startup)
+COPY nginx-fly.conf.template /etc/nginx/nginx.conf.template
 
 # Create non-root user and symlink app data directories to mounted volume
 RUN groupadd -g 1001 appuser && \
@@ -77,6 +78,6 @@ COPY scripts/fly-startup.sh /startup.sh
 COPY scripts/run-migrations.sh /app/scripts/run-migrations.sh
 RUN chmod +x /startup.sh /app/scripts/run-migrations.sh
 
-EXPOSE 80 443 8000 8001
+EXPOSE 80 443
 
 CMD ["/startup.sh"]

--- a/Dockerfile.fly.ai-engine
+++ b/Dockerfile.fly.ai-engine
@@ -1,0 +1,47 @@
+# Dockerfile.fly.ai-engine — Standalone AI Engine for Fly.io
+# Used by fly.ai-engine.toml to deploy the AI Engine as a separate app.
+#
+# Build context must be repo root (not ai-engine/) so we can COPY ai-engine/.
+
+# Python dependencies build stage
+FROM python:3.12-slim AS python-builder
+WORKDIR /tmp
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc g++ && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY ai-engine/requirements.txt /tmp/requirements.txt
+
+ARG CACHE_BUST=20250515
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    pip install --no-cache-dir -r /tmp/requirements.txt
+
+# Production stage
+FROM python:3.12-slim
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl libmagic1 libgomp1 ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=python-builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=python-builder /usr/local/bin /usr/local/bin
+
+COPY ai-engine/ /app/
+
+ENV PYTHONPATH=/app
+ENV PYTHONDONTWRITEBYTECODE=1
+
+RUN mkdir -p /app/conversion_outputs /app/logs && \
+    groupadd -g 1001 appuser && \
+    useradd -u 1001 -g appuser -m appuser && \
+    chown -R appuser:appuser /app
+
+USER appuser
+
+EXPOSE 8001
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8001/health/liveness || exit 1
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001", "--workers", "1", "--access-log"]

--- a/fly-staging.toml
+++ b/fly-staging.toml
@@ -27,6 +27,8 @@ primary_region = "iad"
   PYTHONUNBUFFERED = "1"
   ENVIRONMENT = "staging"
   LOG_LEVEL = "DEBUG"
+  AI_ENGINE_EXTRACTED = "1"
+  AI_ENGINE_UPSTREAM = "portkit-ai-engine-staging.internal:8001"
 
 # Persistent volume for staging (smaller size)
 [mounts]

--- a/fly.ai-engine.toml
+++ b/fly.ai-engine.toml
@@ -1,0 +1,51 @@
+# fly.ai-engine.toml — Portkit AI Engine as a separate Fly.io app
+# Deploy with: flyctl deploy -c fly.ai-engine.toml
+#
+# Prerequisites:
+#   1. Create the app:    fly apps create portkit-ai-engine
+#   2. Create a Fly.io private network (6pn) for backend↔ai-engine communication
+#   3. Set secrets:       fly secrets set -a portkit-ai-engine OPENAI_API_KEY=... ANTHROPIC_API_KEY=...
+#   4. Deploy:            fly deploy -c fly.ai-engine.toml
+
+app = "portkit-ai-engine"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile.fly.ai-engine"
+
+[build.args]
+  PYTHON_VERSION = "3.12"
+
+[env]
+  PYTHONUNBUFFERED = "1"
+  PORT = "8001"
+
+[deploy]
+  strategy = "rolling"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 8001
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[services.ports]]
+    port = 80
+    handlers = ["http"]
+    force_https = true
+
+  [[services.ports]]
+    port = 443
+    handlers = ["tls", "http"]
+
+  [[services.checks]]
+    grace_period = "60s"
+    interval = "30s"
+    method = "get"
+    path = "/health/liveness"
+    port = 8001
+    timeout = "10s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory_mb = 2048

--- a/fly.toml
+++ b/fly.toml
@@ -14,6 +14,8 @@ primary_region = 'iad'
 
 [env]
   PYTHONUNBUFFERED = '1'
+  AI_ENGINE_EXTRACTED = '1'
+  AI_ENGINE_UPSTREAM = 'portkit-ai-engine.internal:8001'
 
 [processes]
   app = '/startup.sh'

--- a/nginx-fly.conf.template
+++ b/nginx-fly.conf.template
@@ -1,5 +1,8 @@
 # Nginx Fly.io Configuration for Portkit
 # Fly.io terminates TLS at the edge and forwards plain HTTP to this container on port 80
+#
+# This file is a template — envsubst replaces ${AI_ENGINE_UPSTREAM} at container startup.
+# Rendered to /etc/nginx/nginx.conf by fly-startup.sh.
 
 worker_processes auto;
 error_log /var/log/nginx/error.log warn;
@@ -77,11 +80,13 @@ http {
         }
 
         # ============================================
-        # AI Engine Proxy (must be before root location)
+        # AI Engine Proxy
+        # Extracted mode: AI_ENGINE_UPSTREAM=portkit-ai-engine.internal:8001
+        # Monolith mode:  AI_ENGINE_UPSTREAM=localhost:8001 (default)
         # ============================================
         location /ai-engine/ {
             rewrite ^/ai-engine/(.*) /$1 break;
-            proxy_pass http://localhost:8001;
+            proxy_pass http://${AI_ENGINE_UPSTREAM};
             proxy_http_version 1.1;
 
             proxy_set_header Host $host;

--- a/scripts/fly-startup.sh
+++ b/scripts/fly-startup.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 # Fly.io startup script for Portkit
+# Supports two modes:
+#   MONOLITH: AI Engine runs in the same container (AI_ENGINE_EXTRACTED unset or 0)
+#   EXTRACTED: AI Engine runs as a separate Fly.io app (AI_ENGINE_EXTRACTED=1)
 
 echo "🚀 Starting Portkit on Fly.io..."
+
+# Default AI Engine upstream for monolith mode
+export AI_ENGINE_UPSTREAM="${AI_ENGINE_UPSTREAM:-localhost:8001}"
+
+# Render nginx config from template (envsubst only replaces ${AI_ENGINE_UPSTREAM})
+echo "📝 Rendering nginx config (AI_ENGINE_UPSTREAM=${AI_ENGINE_UPSTREAM})..."
+envsubst '${AI_ENGINE_UPSTREAM}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
 # Start PostgreSQL if needed (or connect to external)
 if [ "$DATABASE_URL" = "" ]; then
@@ -42,21 +52,25 @@ python -m uvicorn src.main:app --host 0.0.0.0 --port 8000 --workers 1 2>&1 | sed
 BACKEND_PID=$!
 echo "Backend PID: $BACKEND_PID"
 
-# Start AI Engine
-echo "🤖 Starting AI Engine..."
-cd /app/ai-engine
-export PYTHONPATH=/usr/local/lib/python3.11/dist-packages:/app/ai-engine
-echo "PYTHONPATH=$PYTHONPATH"
-python -m uvicorn main:app --host 0.0.0.0 --port 8001 --workers 1 2>&1 | sed 's/^/[AI-ENGINE] /' &
-AI_PID=$!
-echo "AI Engine PID: $AI_PID"
+# Start AI Engine locally only in monolith mode
+if [ "$AI_ENGINE_EXTRACTED" = "1" ]; then
+    echo "🤖 AI Engine runs as a separate Fly.io app (portkit-ai-engine) — skipping local startup"
+else
+    echo "🤖 Starting AI Engine (monolith mode)..."
+    cd /app/ai-engine
+    export PYTHONPATH=/usr/local/lib/python3.11/dist-packages:/app/ai-engine
+    echo "PYTHONPATH=$PYTHONPATH"
+    python -m uvicorn main:app --host 0.0.0.0 --port 8001 --workers 1 2>&1 | sed 's/^/[AI-ENGINE] /' &
+    AI_PID=$!
+    echo "AI Engine PID: $AI_PID"
+fi
 
 # Wait for services to be ready
 echo "⏳ Waiting for services to start..."
 sleep 10
 
-# Check if services are healthy
-echo "🏥 Health checking services..."
+# Check if backend is healthy
+echo "🏥 Health checking backend..."
 for i in 1 2 3 4 5 6 7 8 9 10; do
     if curl -f http://localhost:8000/health > /dev/null 2>&1; then
         echo "✅ Backend API is healthy"
@@ -66,14 +80,27 @@ for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 5
 done
 
-for i in 1 2 3 4 5 6 7 8 9 10; do
-    if curl -f http://localhost:8001/health > /dev/null 2>&1; then
-        echo "✅ AI Engine is healthy"
-        break
-    fi
-    echo "⏳ Waiting for AI engine... attempt $i/10"
-    sleep 5
-done
+# Check AI Engine health (local or remote)
+if [ "$AI_ENGINE_EXTRACTED" = "1" ]; then
+    echo "🤖 Checking remote AI Engine health at ${AI_ENGINE_UPSTREAM}..."
+    for i in 1 2 3 4 5; do
+        if curl -f "http://${AI_ENGINE_UPSTREAM}/health/liveness" > /dev/null 2>&1; then
+            echo "✅ Remote AI Engine is healthy"
+            break
+        fi
+        echo "⏳ Waiting for remote AI engine... attempt $i/5"
+        sleep 5
+    done
+else
+    for i in 1 2 3 4 5 6 7 8 9 10; do
+        if curl -f http://localhost:8001/health > /dev/null 2>&1; then
+            echo "✅ AI Engine is healthy"
+            break
+        fi
+        echo "⏳ Waiting for AI engine... attempt $i/10"
+        sleep 5
+    done
+fi
 
 # Start Nginx
 echo "🌐 Starting Nginx..."
@@ -83,10 +110,17 @@ NGINX_PID=$!
 echo "🎉 Portkit is running!"
 echo "Frontend: http://localhost"
 echo "Backend: http://localhost:8000"
-echo "AI Engine: http://localhost:8001"
+if [ "$AI_ENGINE_EXTRACTED" = "1" ]; then
+    echo "AI Engine: http://${AI_ENGINE_UPSTREAM} (separate app)"
+else
+    echo "AI Engine: http://localhost:8001"
+fi
 
 # Keep the script running and handle signals
-trap "echo 'Stopping services...'; kill $BACKEND_PID $AI_PID $NGINX_PID 2>/dev/null; exit 0" TERM INT
-
-# Wait for any process to exit
-wait $BACKEND_PID $AI_PID $NGINX_PID
+if [ -n "${AI_PID:-}" ]; then
+    trap "echo 'Stopping services...'; kill $BACKEND_PID $AI_PID $NGINX_PID 2>/dev/null; exit 0" TERM INT
+    wait $BACKEND_PID $AI_PID $NGINX_PID
+else
+    trap "echo 'Stopping services...'; kill $BACKEND_PID $NGINX_PID 2>/dev/null; exit 0" TERM INT
+    wait $BACKEND_PID $NGINX_PID
+fi


### PR DESCRIPTION
- Add fly.ai-engine.toml: Fly.io config for standalone AI Engine app
- Add Dockerfile.fly.ai-engine: multi-stage Dockerfile for AI Engine only
  (Python 3.12, uvicorn, health check on /health/liveness)
- Convert nginx-fly.conf to nginx-fly.conf.template with envsubst
  placeholder  for dynamic upstream routing
- Update scripts/fly-startup.sh to support monolith vs extracted modes
  via AI_ENGINE_EXTRACTED env var, with envsubst rendering at startup
- Update fly.toml with AI_ENGINE_EXTRACTED=1 and
  AI_ENGINE_UPSTREAM=portkit-ai-engine.internal:8001
- Update fly-staging.toml similarly for staging environment
- Update Dockerfile.fly: add gettext-base for envsubst, remove EXPOSE 8001,
  copy template instead of static conf

Closes #1493
