### PR TITLE
chore(ci): ratchet AI Engine coverage floor 65% → 70% (#1497)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,7 @@ env:
   # docs/ci/coverage-policy.md, with green CI. Lowering: rare; requires
   # explicit justification + reviewer sign-off (see policy doc).
   # ---------------------------------------------------------------------------
-  COVERAGE_FLOOR_BACKEND: '40'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
+  COVERAGE_FLOOR_BACKEND: '50'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
   COVERAGE_FLOOR_AI_ENGINE: '70'    # ratchet milestones: 70 → 75 → 80
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ env:
   # explicit justification + reviewer sign-off (see policy doc).
   # ---------------------------------------------------------------------------
   COVERAGE_FLOOR_BACKEND: '40'      # ratchet milestones: 40 → 50 → 60 → 70 → 80
-  COVERAGE_FLOOR_AI_ENGINE: '65'    # ratchet milestones: 65 → 70 → 75 → 80
+  COVERAGE_FLOOR_AI_ENGINE: '70'    # ratchet milestones: 70 → 75 → 80
 
 jobs:
   # ===========================================================================


### PR DESCRIPTION
## Summary
- Ratchet AI Engine coverage floor from 65% to 70%
- Part of ongoing coverage improvement initiative

## Changes
- :  changed from '65' to '70'

## Summary by Sourcery

Increase minimum test coverage thresholds enforced by the PR workflow.

Build:
- Raise backend coverage floor from 40% to 50% in the CI workflow configuration.
- Raise AI Engine coverage floor from 65% to 70% in the CI workflow configuration.