### PR TITLE
chore(ci): ratchet backend coverage floor 40% → 50%

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,7 @@ env:
   # docs/ci/coverage-policy.md, with green CI. Lowering: rare; requires
   # explicit justification + reviewer sign-off (see policy doc).
   # ---------------------------------------------------------------------------
-  COVERAGE_FLOOR_BACKEND: '40'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
+  COVERAGE_FLOOR_BACKEND: '50'      # ratchet milestones: 50 → 60 → 70 → 80
   COVERAGE_FLOOR_AI_ENGINE: '65'    # ratchet milestones: 65 → 70 → 75 → 80
 
 jobs:


### PR DESCRIPTION
## Summary
- Update COVERAGE_FLOOR_BACKEND from 40 → 50 in `.github/workflows/pr.yml`
- Issue #1499: M1 promotion requires sustained ≥55% coverage

## Changes
- `.github/workflows/pr.yml`: Update COVERAGE_FLOOR_BACKEND env var

## Testing
- CI will enforce 50% coverage floor on backend tests

## Summary by Sourcery

CI:
- Raise the COVERAGE_FLOOR_BACKEND value in the PR GitHub Actions workflow from 40% to 50%.