### PR TITLE
fix(ci): add pnpm install before vitest coverage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -389,7 +389,10 @@ jobs:
           test "$T" = 0 && test "$L" = 0
 
       - name: Unit tests (vitest)
-        run: cd frontend && pnpm vitest run --coverage --coverage-provider=v8 --coverage-threshold-fail-global=${{ env.COVERAGE_FLOOR_FRONTEND }} --reporter=verbose --passWithNoTests
+        run: |
+          cd frontend
+          pnpm install --frozen-lockfile
+          pnpm vitest run --coverage --coverage-provider=v8 --coverage-threshold-fail-global=${{ env.COVERAGE_FLOOR_FRONTEND }} --reporter=verbose --passWithNoTests
 
       - name: Upload coverage
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Add `pnpm install --frozen-lockfile` before vitest coverage runs in CI
- Fixes module resolution issue with istanbul-reports/verbose dependency

## Root Cause
pnpm symlink resolution conflict between `@vitest/coverage-v8` and `istanbul-reports` can cause module lookup failures when node_modules is cached.

## Fix
Run `pnpm install --frozen-lockfile` explicitly before coverage generation to ensure proper dependency hoisting.