### PR TITLE
chore(ci): ratchet AI Engine coverage floor 65% → 70% (#1497)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,7 @@ env:
   # docs/ci/coverage-policy.md, with green CI. Lowering: rare; requires
   # explicit justification + reviewer sign-off (see policy doc).
   # ---------------------------------------------------------------------------
-  COVERAGE_FLOOR_BACKEND: '40'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
+  COVERAGE_FLOOR_BACKEND: '50'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
   COVERAGE_FLOOR_AI_ENGINE: '70'    # ratchet milestones: 70 → 75 → 80
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ env:
   # explicit justification + reviewer sign-off (see policy doc).
   # ---------------------------------------------------------------------------
   COVERAGE_FLOOR_BACKEND: '40'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
-  COVERAGE_FLOOR_AI_ENGINE: '65'    # ratchet milestones: 65 → 70 → 75 → 80
+  COVERAGE_FLOOR_AI_ENGINE: '70'    # ratchet milestones: 70 → 75 → 80
 
 jobs:
   # ===========================================================================


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Raise the AI Engine coverage floor in the PR GitHub Actions workflow from 65% to 70%.