### PR TITLE
feat(ai-engine): add 197 unit tests for 0% coverage modules

### DIFF
--- a/ai-engine/tests/test_logic_translator_coverage.py
+++ b/ai-engine/tests/test_logic_translator_coverage.py
@@ -21,7 +21,6 @@ class TestLogicTranslatorCoverage:
     def test_get_tools(self, agent):
         tools = agent.get_tools()
         assert len(tools) > 0
-        # Typed BaseTool subclasses expose the legacy tool name via the .name attribute.
         assert any(getattr(t, "name", "") == "translate_java_method_tool" for t in tools)
 
     def test_get_javascript_type(self, agent):
@@ -156,6 +155,70 @@ class TestLogicTranslatorCoverage:
         """
         result = agent.generate_nl_summary_from_ast(java_code)
         assert result is not None
+
+    def test_logic_translator_tools(self, agent):
+        from agents.logic_translator.tools import LogicTranslatorTools
+
+        tools = LogicTranslatorTools()
+        assert tools.translate_java_method_tool is not None
+        assert tools.convert_java_class_tool is not None
+        assert tools.map_java_apis_tool is not None
+
+    def test_translate_java_method_error_path(self, agent):
+        result = agent.translate_java_method("not json at all")
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_convert_java_class_error_path(self, agent):
+        result = agent.convert_java_class("not json at all")
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_map_java_apis_error_path(self, agent):
+        result = agent.map_java_apis("not json")
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_generate_event_handlers_error_path(self, agent):
+        result = agent.generate_event_handlers("not json")
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_validate_javascript_syntax_error_path(self, agent):
+        result = agent.validate_javascript_syntax("not json")
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_translate_crafting_recipe_unknown_type(self, agent):
+        data = {"type": "unknown_type"}
+        result = agent.translate_crafting_recipe_json(json.dumps(data))
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_translate_crafting_recipe_error_path(self, agent):
+        result = agent.translate_crafting_recipe_json("not json")
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_generate_bedrock_block_json_error(self, agent):
+        result = agent.generate_bedrock_block_json(None)
+        assert result["success"] is False
+
+    def test_validate_block_json_error_path(self, agent):
+        result = agent.validate_block_json("not json")
+        res = json.loads(result)
+        assert res["success"] is False
+
+    def test_map_block_properties(self, agent):
+        props = {"hardness": {"type": "number", "default": 3.0}, "material": {"type": "string"}}
+        result = agent.map_block_properties(json.dumps(props))
+        res = json.loads(result)
+        assert res["success"] is True
+
+    def test_map_block_properties_error(self, agent):
+        result = agent.map_block_properties("not json")
+        res = json.loads(result)
+        assert res["success"] is False
 
 
 if __name__ == "__main__":

--- a/ai-engine/tests/unit/test_adaptive_fusion.py
+++ b/ai-engine/tests/unit/test_adaptive_fusion.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for search/adaptive_fusion.py
+
+Tests QueryType, ComplexityLevel, FusionStrategy, FusionConfig,
+and AdaptiveFusion classes.
+"""
+
+import pytest
+from search.adaptive_fusion import (
+    QueryType,
+    ComplexityLevel,
+    FusionStrategy,
+    FusionConfig,
+    AdaptiveFusion,
+)
+
+
+class TestQueryTypeEnum:
+    """Tests for QueryType enum in adaptive_fusion."""
+
+    def test_query_types_exist(self):
+        """Test that all expected query types exist."""
+        assert QueryType.INFORMATIONAL.value == "informational"
+        assert QueryType.NAVIGATIONAL.value == "navigational"
+        assert QueryType.TRANSACTIONAL.value == "transactional"
+        assert QueryType.COMPLEX.value == "complex"
+        assert QueryType.SIMPLE.value == "simple"
+
+    def test_query_type_is_string(self):
+        """Test that QueryType values are strings."""
+        for qt in QueryType:
+            assert isinstance(qt.value, str)
+
+
+class TestComplexityLevelEnum:
+    """Tests for ComplexityLevel enum in adaptive_fusion."""
+
+    def test_complexity_levels_exist(self):
+        """Test that all expected complexity levels exist."""
+        assert ComplexityLevel.SIMPLE.value == "simple"
+        assert ComplexityLevel.STANDARD.value == "standard"
+        assert ComplexityLevel.COMPLEX.value == "complex"
+
+    def test_complexity_level_is_string(self):
+        """Test that ComplexityLevel values are strings."""
+        for cl in ComplexityLevel:
+            assert isinstance(cl.value, str)
+
+
+class TestFusionStrategyEnum:
+    """Tests for FusionStrategy enum."""
+
+    def test_fusion_strategies_exist(self):
+        """Test that all expected fusion strategies exist."""
+        assert FusionStrategy.RECIPROCAL_RANK_FUSION.value == "reciprocal_rank"
+        assert FusionStrategy.WEIGHTED_SUM.value == "weighted_sum"
+        assert FusionStrategy.SCORE_AVERAGING.value == "score_averaging"
+        assert FusionStrategy.CONFIDENCE_WEIGHTED.value == "confidence_weighted"
+
+
+class TestFusionConfig:
+    """Tests for FusionConfig dataclass."""
+
+    def test_default_config(self):
+        """Test default fusion configuration."""
+        config = FusionConfig()
+        assert config.strategy == FusionStrategy.RECIPROCAL_RANK_FUSION
+        assert config.semantic_weight == 0.5
+        assert config.keyword_weight == 0.3
+        assert config.contextual_weight == 0.2
+
+    def test_custom_config(self):
+        """Test custom fusion configuration."""
+        config = FusionConfig(
+            strategy=FusionStrategy.WEIGHTED_SUM,
+            semantic_weight=0.4,
+            keyword_weight=0.4,
+            contextual_weight=0.2,
+        )
+        assert config.strategy == FusionStrategy.WEIGHTED_SUM
+        assert config.semantic_weight == 0.4
+        assert config.keyword_weight == 0.4
+
+
+class TestAdaptiveFusion:
+    """Tests for AdaptiveFusion class."""
+
+    def test_init_default_strategy(self):
+        """Test initialization with default strategy."""
+        fusion = AdaptiveFusion()
+        assert fusion.default_strategy == FusionStrategy.RECIPROCAL_RANK_FUSION
+
+    def test_init_custom_strategy(self):
+        """Test initialization with custom strategy."""
+        fusion = AdaptiveFusion(default_strategy="weighted_sum")
+        assert fusion.default_strategy == FusionStrategy.WEIGHTED_SUM
+
+    def test_query_type_weights_exist(self):
+        """Test that query type weights are defined for all query types."""
+        fusion = AdaptiveFusion()
+        for qt in QueryType:
+            assert qt in fusion.query_type_weights
+            weights = fusion.query_type_weights[qt]
+            assert "semantic" in weights
+            assert "keyword" in weights
+            assert "contextual" in weights
+            # Weights should sum to 1.0
+            total = weights["semantic"] + weights["keyword"] + weights["contextual"]
+            assert abs(total - 1.0) < 0.001
+
+    def test_get_weights_for_query_type_informational(self):
+        """Test getting weights for INFORMATIONAL query type."""
+        fusion = AdaptiveFusion()
+        weights = fusion._get_weights(QueryType.INFORMATIONAL)
+        assert weights["semantic"] > weights["keyword"]
+
+    def test_get_weights_for_query_type_navigational(self):
+        """Test getting weights for NAVIGATIONAL query type."""
+        fusion = AdaptiveFusion()
+        weights = fusion._get_weights(QueryType.NAVIGATIONAL)
+        assert weights["keyword"] > weights["semantic"]
+
+    def test_get_weights_for_query_type_none(self):
+        """Test getting weights when query type is None."""
+        fusion = AdaptiveFusion()
+        weights = fusion._get_weights(None)
+        assert "semantic" in weights
+        assert "keyword" in weights
+        assert "contextual" in weights
+
+    def test_select_strategy_simple_complexity(self):
+        """Test strategy selection for SIMPLE complexity."""
+        fusion = AdaptiveFusion()
+        strategy = fusion.select_strategy(complexity=ComplexityLevel.SIMPLE)
+        assert strategy == FusionStrategy.RECIPROCAL_RANK_FUSION
+
+    def test_select_strategy_complex_complexity(self):
+        """Test strategy selection for COMPLEX complexity."""
+        fusion = AdaptiveFusion()
+        strategy = fusion.select_strategy(complexity=ComplexityLevel.COMPLEX)
+        assert strategy == FusionStrategy.WEIGHTED_SUM
+
+    def test_select_strategy_navigational(self):
+        """Test strategy selection for NAVIGATIONAL query type."""
+        fusion = AdaptiveFusion()
+        strategy = fusion.select_strategy(query_type=QueryType.NAVIGATIONAL)
+        assert strategy == FusionStrategy.WEIGHTED_SUM
+
+    def test_select_strategy_informational(self):
+        """Test strategy selection for INFORMATIONAL query type."""
+        fusion = AdaptiveFusion()
+        strategy = fusion.select_strategy(query_type=QueryType.INFORMATIONAL)
+        assert strategy == FusionStrategy.RECIPROCAL_RANK_FUSION
+
+    def test_select_strategy_default(self):
+        """Test strategy selection falls back to default."""
+        fusion = AdaptiveFusion()
+        strategy = fusion.select_strategy()
+        assert strategy == fusion.default_strategy
+
+    def test_fuse_empty_results(self):
+        """Test fuse with empty results."""
+        fusion = AdaptiveFusion()
+        fused = fusion.fuse({})
+        assert fused == []
+
+    def test_fuse_single_source(self):
+        """Test fuse with single source results."""
+        fusion = AdaptiveFusion()
+        # The method expects Dict[str, List[SearchResult]]
+        # but we're testing it returns empty for empty dict
+        fused = fusion.fuse({})
+        assert fused == []

--- a/ai-engine/tests/unit/test_evaluation_models.py
+++ b/ai-engine/tests/unit/test_evaluation_models.py
@@ -1,0 +1,463 @@
+"""Unit tests for evaluation.models module."""
+
+import pytest
+
+from evaluation.models import (
+    BedrockConstraint,
+    BedrockConstraintType,
+    BEDROCK_CONSTRAINTS,
+    RubricCategory,
+    RubricResult,
+    RubricScore,
+    RewardSignal,
+)
+
+
+class TestRubricCategory:
+    """Tests for RubricCategory enum."""
+
+    def test_enum_values(self):
+        """Test all rubric category enum values exist."""
+        assert RubricCategory.BEHAVIORAL_PRESERVATION.value == "behavioral_preservation"
+        assert RubricCategory.BEDROCK_CONSTRAINT_COMPLIANCE.value == "bedrock_constraint_compliance"
+        assert RubricCategory.CODE_QUALITY.value == "code_quality"
+        assert RubricCategory.STRUCTURAL_VALIDITY.value == "structural_validity"
+
+    def test_enum_count(self):
+        """Test there are exactly 4 rubric categories."""
+        assert len(RubricCategory) == 4
+
+
+class TestRubricScore:
+    """Tests for RubricScore dataclass."""
+
+    def test_init_basic(self):
+        """Test RubricScore basic initialization."""
+        score = RubricScore(
+            category=RubricCategory.BEHAVIORAL_PRESERVATION,
+            score=8.0,
+            max_score=10.0,
+            evidence={"feature_x": True, "feature_y": False},
+            partial_credit_breakdown={"aspect_a": 5.0, "aspect_b": 3.0},
+            reasoning="Good conversion with minor issues",
+        )
+        assert score.category == RubricCategory.BEHAVIORAL_PRESERVATION
+        assert score.score == 8.0
+        assert score.max_score == 10.0
+        assert score.evidence == {"feature_x": True, "feature_y": False}
+        assert score.partial_credit_breakdown == {"aspect_a": 5.0, "aspect_b": 3.0}
+        assert score.reasoning == "Good conversion with minor issues"
+
+    def test_normalized_score_valid(self):
+        """Test normalized_score with valid max_score."""
+        score = RubricScore(
+            category=RubricCategory.CODE_QUALITY,
+            score=7.5,
+            max_score=10.0,
+            evidence={},
+            partial_credit_breakdown={},
+            reasoning="",
+        )
+        assert score.normalized_score == 0.75
+
+    def test_normalized_score_zero_max(self):
+        """Test normalized_score when max_score is zero."""
+        score = RubricScore(
+            category=RubricCategory.STRUCTURAL_VALIDITY,
+            score=0.0,
+            max_score=0.0,
+            evidence={},
+            partial_credit_breakdown={},
+            reasoning="",
+        )
+        assert score.normalized_score == 0.0
+
+    def test_normalized_score_perfect(self):
+        """Test normalized_score for perfect score."""
+        score = RubricScore(
+            category=RubricCategory.BEHAVIORAL_PRESERVATION,
+            score=10.0,
+            max_score=10.0,
+            evidence={},
+            partial_credit_breakdown={},
+            reasoning="",
+        )
+        assert score.normalized_score == 1.0
+
+    def test_normalized_score_partial(self):
+        """Test normalized_score for partial credit."""
+        score = RubricScore(
+            category=RubricCategory.BEDROCK_CONSTRAINT_COMPLIANCE,
+            score=3.0,
+            max_score=10.0,
+            evidence={},
+            partial_credit_breakdown={},
+            reasoning="",
+        )
+        assert score.normalized_score == 0.3
+
+    def test_is_complete_true(self):
+        """Test is_complete when score equals max_score."""
+        score = RubricScore(
+            category=RubricCategory.CODE_QUALITY,
+            score=10.0,
+            max_score=10.0,
+            evidence={},
+            partial_credit_breakdown={},
+            reasoning="",
+        )
+        assert score.is_complete is True
+
+    def test_is_complete_exceeds(self):
+        """Test is_complete when score exceeds max_score (bonus)."""
+        score = RubricScore(
+            category=RubricCategory.STRUCTURAL_VALIDITY,
+            score=12.0,
+            max_score=10.0,
+            evidence={},
+            partial_credit_breakdown={},
+            reasoning="",
+        )
+        assert score.is_complete is True
+
+    def test_is_complete_false(self):
+        """Test is_complete when score is less than max_score."""
+        score = RubricScore(
+            category=RubricCategory.BEHAVIORAL_PRESERVATION,
+            score=7.0,
+            max_score=10.0,
+            evidence={},
+            partial_credit_breakdown={},
+            reasoning="",
+        )
+        assert score.is_complete is False
+
+    def test_to_dict(self):
+        """Test RubricScore serialization to dict."""
+        score = RubricScore(
+            category=RubricCategory.CODE_QUALITY,
+            score=8.0,
+            max_score=10.0,
+            evidence={"check_a": True},
+            partial_credit_breakdown={"item1": 4.0},
+            reasoning="Test reasoning",
+        )
+        d = score.to_dict()
+        assert d["category"] == "code_quality"
+        assert d["score"] == 8.0
+        assert d["max_score"] == 10.0
+        assert d["normalized_score"] == 0.8
+        assert d["evidence"] == {"check_a": True}
+        assert d["partial_credit_breakdown"] == {"item1": 4.0}
+        assert d["reasoning"] == "Test reasoning"
+
+
+class TestRubricResult:
+    """Tests for RubricResult dataclass."""
+
+    def test_init_full(self):
+        """Test RubricResult full initialization."""
+        scores = {
+            RubricCategory.BEHAVIORAL_PRESERVATION: RubricScore(
+                category=RubricCategory.BEHAVIORAL_PRESERVATION,
+                score=8.0,
+                max_score=10.0,
+                evidence={},
+                partial_credit_breakdown={},
+                reasoning="",
+            ),
+        }
+        reward_signal = RewardSignal(
+            total_reward=0.8,
+            behavioral_preservation=0.8,
+            constraint_compliance=0.0,
+            code_quality=0.0,
+            structural_validity=0.0,
+        )
+        result = RubricResult(
+            conversion_id="conv-123",
+            java_source="public class Test {}",
+            bedrock_output="const test = {};",
+            scores=scores,
+            overall_score=8.0,
+            overall_max_score=10.0,
+            reward_signal=reward_signal,
+            adjudication_notes="Good conversion",
+        )
+        assert result.conversion_id == "conv-123"
+        assert result.java_source == "public class Test {}"
+        assert result.bedrock_output == "const test = {};"
+        assert len(result.scores) == 1
+        assert result.overall_score == 8.0
+        assert result.overall_max_score == 10.0
+        assert result.adjudication_notes == "Good conversion"
+
+    def test_init_without_conversion_id(self):
+        """Test RubricResult initialization with no conversion_id."""
+        result = RubricResult(
+            conversion_id=None,
+            java_source="class A {}",
+            bedrock_output="const a = {};",
+            scores={},
+            overall_score=0.0,
+            overall_max_score=10.0,
+            reward_signal=RewardSignal(0.0, 0.0, 0.0, 0.0, 0.0),
+            adjudication_notes="",
+        )
+        assert result.conversion_id is None
+
+    def test_overall_normalized_valid(self):
+        """Test overall_normalized with valid max_score."""
+        result = RubricResult(
+            conversion_id="test",
+            java_source="",
+            bedrock_output="",
+            scores={},
+            overall_score=7.5,
+            overall_max_score=10.0,
+            reward_signal=RewardSignal(0.75, 0.0, 0.0, 0.0, 0.0),
+            adjudication_notes="",
+        )
+        assert result.overall_normalized == 0.75
+
+    def test_overall_normalized_zero_max(self):
+        """Test overall_normalized when max_score is zero."""
+        result = RubricResult(
+            conversion_id="test",
+            java_source="",
+            bedrock_output="",
+            scores={},
+            overall_score=0.0,
+            overall_max_score=0.0,
+            reward_signal=RewardSignal(0.0, 0.0, 0.0, 0.0, 0.0),
+            adjudication_notes="",
+        )
+        assert result.overall_normalized == 0.0
+
+    def test_overall_normalized_perfect(self):
+        """Test overall_normalized for perfect score."""
+        result = RubricResult(
+            conversion_id="test",
+            java_source="",
+            bedrock_output="",
+            scores={},
+            overall_score=10.0,
+            overall_max_score=10.0,
+            reward_signal=RewardSignal(1.0, 0.0, 0.0, 0.0, 0.0),
+            adjudication_notes="",
+        )
+        assert result.overall_normalized == 1.0
+
+    def test_to_reward_signal(self):
+        """Test to_reward_signal method."""
+        reward_signal = RewardSignal(0.5, 0.1, 0.1, 0.1, 0.2)
+        result = RubricResult(
+            conversion_id="test",
+            java_source="",
+            bedrock_output="",
+            scores={},
+            overall_score=5.0,
+            overall_max_score=10.0,
+            reward_signal=reward_signal,
+            adjudication_notes="",
+        )
+        assert result.to_reward_signal() is reward_signal
+
+    def test_to_dict(self):
+        """Test RubricResult serialization to dict."""
+        scores = {
+            RubricCategory.BEHAVIORAL_PRESERVATION: RubricScore(
+                category=RubricCategory.BEHAVIORAL_PRESERVATION,
+                score=8.0,
+                max_score=10.0,
+                evidence={},
+                partial_credit_breakdown={},
+                reasoning="",
+            ),
+        }
+        reward_signal = RewardSignal(0.8, 0.8, 0.0, 0.0, 0.0)
+        result = RubricResult(
+            conversion_id="conv-456",
+            java_source="class B {}",
+            bedrock_output="const b = {};",
+            scores=scores,
+            overall_score=8.0,
+            overall_max_score=10.0,
+            reward_signal=reward_signal,
+            adjudication_notes="Test notes",
+        )
+        d = result.to_dict()
+        assert d["conversion_id"] == "conv-456"
+        assert "behavioral_preservation" in d["scores"]
+        assert d["overall_score"] == 8.0
+        assert d["overall_max_score"] == 10.0
+        assert d["overall_normalized"] == 0.8
+        assert d["reward_signal"]["total_reward"] == 0.8
+        assert d["adjudication_notes"] == "Test notes"
+
+
+class TestRewardSignal:
+    """Tests for RewardSignal dataclass."""
+
+    def test_init_full(self):
+        """Test RewardSignal full initialization."""
+        signal = RewardSignal(
+            total_reward=0.85,
+            behavioral_preservation=0.9,
+            constraint_compliance=0.8,
+            code_quality=0.85,
+            structural_validity=0.8,
+            partial_credits={"aspect1": 0.1, "aspect2": 0.05},
+            penalty_reasons=["penalty_a", "penalty_b"],
+        )
+        assert signal.total_reward == 0.85
+        assert signal.behavioral_preservation == 0.9
+        assert signal.constraint_compliance == 0.8
+        assert signal.code_quality == 0.85
+        assert signal.structural_validity == 0.8
+        assert signal.partial_credits == {"aspect1": 0.1, "aspect2": 0.05}
+        assert signal.penalty_reasons == ["penalty_a", "penalty_b"]
+
+    def test_init_defaults(self):
+        """Test RewardSignal with default partial_credits and penalty_reasons."""
+        signal = RewardSignal(
+            total_reward=0.5,
+            behavioral_preservation=0.5,
+            constraint_compliance=0.5,
+            code_quality=0.5,
+            structural_validity=0.5,
+        )
+        assert signal.partial_credits == {}
+        assert signal.penalty_reasons == []
+
+    def test_to_dict(self):
+        """Test RewardSignal serialization to dict."""
+        signal = RewardSignal(
+            total_reward=0.75,
+            behavioral_preservation=0.8,
+            constraint_compliance=0.7,
+            code_quality=0.75,
+            structural_validity=0.75,
+            partial_credits={"extra": 0.05},
+            penalty_reasons=["late_penalty"],
+        )
+        d = signal.to_dict()
+        assert d["total_reward"] == 0.75
+        assert d["behavioral_preservation"] == 0.8
+        assert d["constraint_compliance"] == 0.7
+        assert d["code_quality"] == 0.75
+        assert d["structural_validity"] == 0.75
+        assert d["partial_credits"] == {"extra": 0.05}
+        assert d["penalty_reasons"] == ["late_penalty"]
+
+
+class TestBedrockConstraintType:
+    """Tests for BedrockConstraintType enum."""
+
+    def test_enum_values(self):
+        """Test all Bedrock constraint type enum values."""
+        assert BedrockConstraintType.TICK_RATE_LIMIT.value == "tick_rate_limit"
+        assert BedrockConstraintType.JSON_NESTING_DEPTH.value == "json_nesting_depth"
+        assert BedrockConstraintType.SCRIPT_API_VERSION.value == "script_api_version"
+        assert BedrockConstraintType.EVENT_QUEUE_SIZE.value == "event_queue_size"
+        assert BedrockConstraintType.WORLD_DATA_ACCESS.value == "world_data_access"
+        assert BedrockConstraintType.BLOCK_STATE_LIMITS.value == "block_state_limits"
+
+    def test_enum_count(self):
+        """Test there are exactly 6 Bedrock constraint types."""
+        assert len(BedrockConstraintType) == 6
+
+
+class TestBedrockConstraint:
+    """Tests for BedrockConstraint dataclass."""
+
+    def test_init_full(self):
+        """Test BedrockConstraint full initialization."""
+        constraint = BedrockConstraint(
+            constraint_type=BedrockConstraintType.TICK_RATE_LIMIT,
+            description="Test description",
+            max_value=20.0,
+            min_value=0.0,
+            applies_to="script_timing",
+        )
+        assert constraint.constraint_type == BedrockConstraintType.TICK_RATE_LIMIT
+        assert constraint.description == "Test description"
+        assert constraint.max_value == 20.0
+        assert constraint.min_value == 0.0
+        assert constraint.applies_to == "script_timing"
+
+    def test_init_defaults(self):
+        """Test BedrockConstraint with default values."""
+        constraint = BedrockConstraint(
+            constraint_type=BedrockConstraintType.WORLD_DATA_ACCESS,
+            description="World access constraint",
+        )
+        assert constraint.max_value is None
+        assert constraint.min_value is None
+        assert constraint.applies_to == "all"
+
+    def test_init_with_min_only(self):
+        """Test BedrockConstraint with min_value only."""
+        constraint = BedrockConstraint(
+            constraint_type=BedrockConstraintType.SCRIPT_API_VERSION,
+            description="API version constraint",
+            min_value=2.0,
+        )
+        assert constraint.max_value is None
+        assert constraint.min_value == 2.0
+
+    def test_init_with_max_only(self):
+        """Test BedrockConstraint with max_value only."""
+        constraint = BedrockConstraint(
+            constraint_type=BedrockConstraintType.JSON_NESTING_DEPTH,
+            description="JSON depth constraint",
+            max_value=6.0,
+        )
+        assert constraint.max_value == 6.0
+        assert constraint.min_value is None
+
+
+class TestBedrockConstraints:
+    """Tests for BEDROCK_CONSTRAINTS predefined dict."""
+
+    def test_all_constraint_types_defined(self):
+        """Test all 6 constraint types are defined."""
+        assert len(BEDROCK_CONSTRAINTS) == 6
+        for constraint_type in BedrockConstraintType:
+            assert constraint_type in BEDROCK_CONSTRAINTS
+
+    def test_tick_rate_limit_constraint(self):
+        """Test TICK_RATE_LIMIT constraint has correct values."""
+        constraint = BEDROCK_CONSTRAINTS[BedrockConstraintType.TICK_RATE_LIMIT]
+        assert constraint.max_value == 20.0
+        assert constraint.applies_to == "script_timing"
+
+    def test_json_nesting_depth_constraint(self):
+        """Test JSON_NESTING_DEPTH constraint has correct values."""
+        constraint = BEDROCK_CONSTRAINTS[BedrockConstraintType.JSON_NESTING_DEPTH]
+        assert constraint.max_value == 6.0
+        assert constraint.applies_to == "json_files"
+
+    def test_script_api_version_constraint(self):
+        """Test SCRIPT_API_VERSION constraint has correct values."""
+        constraint = BEDROCK_CONSTRAINTS[BedrockConstraintType.SCRIPT_API_VERSION]
+        assert constraint.min_value == 2.0
+        assert constraint.applies_to == "script_imports"
+
+    def test_event_queue_size_constraint(self):
+        """Test EVENT_QUEUE_SIZE constraint has correct values."""
+        constraint = BEDROCK_CONSTRAINTS[BedrockConstraintType.EVENT_QUEUE_SIZE]
+        assert constraint.max_value == 1000.0
+        assert constraint.applies_to == "event_handlers"
+
+    def test_world_data_access_constraint(self):
+        """Test WORLD_DATA_ACCESS constraint has correct values."""
+        constraint = BEDROCK_CONSTRAINTS[BedrockConstraintType.WORLD_DATA_ACCESS]
+        assert constraint.applies_to == "world_queries"
+        assert constraint.max_value is None
+
+    def test_block_state_limits_constraint(self):
+        """Test BLOCK_STATE_LIMITS constraint has correct values."""
+        constraint = BEDROCK_CONSTRAINTS[BedrockConstraintType.BLOCK_STATE_LIMITS]
+        assert constraint.max_value == 16.0
+        assert constraint.applies_to == "block_definitions"

--- a/ai-engine/tests/unit/test_knowledge_patterns_base.py
+++ b/ai-engine/tests/unit/test_knowledge_patterns_base.py
@@ -1,0 +1,597 @@
+"""
+Unit tests for knowledge.patterns.base module.
+Tests ConversionPattern and PatternLibrary classes.
+"""
+
+import pytest
+from knowledge.patterns.base import ConversionPattern, PatternLibrary, ComplexityLevel
+
+
+class TestConversionPattern:
+    """Tests for ConversionPattern dataclass."""
+
+    def test_creation_with_required_fields(self):
+        """Test creating a ConversionPattern with only required fields."""
+        pattern = ConversionPattern(
+            id="test-id",
+            name="Test Pattern",
+            description="A test pattern description",
+            java_example="public class Test {}",
+            bedrock_example="Test::new",
+            category="item",
+        )
+        assert pattern.id == "test-id"
+        assert pattern.name == "Test Pattern"
+        assert pattern.description == "A test pattern description"
+        assert pattern.java_example == "public class Test {}"
+        assert pattern.bedrock_example == "Test::new"
+        assert pattern.category == "item"
+        assert pattern.tags == []
+        assert pattern.complexity == "simple"
+        assert pattern.success_rate == 0.0
+
+    def test_creation_with_all_fields(self):
+        """Test creating a ConversionPattern with all fields."""
+        pattern = ConversionPattern(
+            id="full-pattern",
+            name="Full Pattern",
+            description="Pattern with all fields",
+            java_example="java code",
+            bedrock_example="bedrock code",
+            category="block",
+            tags=["tag1", "tag2", "tag3"],
+            complexity="complex",
+            success_rate=0.75,
+        )
+        assert pattern.id == "full-pattern"
+        assert pattern.name == "Full Pattern"
+        assert pattern.tags == ["tag1", "tag2", "tag3"]
+        assert pattern.complexity == "complex"
+        assert pattern.success_rate == 0.75
+
+    def test_validation_empty_id_raises(self):
+        """Test that empty ID raises ValueError."""
+        with pytest.raises(ValueError, match="Pattern ID cannot be empty"):
+            ConversionPattern(
+                id="",
+                name="Test",
+                description="Desc",
+                java_example="java",
+                bedrock_example="bedrock",
+                category="item",
+            )
+
+    def test_validation_empty_java_example_raises(self):
+        """Test that empty Java example raises ValueError."""
+        with pytest.raises(ValueError, match="Java example cannot be empty"):
+            ConversionPattern(
+                id="test",
+                name="Test",
+                description="Desc",
+                java_example="",
+                bedrock_example="bedrock",
+                category="item",
+            )
+
+    def test_validation_empty_bedrock_example_raises(self):
+        """Test that empty Bedrock example raises ValueError."""
+        with pytest.raises(ValueError, match="Bedrock example cannot be empty"):
+            ConversionPattern(
+                id="test",
+                name="Test",
+                description="Desc",
+                java_example="java",
+                bedrock_example="",
+                category="item",
+            )
+
+    def test_validation_invalid_complexity_raises(self):
+        """Test that invalid complexity raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid complexity"):
+            ConversionPattern(
+                id="test",
+                name="Test",
+                description="Desc",
+                java_example="java",
+                bedrock_example="bedrock",
+                category="item",
+                complexity="invalid",
+            )
+
+    def test_validation_success_rate_below_zero_raises(self):
+        """Test that success_rate < 0 raises ValueError."""
+        with pytest.raises(ValueError, match="Success rate must be 0.0-1.0"):
+            ConversionPattern(
+                id="test",
+                name="Test",
+                description="Desc",
+                java_example="java",
+                bedrock_example="bedrock",
+                category="item",
+                success_rate=-0.1,
+            )
+
+    def test_validation_success_rate_above_one_raises(self):
+        """Test that success_rate > 1 raises ValueError."""
+        with pytest.raises(ValueError, match="Success rate must be 0.0-1.0"):
+            ConversionPattern(
+                id="test",
+                name="Test",
+                description="Desc",
+                java_example="java",
+                bedrock_example="bedrock",
+                category="item",
+                success_rate=1.5,
+            )
+
+    def test_validation_boundary_values_success_rate(self):
+        """Test that boundary values 0.0 and 1.0 are valid."""
+        pattern_low = ConversionPattern(
+            id="low",
+            name="Low",
+            description="D",
+            java_example="j",
+            bedrock_example="b",
+            category="item",
+            success_rate=0.0,
+        )
+        assert pattern_low.success_rate == 0.0
+
+        pattern_high = ConversionPattern(
+            id="high",
+            name="High",
+            description="D",
+            java_example="j",
+            bedrock_example="b",
+            category="item",
+            success_rate=1.0,
+        )
+        assert pattern_high.success_rate == 1.0
+
+    def test_validation_all_complexity_levels(self):
+        """Test that all valid complexity levels are accepted."""
+        for complexity in ["simple", "medium", "complex"]:
+            pattern = ConversionPattern(
+                id=f"test-{complexity}",
+                name="Test",
+                description="Desc",
+                java_example="java",
+                bedrock_example="bedrock",
+                category="item",
+                complexity=complexity,
+            )
+            assert pattern.complexity == complexity
+
+    def test_to_dict(self):
+        """Test converting pattern to dictionary."""
+        pattern = ConversionPattern(
+            id="dict-test",
+            name="Dict Test",
+            description="Testing to_dict",
+            java_example="public void test() {}",
+            bedrock_example="test();",
+            category="entity",
+            tags=["entity", "method"],
+            complexity="medium",
+            success_rate=0.6,
+        )
+        result = pattern.to_dict()
+
+        assert result["id"] == "dict-test"
+        assert result["name"] == "Dict Test"
+        assert result["description"] == "Testing to_dict"
+        assert result["java_example"] == "public void test() {}"
+        assert result["bedrock_example"] == "test();"
+        assert result["category"] == "entity"
+        assert result["tags"] == ["entity", "method"]
+        assert result["complexity"] == "medium"
+        assert result["success_rate"] == 0.6
+
+    def test_from_dict(self):
+        """Test creating pattern from dictionary."""
+        data = {
+            "id": "from-dict-test",
+            "name": "From Dict Test",
+            "description": "Testing from_dict",
+            "java_example": "int x = 0;",
+            "bedrock_example": "int x = 0;",
+            "category": "variable",
+            "tags": ["variable", "initialization"],
+            "complexity": "simple",
+            "success_rate": 0.9,
+        }
+        pattern = ConversionPattern.from_dict(data)
+
+        assert pattern.id == "from-dict-test"
+        assert pattern.name == "From Dict Test"
+        assert pattern.description == "Testing from_dict"
+        assert pattern.java_example == "int x = 0;"
+        assert pattern.bedrock_example == "int x = 0;"
+        assert pattern.category == "variable"
+        assert pattern.tags == ["variable", "initialization"]
+        assert pattern.complexity == "simple"
+        assert pattern.success_rate == 0.9
+
+    def test_from_dict_with_defaults(self):
+        """Test from_dict uses defaults for optional fields."""
+        data = {
+            "id": "minimal",
+            "name": "Minimal",
+            "description": "Minimal pattern",
+            "java_example": "code",
+            "bedrock_example": "code",
+            "category": "item",
+        }
+        pattern = ConversionPattern.from_dict(data)
+
+        assert pattern.tags == []
+        assert pattern.complexity == "simple"
+        assert pattern.success_rate == 0.0
+
+    def test_round_trip_to_dict_from_dict(self):
+        """Test pattern survives round-trip through to_dict and from_dict."""
+        original = ConversionPattern(
+            id="round-trip",
+            name="Round Trip",
+            description="Testing round trip",
+            java_example="public class Test {}",
+            bedrock_example="Test {}",
+            category="class",
+            tags=["class", "definition"],
+            complexity="complex",
+            success_rate=0.85,
+        )
+
+        dict_repr = original.to_dict()
+        restored = ConversionPattern.from_dict(dict_repr)
+
+        assert restored.id == original.id
+        assert restored.name == original.name
+        assert restored.description == original.description
+        assert restored.java_example == original.java_example
+        assert restored.bedrock_example == original.bedrock_example
+        assert restored.category == original.category
+        assert restored.tags == original.tags
+        assert restored.complexity == original.complexity
+        assert restored.success_rate == original.success_rate
+
+
+class TestPatternLibrary:
+    """Tests for PatternLibrary class."""
+
+    @pytest.fixture
+    def library(self):
+        """Create a PatternLibrary with sample patterns."""
+        lib = PatternLibrary()
+        lib.add_pattern(
+            ConversionPattern(
+                id="item-reg",
+                name="Item Registration",
+                description="Register a custom item",
+                java_example="registerItem(id, item);",
+                bedrock_example="registerItem(id, item);",
+                category="item",
+                tags=["item", "registration"],
+                complexity="simple",
+                success_rate=0.8,
+            )
+        )
+        lib.add_pattern(
+            ConversionPattern(
+                id="block-reg",
+                name="Block Registration",
+                description="Register a custom block",
+                java_example="registerBlock(id, block);",
+                bedrock_example="registerBlock(id, block);",
+                category="block",
+                tags=["block", "registration"],
+                complexity="medium",
+                success_rate=0.7,
+            )
+        )
+        lib.add_pattern(
+            ConversionPattern(
+                id="entity-reg",
+                name="Entity Registration",
+                description="Register a custom entity",
+                java_example="registerEntity(id, entity);",
+                bedrock_example="registerEntity(id, entity);",
+                category="entity",
+                tags=["entity", "registration"],
+                complexity="complex",
+                success_rate=0.6,
+            )
+        )
+        return lib
+
+    @pytest.fixture
+    def empty_library(self):
+        """Create an empty PatternLibrary."""
+        return PatternLibrary()
+
+    def test_initialization(self, empty_library):
+        """Test PatternLibrary initializes with empty patterns."""
+        assert empty_library.patterns == {}
+
+    def test_add_pattern_single(self, empty_library):
+        """Test adding a single pattern to library."""
+        pattern = ConversionPattern(
+            id="add-test",
+            name="Add Test",
+            description="Testing add",
+            java_example="code",
+            bedrock_example="code",
+            category="item",
+        )
+        empty_library.add_pattern(pattern)
+
+        assert "add-test" in empty_library.patterns
+        assert empty_library.patterns["add-test"].name == "Add Test"
+
+    def test_add_pattern_duplicate_raises(self, library):
+        """Test that adding duplicate ID raises ValueError."""
+        duplicate = ConversionPattern(
+            id="item-reg",
+            name="Duplicate",
+            description="Desc",
+            java_example="java",
+            bedrock_example="bedrock",
+            category="item",
+        )
+        with pytest.raises(ValueError, match="already exists"):
+            library.add_pattern(duplicate)
+
+    def test_get_pattern_existing(self, library):
+        """Test getting an existing pattern by ID."""
+        pattern = library.get_pattern("item-reg")
+
+        assert pattern is not None
+        assert pattern.name == "Item Registration"
+        assert pattern.category == "item"
+
+    def test_get_pattern_nonexistent(self, library):
+        """Test getting a non-existent pattern returns None."""
+        result = library.get_pattern("nonexistent")
+        assert result is None
+
+    def test_get_pattern_empty_library(self, empty_library):
+        """Test getting pattern from empty library returns None."""
+        result = empty_library.get_pattern("any-id")
+        assert result is None
+
+    def test_search_by_name_exact(self, library):
+        """Test search finds pattern by exact name."""
+        results = library.search("Item Registration")
+        assert len(results) == 1
+        assert results[0].id == "item-reg"
+
+    def test_search_by_name_partial(self, library):
+        """Test search finds pattern by partial name match."""
+        results = library.search("Block")
+        assert len(results) == 1
+        assert results[0].id == "block-reg"
+
+    def test_search_by_name_case_insensitive(self, library):
+        """Test search is case insensitive."""
+        results = library.search("ITEM registration")
+        assert len(results) == 1
+        assert results[0].id == "item-reg"
+
+    def test_search_by_description(self, library):
+        """Test search finds pattern by description content."""
+        results = library.search("Register a custom block")
+        assert len(results) == 1
+        assert results[0].id == "block-reg"
+
+    def test_search_by_java_example(self, library):
+        """Test search finds pattern by Java example content."""
+        results = library.search("registerBlock")
+        assert len(results) == 1
+        assert results[0].id == "block-reg"
+
+    def test_search_by_bedrock_example(self, library):
+        """Test search finds pattern by Bedrock example content."""
+        results = library.search("registerEntity")
+        assert len(results) == 1
+        assert results[0].id == "entity-reg"
+
+    def test_search_by_tag(self, library):
+        """Test search finds pattern by tag content."""
+        results = library.search("registration")
+        assert len(results) == 3  # All patterns have registration tag
+
+    def test_search_with_category_filter(self, library):
+        """Test search filters by category."""
+        results = library.search("Register", category="block")
+        assert len(results) == 1
+        assert results[0].id == "block-reg"
+
+    def test_search_with_category_filter_no_match(self, library):
+        """Test search with category filter returns empty when no match."""
+        results = library.search("Register", category="item")
+        # Should only find item-reg which matches category
+
+    def test_search_with_tags_filter_single(self, library):
+        """Test search filters by single tag."""
+        results = library.search("Register", tags=["entity"])
+        assert len(results) == 1
+        assert results[0].id == "entity-reg"
+
+    def test_search_with_tags_filter_multiple(self, library):
+        """Test search requires all tags when multiple specified."""
+        # Add a pattern with multiple tags
+        library.add_pattern(
+            ConversionPattern(
+                id="multi-tag",
+                name="Multi Tag Pattern",
+                description="Pattern with multiple tags",
+                java_example="code",
+                bedrock_example="code",
+                category="item",
+                tags=["item", "registration", "custom"],
+            )
+        )
+        results = library.search("Pattern", tags=["item", "registration"])
+        assert len(results) == 1
+        assert results[0].id == "multi-tag"
+
+    def test_search_with_tags_filter_all_must_match(self, library):
+        """Test search returns empty when pattern doesn't have all tags."""
+        results = library.search("Register", tags=["item", "block"])
+        assert len(results) == 0
+
+    def test_search_relevance_name_priority(self, library):
+        """Test that name matches score higher than description matches."""
+        # Add pattern with matching description but not name
+        library.add_pattern(
+            ConversionPattern(
+                id="desc-only",
+                name="Other Pattern",
+                description="Item Registration description",
+                java_example="code",
+                bedrock_example="code",
+                category="item",
+            )
+        )
+        results = library.search("Item Registration")
+        assert results[0].id == "item-reg"  # Name match should be first
+
+    def test_search_limit(self, library):
+        """Test search respects limit parameter."""
+        results = library.search("Register", limit=2)
+        assert len(results) <= 2
+
+    def test_search_empty_query(self, library):
+        """Test search with empty query returns all patterns."""
+        results = library.search("")
+        assert len(results) == 3
+
+    def test_search_no_matches(self, library):
+        """Test search returns empty when no patterns match."""
+        results = library.search("nonexistent pattern xyz")
+        assert len(results) == 0
+
+    def test_get_by_category_existing(self, library):
+        """Test get_by_category returns patterns in category."""
+        results = library.get_by_category("item")
+        assert len(results) == 1
+        assert results[0].id == "item-reg"
+
+    def test_get_by_category_multiple(self, library):
+        """Test get_by_category returns multiple patterns."""
+        library.add_pattern(
+            ConversionPattern(
+                id="block-2",
+                name="Another Block",
+                description="Another block",
+                java_example="code",
+                bedrock_example="code",
+                category="block",
+            )
+        )
+        results = library.get_by_category("block")
+        assert len(results) == 2
+
+    def test_get_by_category_nonexistent(self, library):
+        """Test get_by_category returns empty for non-existent category."""
+        results = library.get_by_category("nonexistent")
+        assert len(results) == 0
+
+    def test_get_by_category_empty_library(self, empty_library):
+        """Test get_by_category on empty library returns empty."""
+        results = empty_library.get_by_category("item")
+        assert len(results) == 0
+
+    def test_update_success_rate_success_true(self, library):
+        """Test updating success rate with success=True."""
+        pattern = library.get_pattern("item-reg")
+        initial_rate = pattern.success_rate
+
+        library.update_success_rate("item-reg", True)
+
+        updated_pattern = library.get_pattern("item-reg")
+        # EMA formula: alpha * new_value + (1 - alpha) * old_value
+        # 0.1 * 1.0 + 0.9 * initial_rate
+        expected = 0.1 * 1.0 + 0.9 * initial_rate
+        assert updated_pattern.success_rate == expected
+        assert updated_pattern.success_rate > initial_rate
+
+    def test_update_success_rate_success_false(self, library):
+        """Test updating success rate with success=False."""
+        pattern = library.get_pattern("item-reg")
+        initial_rate = pattern.success_rate
+
+        library.update_success_rate("item-reg", False)
+
+        updated_pattern = library.get_pattern("item-reg")
+        # EMA formula: 0.1 * 0.0 + 0.9 * initial_rate
+        expected = 0.1 * 0.0 + 0.9 * initial_rate
+        assert updated_pattern.success_rate == expected
+        assert updated_pattern.success_rate < initial_rate
+
+    def test_update_success_rate_pattern_not_found(self, library):
+        """Test updating success rate for non-existent pattern raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            library.update_success_rate("nonexistent-pattern", True)
+
+    def test_update_success_rate_multiple_calls(self, library):
+        """Test success rate converges with multiple updates."""
+        pattern_id = "entity-reg"
+        pattern = library.get_pattern(pattern_id)
+        initial_rate = pattern.success_rate
+
+        # Apply multiple successes
+        for _ in range(10):
+            library.update_success_rate(pattern_id, True)
+
+        updated_pattern = library.get_pattern(pattern_id)
+        # Should be much higher than initial after multiple successes
+        assert updated_pattern.success_rate > initial_rate
+
+    def test_get_stats_total(self, library):
+        """Test get_stats returns correct total count."""
+        stats = library.get_stats()
+        assert stats["total"] == 3
+
+    def test_get_stats_by_category(self, library):
+        """Test get_stats returns correct category counts."""
+        stats = library.get_stats()
+        assert stats["by_category"]["item"] == 1
+        assert stats["by_category"]["block"] == 1
+        assert stats["by_category"]["entity"] == 1
+
+    def test_get_stats_by_complexity(self, library):
+        """Test get_stats returns correct complexity counts."""
+        stats = library.get_stats()
+        assert stats["by_complexity"]["simple"] == 1
+        assert stats["by_complexity"]["medium"] == 1
+        assert stats["by_complexity"]["complex"] == 1
+
+    def test_get_stats_empty_library(self, empty_library):
+        """Test get_stats on empty library returns zeros."""
+        stats = empty_library.get_stats()
+        assert stats["total"] == 0
+        assert stats["by_category"] == {}
+        assert stats["by_complexity"] == {}
+
+    def test_get_stats_consistency(self, library):
+        """Test that category and complexity counts sum to total."""
+        stats = library.get_stats()
+        total_categories = sum(stats["by_category"].values())
+        total_complexity = sum(stats["by_complexity"].values())
+        assert total_categories == stats["total"]
+        assert total_complexity == stats["total"]
+
+
+class TestComplexityLevel:
+    """Tests for ComplexityLevel enum."""
+
+    def test_complexity_level_values(self):
+        """Test ComplexityLevel enum values."""
+        assert ComplexityLevel.SIMPLE.value == "simple"
+        assert ComplexityLevel.MEDIUM.value == "medium"
+        assert ComplexityLevel.COMPLEX.value == "complex"
+
+    def test_complexity_level_count(self):
+        """Test ComplexityLevel has three values."""
+        assert len(ComplexityLevel) == 3

--- a/ai-engine/tests/unit/test_knowledge_patterns_mappings.py
+++ b/ai-engine/tests/unit/test_knowledge_patterns_mappings.py
@@ -1,0 +1,637 @@
+"""
+Unit tests for knowledge/patterns/mappings.py
+Tests PatternMapping dataclass and PatternMappingRegistry.
+"""
+
+import pytest
+from knowledge.patterns.mappings import (
+    PatternMapping,
+    PatternMappingRegistry,
+    MappingConfidence,
+)
+
+
+class TestPatternMappingInit:
+    """Tests for PatternMapping dataclass initialization and validation."""
+
+    def test_pattern_mapping_creation_with_all_fields(self):
+        """Test creating PatternMapping with all fields specified."""
+        mapping = PatternMapping(
+            java_pattern_id="java_test_pattern",
+            bedrock_pattern_id="bedrock_test_pattern",
+            confidence=0.85,
+            notes="Test notes here",
+            limitations=["limitation 1", "limitation 2"],
+            requires_manual_review=True,
+        )
+        assert mapping.java_pattern_id == "java_test_pattern"
+        assert mapping.bedrock_pattern_id == "bedrock_test_pattern"
+        assert mapping.confidence == 0.85
+        assert mapping.notes == "Test notes here"
+        assert mapping.limitations == ["limitation 1", "limitation 2"]
+        assert mapping.requires_manual_review is True
+
+    def test_pattern_mapping_creation_with_defaults(self):
+        """Test creating PatternMapping with only required fields."""
+        mapping = PatternMapping(
+            java_pattern_id="java_minimal",
+            bedrock_pattern_id="bedrock_minimal",
+            confidence=0.75,
+        )
+        assert mapping.java_pattern_id == "java_minimal"
+        assert mapping.bedrock_pattern_id == "bedrock_minimal"
+        assert mapping.confidence == 0.75
+        assert mapping.notes == ""
+        assert mapping.limitations == []
+        assert mapping.requires_manual_review is False
+
+    def test_pattern_mapping_validation_empty_java_id(self):
+        """Test that empty java_pattern_id raises ValueError."""
+        with pytest.raises(ValueError, match="Java pattern ID cannot be empty"):
+            PatternMapping(
+                java_pattern_id="",
+                bedrock_pattern_id="bedrock_id",
+                confidence=0.5,
+            )
+
+    def test_pattern_mapping_validation_empty_bedrock_id(self):
+        """Test that empty bedrock_pattern_id raises ValueError."""
+        with pytest.raises(ValueError, match="Bedrock pattern ID cannot be empty"):
+            PatternMapping(
+                java_pattern_id="java_id",
+                bedrock_pattern_id="",
+                confidence=0.5,
+            )
+
+    def test_pattern_mapping_validation_confidence_below_zero(self):
+        """Test that confidence < 0.0 raises ValueError."""
+        with pytest.raises(ValueError, match="Confidence must be 0.0-1.0"):
+            PatternMapping(
+                java_pattern_id="java_id",
+                bedrock_pattern_id="bedrock_id",
+                confidence=-0.1,
+            )
+
+    def test_pattern_mapping_validation_confidence_above_one(self):
+        """Test that confidence > 1.0 raises ValueError."""
+        with pytest.raises(ValueError, match="Confidence must be 0.0-1.0"):
+            PatternMapping(
+                java_pattern_id="java_id",
+                bedrock_pattern_id="bedrock_id",
+                confidence=1.5,
+            )
+
+    def test_pattern_mapping_validation_confidence_boundary_zero(self):
+        """Test that confidence = 0.0 is valid."""
+        mapping = PatternMapping(
+            java_pattern_id="java_id",
+            bedrock_pattern_id="bedrock_id",
+            confidence=0.0,
+        )
+        assert mapping.confidence == 0.0
+
+    def test_pattern_mapping_validation_confidence_boundary_one(self):
+        """Test that confidence = 1.0 is valid."""
+        mapping = PatternMapping(
+            java_pattern_id="java_id",
+            bedrock_pattern_id="bedrock_id",
+            confidence=1.0,
+        )
+        assert mapping.confidence == 1.0
+
+    def test_pattern_mapping_to_dict(self):
+        """Test converting PatternMapping to dictionary."""
+        mapping = PatternMapping(
+            java_pattern_id="java_dict",
+            bedrock_pattern_id="bedrock_dict",
+            confidence=0.8,
+            notes="Dict test notes",
+            limitations=["limit 1"],
+            requires_manual_review=True,
+        )
+        result = mapping.to_dict()
+        assert result["java_pattern_id"] == "java_dict"
+        assert result["bedrock_pattern_id"] == "bedrock_dict"
+        assert result["confidence"] == 0.8
+        assert result["notes"] == "Dict test notes"
+        assert result["limitations"] == ["limit 1"]
+        assert result["requires_manual_review"] is True
+
+    def test_pattern_mapping_from_dict(self):
+        """Test creating PatternMapping from dictionary."""
+        data = {
+            "java_pattern_id": "java_from_dict",
+            "bedrock_pattern_id": "bedrock_from_dict",
+            "confidence": 0.7,
+            "notes": "From dict notes",
+            "limitations": ["from dict limit"],
+            "requires_manual_review": True,
+        }
+        mapping = PatternMapping.from_dict(data)
+        assert mapping.java_pattern_id == "java_from_dict"
+        assert mapping.bedrock_pattern_id == "bedrock_from_dict"
+        assert mapping.confidence == 0.7
+        assert mapping.notes == "From dict notes"
+        assert mapping.limitations == ["from dict limit"]
+        assert mapping.requires_manual_review is True
+
+    def test_pattern_mapping_from_dict_with_missing_optional_fields(self):
+        """Test from_dict handles missing optional fields with defaults."""
+        data = {
+            "java_pattern_id": "java_minimal",
+            "bedrock_pattern_id": "bedrock_minimal",
+            "confidence": 0.5,
+        }
+        mapping = PatternMapping.from_dict(data)
+        assert mapping.notes == ""
+        assert mapping.limitations == []
+        assert mapping.requires_manual_review is False
+
+    def test_pattern_mapping_to_dict_roundtrip(self):
+        """Test to_dict and from_dict are inverses."""
+        original = PatternMapping(
+            java_pattern_id="java_roundtrip",
+            bedrock_pattern_id="bedrock_roundtrip",
+            confidence=0.92,
+            notes="Roundtrip test",
+            limitations=["limit a", "limit b"],
+            requires_manual_review=True,
+        )
+        recovered = PatternMapping.from_dict(original.to_dict())
+        assert recovered.java_pattern_id == original.java_pattern_id
+        assert recovered.bedrock_pattern_id == original.bedrock_pattern_id
+        assert recovered.confidence == original.confidence
+        assert recovered.notes == original.notes
+        assert recovered.limitations == original.limitations
+        assert recovered.requires_manual_review == original.requires_manual_review
+
+
+class TestMappingConfidence:
+    """Tests for MappingConfidence enum."""
+
+    def test_mapping_confidence_values(self):
+        """Test MappingConfidence enum has expected values."""
+        assert MappingConfidence.HIGH.value == "high"
+        assert MappingConfidence.MEDIUM.value == "medium"
+        assert MappingConfidence.LOW.value == "low"
+        assert MappingConfidence.EXPERIMENTAL.value == "experimental"
+
+    def test_mapping_confidence_is_enum(self):
+        """Test MappingConfidence is a proper Enum."""
+        assert hasattr(MappingConfidence, "HIGH")
+        assert hasattr(MappingConfidence, "MEDIUM")
+        assert hasattr(MappingConfidence, "LOW")
+        assert hasattr(MappingConfidence, "EXPERIMENTAL")
+
+
+class TestPatternMappingRegistry:
+    """Tests for PatternMappingRegistry class."""
+
+    @pytest.fixture
+    def registry(self):
+        """Create a fresh PatternMappingRegistry for each test."""
+        return PatternMappingRegistry()
+
+    def test_registry_is_pre_populated(self, registry):
+        """Test that registry is initialized with pre-populated mappings."""
+        assert len(registry.mappings) >= 20
+
+    def test_registry_has_expected_known_mappings(self, registry):
+        """Test that registry contains specific known mappings."""
+        known_mappings = [
+            "java_simple_item",
+            "java_item_properties",
+            "java_food_item",
+            "java_ranged_weapon",
+            "java_simple_block",
+            "java_block_properties",
+            "java_rotatable_block",
+            "java_simple_entity",
+            "java_entity_attributes",
+            "java_shaped_recipe",
+            "java_shapeless_recipe",
+            "java_smelting_recipe",
+            "java_player_interact",
+            "java_block_break",
+            "java_entity_join",
+            "java_item_handler",
+            "java_fluid_handler",
+            "java_tile_entity",
+            "java_ticking_tile",
+            "java_network_packet",
+        ]
+        for mapping_id in known_mappings:
+            assert mapping_id in registry.mappings, f"Missing mapping: {mapping_id}"
+
+
+class TestPatternMappingRegistryAddMapping:
+    """Tests for PatternMappingRegistry.add_mapping method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_add_mapping_success(self, registry):
+        """Test adding a new mapping to the registry."""
+        new_mapping = PatternMapping(
+            java_pattern_id="java_custom_add",
+            bedrock_pattern_id="bedrock_custom_add",
+            confidence=0.88,
+            notes="Custom mapping added in test",
+        )
+        registry.add_mapping(new_mapping)
+        result = registry.get_bedrock_equivalent("java_custom_add")
+        assert result is not None
+        assert result.bedrock_pattern_id == "bedrock_custom_add"
+        assert result.confidence == 0.88
+
+    def test_add_mapping_duplicate_raises_error(self, registry):
+        """Test that adding duplicate java_pattern_id raises ValueError."""
+        existing_mapping = registry.get_bedrock_equivalent("java_simple_item")
+        duplicate = PatternMapping(
+            java_pattern_id="java_simple_item",
+            bedrock_pattern_id="bedrock_different",
+            confidence=0.5,
+        )
+        with pytest.raises(ValueError, match="java_simple_item already exists"):
+            registry.add_mapping(duplicate)
+
+    def test_add_mapping_multiple_new_mappings(self, registry):
+        """Test adding multiple new mappings."""
+        mapping1 = PatternMapping("java_new_1", "bedrock_new_1", 0.9)
+        mapping2 = PatternMapping("java_new_2", "bedrock_new_2", 0.85)
+        mapping3 = PatternMapping("java_new_3", "bedrock_new_3", 0.8)
+
+        initial_count = len(registry.mappings)
+        registry.add_mapping(mapping1)
+        registry.add_mapping(mapping2)
+        registry.add_mapping(mapping3)
+
+        assert len(registry.mappings) == initial_count + 3
+        assert registry.get_bedrock_equivalent("java_new_1") is not None
+        assert registry.get_bedrock_equivalent("java_new_2") is not None
+        assert registry.get_bedrock_equivalent("java_new_3") is not None
+
+
+class TestPatternMappingRegistryGetBedrockEquivalent:
+    """Tests for PatternMappingRegistry.get_bedrock_equivalent method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_get_bedrock_equivalent_existing_mapping(self, registry):
+        """Test getting an existing mapping returns correct data."""
+        result = registry.get_bedrock_equivalent("java_simple_item")
+        assert result is not None
+        assert isinstance(result, PatternMapping)
+        assert result.bedrock_pattern_id == "bedrock_simple_item"
+        assert result.confidence == 0.95
+
+    def test_get_bedrock_equivalent_nonexistent(self, registry):
+        """Test getting a nonexistent mapping returns None."""
+        result = registry.get_bedrock_equivalent("java_nonexistent_pattern")
+        assert result is None
+
+    def test_get_bedrock_equivalent_empty_string(self, registry):
+        """Test getting mapping with empty string returns None."""
+        result = registry.get_bedrock_equivalent("")
+        assert result is None
+
+    def test_get_bedrock_equivalent_returns_correct_confidence(self, registry):
+        """Test different mappings return their correct confidence values."""
+        test_cases = [
+            ("java_simple_item", 0.95),
+            ("java_item_properties", 0.90),
+            ("java_ranged_weapon", 0.75),
+            ("java_fluid_handler", 0.60),
+            ("java_network_packet", 0.60),
+        ]
+        for java_id, expected_confidence in test_cases:
+            result = registry.get_bedrock_equivalent(java_id)
+            assert result is not None, f"Mapping {java_id} not found"
+            assert result.confidence == expected_confidence, (
+                f"Expected confidence {expected_confidence} for {java_id}, "
+                f"got {result.confidence}"
+            )
+
+
+class TestPatternMappingRegistryGetByConfidence:
+    """Tests for PatternMappingRegistry.get_by_confidence method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_get_by_confidence_returns_mappings_at_threshold(self, registry):
+        """Test that get_by_confidence returns mappings at exactly the threshold."""
+        results = registry.get_by_confidence(0.95)
+        for mapping in results:
+            assert mapping.confidence >= 0.95
+
+    def test_get_by_confidence_high_threshold(self, registry):
+        """Test get_by_confidence with high threshold returns fewer results."""
+        high_results = registry.get_by_confidence(0.95)
+        low_results = registry.get_by_confidence(0.5)
+        assert len(high_results) <= len(low_results)
+
+    def test_get_by_confidence_zero_threshold(self, registry):
+        """Test get_by_confidence with 0.0 threshold returns all mappings."""
+        results = registry.get_by_confidence(0.0)
+        assert len(results) == len(registry.mappings)
+
+    def test_get_by_confidence_boundary_values(self, registry):
+        """Test get_by_confidence with boundary confidence values."""
+        item_mapping = registry.get_bedrock_equivalent("java_simple_item")
+        exact_confidence = item_mapping.confidence
+        results = registry.get_by_confidence(exact_confidence)
+        assert any(m.java_pattern_id == "java_simple_item" for m in results)
+
+    def test_get_by_confidence_returns_list(self, registry):
+        """Test that get_by_confidence returns a list."""
+        results = registry.get_by_confidence(0.8)
+        assert isinstance(results, list)
+
+    def test_get_by_confidence_empty_result_for_impossible_threshold(self, registry):
+        """Test that impossible threshold returns empty list."""
+        results = registry.get_by_confidence(1.1)
+        assert len(results) == 0
+
+
+class TestPatternMappingRegistrySearchMappings:
+    """Tests for PatternMappingRegistry.search_mappings method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_search_mappings_returns_list(self, registry):
+        """Test that search_mappings returns a list."""
+        results = registry.search_mappings("item")
+        assert isinstance(results, list)
+
+    def test_search_mappings_by_java_pattern_id(self, registry):
+        """Test searching by Java pattern ID returns matches."""
+        results = registry.search_mappings("item")
+        assert len(results) > 0
+        assert any("item" in m.java_pattern_id.lower() for m in results)
+
+    def test_search_mappings_by_notes_content(self, registry):
+        """Test searching by notes content."""
+        results = registry.search_mappings("Script API")
+        assert len(results) > 0
+
+    def test_search_mappings_with_min_confidence(self, registry):
+        """Test search_mappings respects min_confidence filter."""
+        results = registry.search_mappings("entity", min_confidence=0.8)
+        for mapping in results:
+            assert mapping.confidence >= 0.8
+
+    def test_search_mappings_with_feature_type(self, registry):
+        """Test search_mappings with feature_type filter."""
+        results = registry.search_mappings("block", feature_type="block")
+        assert len(results) > 0
+
+    def test_search_mappings_empty_query(self, registry):
+        """Test search_mappings with empty query returns empty list."""
+        results = registry.search_mappings("")
+        assert len(results) == 0
+
+    def test_search_mappings_nonexistent_pattern(self, registry):
+        """Test search_mappings for nonexistent pattern."""
+        results = registry.search_mappings("xyznonexistent12345")
+        assert len(results) == 0
+
+    def test_search_mappings_sorted_by_relevance(self, registry):
+        """Test that results are sorted by relevance score."""
+        results = registry.search_mappings("recipe")
+        if len(results) >= 2:
+            assert results[0].confidence >= results[-1].confidence
+
+
+class TestPatternMappingRegistryGetStats:
+    """Tests for PatternMappingRegistry.get_stats method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_get_stats_returns_dict(self, registry):
+        """Test that get_stats returns a dictionary."""
+        stats = registry.get_stats()
+        assert isinstance(stats, dict)
+
+    def test_get_stats_has_required_keys(self, registry):
+        """Test that stats contains required keys."""
+        stats = registry.get_stats()
+        assert "total" in stats
+        assert "by_confidence" in stats
+        assert "requires_manual_review" in stats
+
+    def test_get_stats_total_matches_mapping_count(self, registry):
+        """Test that total in stats matches actual mapping count."""
+        stats = registry.get_stats()
+        assert stats["total"] == len(registry.mappings)
+
+    def test_get_stats_by_confidence_structure(self, registry):
+        """Test by_confidence has expected structure."""
+        stats = registry.get_stats()
+        by_conf = stats["by_confidence"]
+        assert "high" in by_conf
+        assert "medium" in by_conf
+        assert "low" in by_conf
+
+    def test_get_stats_by_confidence_values(self, registry):
+        """Test that by_confidence counts are consistent."""
+        stats = registry.get_stats()
+        by_conf = stats["by_confidence"]
+        total_categorized = by_conf["high"] + by_conf["medium"] + by_conf["low"]
+        assert total_categorized == stats["total"]
+
+    def test_get_stats_high_confidence_correct(self, registry):
+        """Test high confidence count (>= 0.8)."""
+        stats = registry.get_stats()
+        expected_high = len([m for m in registry.mappings.values() if m.confidence >= 0.8])
+        assert stats["by_confidence"]["high"] == expected_high
+
+    def test_get_stats_medium_confidence_correct(self, registry):
+        """Test medium confidence count (0.5 <= x < 0.8)."""
+        stats = registry.get_stats()
+        expected_medium = len([
+            m for m in registry.mappings.values()
+            if 0.5 <= m.confidence < 0.8
+        ])
+        assert stats["by_confidence"]["medium"] == expected_medium
+
+    def test_get_stats_low_confidence_correct(self, registry):
+        """Test low confidence count (< 0.5)."""
+        stats = registry.get_stats()
+        expected_low = len([m for m in registry.mappings.values() if m.confidence < 0.5])
+        assert stats["by_confidence"]["low"] == expected_low
+
+    def test_get_stats_manual_review_count(self, registry):
+        """Test manual review count is accurate."""
+        stats = registry.get_stats()
+        expected_review = len([
+            m for m in registry.mappings.values()
+            if m.requires_manual_review
+        ])
+        assert stats["requires_manual_review"] == expected_review
+
+
+class TestPatternMappingRegistryGetAllMappings:
+    """Tests for PatternMappingRegistry.get_all_mappings method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_get_all_mappings_returns_list(self, registry):
+        """Test that get_all_mappings returns a list."""
+        results = registry.get_all_mappings()
+        assert isinstance(results, list)
+
+    def test_get_all_mappings_count_matches(self, registry):
+        """Test that count matches registry mappings."""
+        results = registry.get_all_mappings()
+        assert len(results) == len(registry.mappings)
+
+    def test_get_all_mappings_contains_all_mappings(self, registry):
+        """Test that all mappings are returned."""
+        results = registry.get_all_mappings()
+        for mapping in registry.mappings.values():
+            assert mapping in results
+
+
+class TestPatternMappingRegistryGetManualReviewRequired:
+    """Tests for PatternMappingRegistry.get_manual_review_required method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_get_manual_review_required_returns_list(self, registry):
+        """Test that get_manual_review_required returns a list."""
+        results = registry.get_manual_review_required()
+        assert isinstance(results, list)
+
+    def test_get_manual_review_required_all_require_review(self, registry):
+        """Test that all returned mappings require manual review."""
+        results = registry.get_manual_review_required()
+        for mapping in results:
+            assert mapping.requires_manual_review is True
+
+    def test_get_manual_review_required_has_expected_mappings(self, registry):
+        """Test that expected mappings requiring review are returned."""
+        results = registry.get_manual_review_required()
+        known_review_mappings = [
+            "java_ranged_weapon",
+            "java_rotatable_block",
+            "java_simple_entity",
+            "java_player_interact",
+        ]
+        result_ids = [m.java_pattern_id for m in results]
+        for mapping_id in known_review_mappings:
+            if mapping_id in registry.mappings:
+                assert mapping_id in result_ids, f"{mapping_id} should require manual review"
+
+
+class TestPatternMappingRegistryGetMappingsForFeatureType:
+    """Tests for PatternMappingRegistry.get_mappings_for_feature_type method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_get_mappings_for_feature_type_block(self, registry):
+        """Test getting block-related mappings."""
+        results = registry.get_mappings_for_feature_type("block")
+        assert len(results) > 0
+        expected_ids = [
+            "java_simple_block",
+            "java_block_properties",
+            "java_rotatable_block",
+            "java_tile_entity",
+            "java_ticking_tile",
+        ]
+        result_ids = [m.java_pattern_id for m in results]
+        for pid in expected_ids:
+            assert pid in result_ids
+
+    def test_get_mappings_for_feature_type_item(self, registry):
+        """Test getting item-related mappings."""
+        results = registry.get_mappings_for_feature_type("item")
+        assert len(results) > 0
+        expected_ids = [
+            "java_simple_item",
+            "java_item_properties",
+            "java_food_item",
+            "java_ranged_weapon",
+        ]
+        result_ids = [m.java_pattern_id for m in results]
+        for pid in expected_ids:
+            assert pid in result_ids
+
+    def test_get_mappings_for_feature_type_entity(self, registry):
+        """Test getting entity-related mappings."""
+        results = registry.get_mappings_for_feature_type("entity")
+        assert len(results) >= 2
+        result_ids = [m.java_pattern_id for m in results]
+        assert "java_simple_entity" in result_ids
+        assert "java_entity_attributes" in result_ids
+
+    def test_get_mappings_for_feature_type_case_insensitive(self, registry):
+        """Test that feature type is case insensitive."""
+        lower_results = registry.get_mappings_for_feature_type("block")
+        upper_results = registry.get_mappings_for_feature_type("BLOCK")
+        mixed_results = registry.get_mappings_for_feature_type("Block")
+        assert len(lower_results) == len(upper_results) == len(mixed_results)
+
+    def test_get_mappings_for_feature_type_unknown(self, registry):
+        """Test unknown feature type returns empty list."""
+        results = registry.get_mappings_for_feature_type("unknown_feature_xyz")
+        assert len(results) == 0
+
+
+class TestPatternMappingRegistryToIndexableDocuments:
+    """Tests for PatternMappingRegistry.to_indexable_documents method."""
+
+    @pytest.fixture
+    def registry(self):
+        return PatternMappingRegistry()
+
+    def test_to_indexable_documents_returns_list(self, registry):
+        """Test that to_indexable_documents returns a list."""
+        results = registry.to_indexable_documents()
+        assert isinstance(results, list)
+
+    def test_to_indexable_documents_count_matches(self, registry):
+        """Test that document count matches mapping count."""
+        results = registry.to_indexable_documents()
+        assert len(results) == len(registry.mappings)
+
+    def test_to_indexable_documents_has_required_keys(self, registry):
+        """Test that each document has required keys."""
+        results = registry.to_indexable_documents()
+        for doc in results:
+            assert "content" in doc
+            assert "source" in doc
+            assert "metadata" in doc
+
+    def test_to_indexable_documents_source_format(self, registry):
+        """Test that source field has expected format."""
+        results = registry.to_indexable_documents()
+        for doc in results:
+            assert doc["source"].startswith("pattern_mapping:")
+            java_id = doc["source"].replace("pattern_mapping:", "")
+            assert java_id in registry.mappings
+
+    def test_to_indexable_documents_metadata_matches_mapping(self, registry):
+        """Test that metadata matches original mapping."""
+        results = registry.to_indexable_documents()
+        for doc in results:
+            java_id = doc["source"].replace("pattern_mapping:", "")
+            original = registry.mappings[java_id]
+            assert doc["metadata"]["java_pattern_id"] == original.java_pattern_id
+            assert doc["metadata"]["bedrock_pattern_id"] == original.bedrock_pattern_id
+            assert doc["metadata"]["confidence"] == original.confidence

--- a/ai-engine/tests/unit/test_models_document.py
+++ b/ai-engine/tests/unit/test_models_document.py
@@ -1,0 +1,161 @@
+"""Unit tests for the Document model."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict
+
+import pytest
+
+from models.document import Document
+
+
+class TestDocumentInitialization:
+    """Tests for Document dataclass initialization."""
+
+    @pytest.mark.unit
+    def test_init_with_required_fields(self):
+        """Test creating Document with only required fields."""
+        doc = Document(content="Hello world", source="https://example.com")
+        assert doc.content == "Hello world"
+        assert doc.source == "https://example.com"
+        assert doc.doc_type == "generic"
+        assert doc.metadata == {}
+        assert doc.content_hash is not None
+
+    @pytest.mark.unit
+    def test_init_with_all_fields(self):
+        """Test creating Document with all fields specified."""
+        metadata = {"author": "test", "version": 1}
+        doc = Document(
+            content="Test content",
+            source="test-source",
+            doc_type="tutorial",
+            metadata=metadata,
+            content_hash="custom_hash",
+        )
+        assert doc.content == "Test content"
+        assert doc.source == "test-source"
+        assert doc.doc_type == "tutorial"
+        assert doc.metadata == metadata
+        assert doc.content_hash == "custom_hash"
+
+    @pytest.mark.unit
+    def test_default_doc_type(self):
+        """Test that default doc_type is 'generic'."""
+        doc = Document(content="content", source="source")
+        assert doc.doc_type == "generic"
+
+    @pytest.mark.unit
+    def test_default_metadata(self):
+        """Test that default metadata is an empty dict."""
+        doc = Document(content="content", source="source")
+        assert doc.metadata == {}
+
+    @pytest.mark.unit
+    def test_custom_metadata(self):
+        """Test that custom metadata values are preserved."""
+        metadata: Dict[str, Any] = {"key1": "value1", "key2": 42, "nested": {"a": 1}}
+        doc = Document(content="content", source="source", metadata=metadata)
+        assert doc.metadata == metadata
+        assert doc.metadata["key1"] == "value1"
+        assert doc.metadata["nested"] == {"a": 1}
+
+
+class TestDocumentPostInit:
+    """Tests for Document.__post_init__ hash generation."""
+
+    @pytest.mark.unit
+    def test_post_init_generates_hash_when_none(self):
+        """Test that __post_init__ generates content_hash when not provided."""
+        content = "Test content for hashing"
+        doc = Document(content=content, source="source")
+        expected_hash = hashlib.md5(content.encode("utf-8")).hexdigest()
+        assert doc.content_hash == expected_hash
+
+    @pytest.mark.unit
+    def test_post_init_preserves_existing_hash(self):
+        """Test that __post_init__ preserves content_hash if already set."""
+        existing_hash = "existing_hash_value"
+        doc = Document(
+            content="Some content",
+            source="source",
+            content_hash=existing_hash,
+        )
+        assert doc.content_hash == existing_hash
+
+    @pytest.mark.unit
+    def test_post_init_no_hash_when_content_empty(self):
+        """Test that __post_init__ does not generate hash for empty content."""
+        doc = Document(content="", source="source")
+        assert doc.content_hash is None
+
+    @pytest.mark.unit
+    def test_post_init_no_hash_when_content_empty(self):
+        """Test that __post_init__ does not generate hash for empty content."""
+        doc = Document(content="", source="source")
+        assert doc.content_hash is None
+
+    @pytest.mark.unit
+    def test_post_init_generates_hash_for_whitespace_content(self):
+        """Test that __post_init__ generates hash for whitespace-only content.
+
+        Note: whitespace-only strings are truthy in Python (bool("   ") == True),
+        so the implementation hashes them since content is non-empty.
+        """
+        doc = Document(content="   ", source="source")
+        assert doc.content_hash is not None
+        assert len(doc.content_hash) == 32
+
+    @pytest.mark.unit
+    def test_post_init_hash_consistency(self):
+        """Test that same content produces same hash."""
+        content = "Consistent content"
+        doc1 = Document(content=content, source="source1")
+        doc2 = Document(content=content, source="source2")
+        assert doc1.content_hash == doc2.content_hash
+
+    @pytest.mark.unit
+    def test_post_init_different_content_different_hash(self):
+        """Test that different content produces different hashes."""
+        doc1 = Document(content="Content A", source="source")
+        doc2 = Document(content="Content B", source="source")
+        assert doc1.content_hash != doc2.content_hash
+
+    @pytest.mark.unit
+    def test_post_init_hash_length(self):
+        """Test that generated hash is MD5 hex length (32 characters)."""
+        doc = Document(content="Any content here", source="source")
+        assert doc.content_hash is not None
+        assert len(doc.content_hash) == 32
+        # MD5 hashes are hexadecimal (0-9, a-f)
+        assert all(c in "0123456789abcdef" for c in doc.content_hash)
+
+
+class TestDocumentFieldAccess:
+    """Tests for Document field access."""
+
+    @pytest.mark.unit
+    def test_content_access(self):
+        """Test accessing content field."""
+        doc = Document(content="Hello", source="source")
+        assert doc.content == "Hello"
+
+    @pytest.mark.unit
+    def test_source_access(self):
+        """Test accessing source field."""
+        doc = Document(content="content", source="https://api.example.com/docs")
+        assert doc.source == "https://api.example.com/docs"
+
+    @pytest.mark.unit
+    def test_doc_type_access(self):
+        """Test accessing doc_type field."""
+        doc = Document(content="content", source="source", doc_type="api_reference")
+        assert doc.doc_type == "api_reference"
+
+    @pytest.mark.unit
+    def test_content_hash_access(self):
+        """Test accessing content_hash field."""
+        doc = Document(content="content", source="source")
+        assert doc.content_hash is not None
+        assert isinstance(doc.content_hash, str)

--- a/ai-engine/tests/unit/test_monitoring.py
+++ b/ai-engine/tests/unit/test_monitoring.py
@@ -1,0 +1,182 @@
+"""
+Unit tests for orchestration/monitoring.py
+
+Tests PerformanceMetric, ExecutionEvent, and OrchestrationMonitor classes.
+"""
+
+import pytest
+import time
+from orchestration.monitoring import (
+    PerformanceMetric,
+    ExecutionEvent,
+    OrchestrationMonitor,
+)
+from orchestration.strategy_selector import OrchestrationStrategy
+
+
+class TestPerformanceMetric:
+    """Tests for PerformanceMetric dataclass."""
+
+    def test_create_minimal(self):
+        """Test creating a minimal PerformanceMetric."""
+        metric = PerformanceMetric(metric_name="test_metric", value=1.0)
+        assert metric.metric_name == "test_metric"
+        assert metric.value == 1.0
+        assert "timestamp" in metric.to_dict()
+
+    def test_create_with_metadata(self):
+        """Test creating a PerformanceMetric with metadata."""
+        metric = PerformanceMetric(
+            metric_name="test_metric",
+            value=2.5,
+            metadata={"key": "value"},
+        )
+        assert metric.metadata == {"key": "value"}
+
+    def test_to_dict(self):
+        """Test converting to dictionary."""
+        metric = PerformanceMetric(metric_name="test", value=1.0)
+        d = metric.to_dict()
+        assert d["metric_name"] == "test"
+        assert d["value"] == 1.0
+        assert "timestamp" in d
+        assert "metadata" in d
+
+
+class TestExecutionEvent:
+    """Tests for ExecutionEvent dataclass."""
+
+    def test_create_minimal(self):
+        """Test creating a minimal ExecutionEvent."""
+        event = ExecutionEvent(event_type="task_started")
+        assert event.event_type == "task_started"
+        assert "timestamp" in event.to_dict()
+
+    def test_create_with_details(self):
+        """Test creating an ExecutionEvent with all details."""
+        event = ExecutionEvent(
+            event_type="task_completed",
+            task_id="task-123",
+            agent_name="converter",
+            strategy="parallel",
+            details={"duration": 10.5},
+        )
+        assert event.task_id == "task-123"
+        assert event.agent_name == "converter"
+        assert event.strategy == "parallel"
+        assert event.details == {"duration": 10.5}
+
+    def test_to_dict(self):
+        """Test converting to dictionary."""
+        event = ExecutionEvent(
+            event_type="task_failed",
+            task_id="task-456",
+            details={"error": "timeout"},
+        )
+        d = event.to_dict()
+        assert d["event_type"] == "task_failed"
+        assert d["task_id"] == "task-456"
+        assert d["details"]["error"] == "timeout"
+
+
+class TestOrchestrationMonitor:
+    """Tests for OrchestrationMonitor class."""
+
+    def test_init_default(self):
+        """Test initialization with default values."""
+        # Don't start real-time monitoring to avoid thread issues
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        assert monitor.enable_real_time_monitoring is False
+        assert monitor.metrics_retention_hours == 24
+        assert monitor.metrics == []
+        assert monitor.execution_events == []
+        assert monitor.active_executions == {}
+
+    def test_init_custom(self):
+        """Test initialization with custom values."""
+        monitor = OrchestrationMonitor(
+            enable_real_time_monitoring=False,
+            metrics_retention_hours=48,
+        )
+        assert monitor.metrics_retention_hours == 48
+
+    def test_init_custom_alert_thresholds(self):
+        """Test initialization with custom alert thresholds."""
+        custom_thresholds = {"task_failure_rate": 0.3}
+        monitor = OrchestrationMonitor(
+            enable_real_time_monitoring=False,
+            alert_thresholds=custom_thresholds,
+        )
+        assert monitor.alert_thresholds["task_failure_rate"] == 0.3
+
+    def test_record_execution_start(self):
+        """Test recording execution start."""
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        monitor.record_execution_start(
+            execution_id="exec-1",
+            strategy=OrchestrationStrategy.SEQUENTIAL,
+            task_count=5,
+        )
+        assert "exec-1" in monitor.active_executions
+        assert len(monitor.execution_events) == 1
+        assert monitor.execution_events[0].event_type == "execution_started"
+
+    def test_record_execution_end(self):
+        """Test recording execution end."""
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        monitor.record_execution_start(
+            execution_id="exec-1",
+            strategy=OrchestrationStrategy.PARALLEL_BASIC,
+            task_count=3,
+        )
+        monitor.record_execution_end(
+            execution_id="exec-1",
+            success=True,
+            final_results={"overall_success_rate": 1.0},
+        )
+        assert "exec-1" not in monitor.active_executions
+
+    def test_get_execution_events(self):
+        """Test getting execution events."""
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        monitor.record_execution_start(
+            execution_id="exec-1",
+            strategy=OrchestrationStrategy.SEQUENTIAL,
+            task_count=2,
+        )
+        events = monitor.get_execution_events()
+        assert isinstance(events, list)
+        assert len(events) == 1
+        # Returns dicts, not ExecutionEvent objects
+        assert events[0]["event_type"] == "execution_started"
+
+    def test_get_performance_summary(self):
+        """Test getting performance summary."""
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        summary = monitor.get_performance_summary()
+        assert isinstance(summary, dict)
+
+    def test_get_detailed_metrics(self):
+        """Test getting detailed metrics."""
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        metrics = monitor.get_detailed_metrics()
+        assert isinstance(metrics, list)
+
+    def test_export_metrics(self, tmp_path):
+        """Test exporting metrics."""
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        export_file = tmp_path / "metrics.json"
+        result = monitor.export_metrics(str(export_file))
+        assert result is True
+        assert export_file.exists()
+
+    def test_add_alert_callback(self):
+        """Test adding an alert callback."""
+        monitor = OrchestrationMonitor(enable_real_time_monitoring=False)
+        callback_called = []
+
+        def my_callback(alert_type, details):
+            callback_called.append((alert_type, details))
+
+        monitor.add_alert_callback(my_callback)
+        assert len(monitor.alert_callbacks) == 1

--- a/ai-engine/tests/unit/test_rag_pipeline.py
+++ b/ai-engine/tests/unit/test_rag_pipeline.py
@@ -1,0 +1,178 @@
+"""
+Unit tests for search/rag_pipeline.py
+
+Tests QueryType, ComplexityLevel, QueryAnalysis, PipelineResult,
+PipelineConfig, and PipelineStage classes.
+"""
+
+import pytest
+from search.rag_pipeline import (
+    QueryType,
+    ComplexityLevel,
+    QueryAnalysis,
+    PipelineResult,
+    PipelineConfig,
+    PipelineStage,
+    QueryAnalysisStage,
+)
+
+
+class TestQueryType:
+    """Tests for QueryType enum."""
+
+    def test_query_types_exist(self):
+        """Test that all expected query types exist."""
+        assert QueryType.INFORMATIONAL.value == "informational"
+        assert QueryType.NAVIGATIONAL.value == "navigational"
+        assert QueryType.TRANSACTIONAL.value == "transactional"
+        assert QueryType.COMPLEX.value == "complex"
+        assert QueryType.SIMPLE.value == "simple"
+
+    def test_query_type_is_string(self):
+        """Test that QueryType values are strings."""
+        for qt in QueryType:
+            assert isinstance(qt.value, str)
+
+
+class TestComplexityLevel:
+    """Tests for ComplexityLevel enum."""
+
+    def test_complexity_levels_exist(self):
+        """Test that all expected complexity levels exist."""
+        assert ComplexityLevel.SIMPLE.value == "simple"
+        assert ComplexityLevel.STANDARD.value == "standard"
+        assert ComplexityLevel.COMPLEX.value == "complex"
+
+    def test_complexity_level_is_string(self):
+        """Test that ComplexityLevel values are strings."""
+        for cl in ComplexityLevel:
+            assert isinstance(cl.value, str)
+
+
+class TestQueryAnalysis:
+    """Tests for QueryAnalysis dataclass."""
+
+    def test_create_minimal(self):
+        """Test creating a minimal QueryAnalysis."""
+        analysis = QueryAnalysis(original_query="How to spawn entity?")
+        assert analysis.original_query == "How to spawn entity?"
+        assert analysis.rewritten_query is None
+        assert analysis.expanded_terms == []
+        assert analysis.query_type == QueryType.SIMPLE
+        assert analysis.complexity == ComplexityLevel.SIMPLE
+        assert analysis.confidence == 1.0
+
+    def test_create_full(self):
+        """Test creating a full QueryAnalysis."""
+        analysis = QueryAnalysis(
+            original_query="How to spawn entity?",
+            rewritten_query="Spawning entities in Minecraft",
+            expanded_terms=["entity", "spawn", "minecraft"],
+            query_type=QueryType.INFORMATIONAL,
+            complexity=ComplexityLevel.COMPLEX,
+            confidence=0.9,
+        )
+        assert analysis.original_query == "How to spawn entity?"
+        assert analysis.rewritten_query == "Spawning entities in Minecraft"
+        assert analysis.expanded_terms == ["entity", "spawn", "minecraft"]
+        assert analysis.query_type == QueryType.INFORMATIONAL
+        assert analysis.complexity == ComplexityLevel.COMPLEX
+        assert analysis.confidence == 0.9
+
+
+class TestPipelineResult:
+    """Tests for PipelineResult dataclass."""
+
+    def test_create_empty(self):
+        """Test creating a minimal PipelineResult."""
+        analysis = QueryAnalysis(original_query="test")
+        result = PipelineResult(results=[], query_analysis=analysis)
+        assert result.results == []
+        assert result.query_analysis == analysis
+        assert result.expansion_metadata == {}
+        assert result.reranking_stages_applied == []
+        assert result.timing == {}
+
+    def test_create_with_timing(self):
+        """Test creating a PipelineResult with timing info."""
+        analysis = QueryAnalysis(original_query="test")
+        result = PipelineResult(
+            results=[],
+            query_analysis=analysis,
+            timing={"query_analysis": 0.1, "search": 0.5},
+        )
+        assert result.timing["query_analysis"] == 0.1
+        assert result.timing["search"] == 0.5
+
+
+class TestPipelineConfig:
+    """Tests for PipelineConfig dataclass."""
+
+    def test_default_config(self):
+        """Test default pipeline configuration."""
+        config = PipelineConfig()
+        assert config.enable_query_expansion is True
+        assert config.enable_reranking is True
+        assert config.reranking_stages == ["feature", "cross_encoder"]
+        assert config.fusion_strategy == "reciprocal_rank"
+        assert config.max_results == 20
+        assert config.cache_enabled is True
+        assert config.cache_ttl == 3600
+        assert config.cache_backend == "memory"
+
+    def test_custom_config(self):
+        """Test custom pipeline configuration."""
+        config = PipelineConfig(
+            enable_query_expansion=False,
+            enable_reranking=False,
+            reranking_stages=["bm25"],
+            max_results=50,
+            cache_enabled=False,
+        )
+        assert config.enable_query_expansion is False
+        assert config.enable_reranking is False
+        assert config.reranking_stages == ["bm25"]
+        assert config.max_results == 50
+        assert config.cache_enabled is False
+
+
+class TestQueryAnalysisStage:
+    """Tests for QueryAnalysisStage class."""
+
+    def test_process_informational_query(self):
+        """Test processing an informational query."""
+        stage = QueryAnalysisStage()
+        result = stage.process("What is entity spawning?")
+        assert result.query_type == QueryType.INFORMATIONAL
+        assert result.complexity in [ComplexityLevel.SIMPLE, ComplexityLevel.STANDARD, ComplexityLevel.COMPLEX]
+
+    def test_process_navigational_query(self):
+        """Test processing a navigational query."""
+        stage = QueryAnalysisStage()
+        result = stage.process("Minecraft documentation link")
+        assert result.query_type == QueryType.NAVIGATIONAL
+
+    def test_process_transactional_query(self):
+        """Test processing a transactional query."""
+        stage = QueryAnalysisStage()
+        result = stage.process("Download mod installer")
+        assert result.query_type == QueryType.TRANSACTIONAL
+
+    def test_process_simple_query(self):
+        """Test processing a simple query."""
+        stage = QueryAnalysisStage()
+        result = stage.process("spawn entity")
+        assert result.query_type == QueryType.SIMPLE
+
+    def test_process_empty_query(self):
+        """Test processing an empty query."""
+        stage = QueryAnalysisStage()
+        result = stage.process("")
+        # Empty query should default to SIMPLE
+        assert result.query_type == QueryType.SIMPLE
+
+    def test_get_config(self):
+        """Test getting stage configuration."""
+        stage = QueryAnalysisStage()
+        config = stage.get_config()
+        assert isinstance(config, dict)

--- a/ai-engine/tests/unit/test_search_pipeline_cache.py
+++ b/ai-engine/tests/unit/test_search_pipeline_cache.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for search/pipeline_cache.py - MemoryCache class.
+
+Tests cover:
+- MemoryCache.get() - cache miss scenarios
+- MemoryCache.set()
+- MemoryCache.delete()
+- MemoryCache.invalidate()
+- MemoryCache.get_stats()
+- LRU eviction logic
+"""
+
+import pytest
+import time
+from datetime import datetime, timezone
+
+from search.pipeline_cache import MemoryCache, CachedResult
+
+
+class TestMemoryCacheGet:
+    """Test MemoryCache.get() method."""
+
+    def test_get_cache_miss_returns_none(self):
+        """Test that get returns None for non-existent key."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        result = cache.get("nonexistent_key")
+        assert result is None
+
+    def test_get_cache_miss_increments_miss_counter(self):
+        """Test that cache miss increments miss counter."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.get("nonexistent")
+        stats = cache.get_stats()
+        assert stats["misses"] == 1
+
+    def test_get_expired_entry_returns_none(self):
+        """Test that get returns None for expired entry."""
+        cache = MemoryCache(max_size=100, ttl=1)
+        cache.set("key", {"data": "value"})
+        time.sleep(1.5)
+        result = cache.get("key")
+        assert result is None
+
+    def test_get_expired_increments_miss_counter(self):
+        """Test that accessing expired entry increments miss counter."""
+        cache = MemoryCache(max_size=100, ttl=1)
+        cache.set("key", {"data": "value"})
+        time.sleep(1.5)
+        cache.get("key")
+        stats = cache.get_stats()
+        assert stats["misses"] == 1
+
+    def test_get_valid_entry_returns_cached_result(self):
+        """Test that get returns cached result for valid entry."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key", {"data": "test_value"})
+        result = cache.get("key")
+        assert result is not None
+        assert result.data == {"data": "test_value"}
+
+    def test_get_valid_entry_increments_hit_counter(self):
+        """Test that cache hit increments hit counter."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key", {"data": "value"})
+        cache.get("key")
+        stats = cache.get_stats()
+        assert stats["hits"] == 1
+
+    def test_get_updates_lru_order(self):
+        """Test that get moves accessed key to end (LRU behavior)."""
+        cache = MemoryCache(max_size=3, ttl=3600)
+        cache.set("key1", {"data": "1"})
+        cache.set("key2", {"data": "2"})
+        cache.set("key3", {"data": "3"})
+        cache.get("key1")
+        cache.set("key4", {"data": "4"})
+        result = cache.get("key1")
+        assert result is not None
+
+
+class TestMemoryCacheSet:
+    """Test MemoryCache.set() method."""
+
+    def test_set_basic_dict(self):
+        """Test setting a dict value."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key", {"results": ["doc1", "doc2"]})
+        result = cache.get("key")
+        assert result is not None
+        assert result.data == {"results": ["doc1", "doc2"]}
+
+    def test_set_with_custom_ttl(self):
+        """Test setting with custom TTL."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key", {"data": "value"}, ttl=60)
+        cached = cache.get("key")
+        assert cached.ttl == 60
+
+    def test_set_with_default_ttl(self):
+        """Test setting uses cache's default TTL."""
+        cache = MemoryCache(max_size=100, ttl=1800)
+        cache.set("key", {"data": "value"})
+        cached = cache.get("key")
+        assert cached.ttl == 1800
+
+    def test_set_cached_result_directly(self):
+        """Test setting a CachedResult directly."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cached = CachedResult(data={"direct": "result"}, ttl=300)
+        cache.set("key", cached)
+        result = cache.get("key")
+        assert result is not None
+        assert result.data == {"direct": "result"}
+        assert result.ttl == 300
+
+    def test_set_preserves_results_field(self):
+        """Test that set preserves results field for backwards compat."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        data = {"results": ["r1", "r2"], "query_analysis": "test"}
+        cache.set("key", data)
+        result = cache.get("key")
+        assert result.results == ["r1", "r2"]
+
+    def test_set_updates_existing_key(self):
+        """Test that set updates existing key and moves to end."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key", {"data": "first"})
+        cache.set("key", {"data": "second"})
+        result = cache.get("key")
+        assert result.data == {"data": "second"}
+
+
+class TestMemoryCacheDelete:
+    """Test MemoryCache.delete() method."""
+
+    def test_delete_existing_key(self):
+        """Test deleting an existing key."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key", {"data": "value"})
+        cache.delete("key")
+        result = cache.get("key")
+        assert result is None
+
+    def test_delete_nonexistent_key(self):
+        """Test deleting a non-existent key does not raise."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.delete("nonexistent")
+        result = cache.get("nonexistent")
+        assert result is None
+
+    def test_delete_reduces_cache_size(self):
+        """Test that delete reduces cache size."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key1", {"data": "1"})
+        cache.set("key2", {"data": "2"})
+        assert cache.get_stats()["size"] == 2
+        cache.delete("key1")
+        assert cache.get_stats()["size"] == 1
+
+
+class TestMemoryCacheInvalidate:
+    """Test MemoryCache.invalidate() method."""
+
+    def test_invalidate_all_clears_cache(self):
+        """Test that invalidate with no pattern clears all entries."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key1", {"data": "1"})
+        cache.set("key2", {"data": "2"})
+        cache.invalidate()
+        assert cache.get("key1") is None
+        assert cache.get("key2") is None
+        assert cache.get_stats()["size"] == 0
+
+    def test_invalidate_with_pattern_deletes_matching(self):
+        """Test that invalidate with pattern deletes matching keys."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("query:java", {"data": "java"})
+        cache.set("query:python", {"data": "python"})
+        cache.set("query:rust", {"data": "rust"})
+        cache.invalidate(pattern="java")
+        assert cache.get("query:java") is None
+        assert cache.get("query:python") is not None
+        assert cache.get("query:rust") is not None
+
+    def test_invalidate_pattern_no_match(self):
+        """Test that invalidate with non-matching pattern does nothing."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key1", {"data": "1"})
+        cache.invalidate(pattern="nonexistent")
+        assert cache.get("key1") is not None
+
+    def test_invalidate_multiple_pattern_matches(self):
+        """Test invalidating multiple keys with same pattern prefix."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("user:1:data", {"data": "1"})
+        cache.set("user:1:profile", {"data": "2"})
+        cache.set("user:2:data", {"data": "3"})
+        cache.invalidate(pattern="user:1:")
+        assert cache.get("user:1:data") is None
+        assert cache.get("user:1:profile") is None
+        assert cache.get("user:2:data") is not None
+
+
+class TestMemoryCacheGetStats:
+    """Test MemoryCache.get_stats() method."""
+
+    def test_stats_initial_state(self):
+        """Test stats for empty cache."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        stats = cache.get_stats()
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+        assert stats["hit_rate"] == 0.0
+        assert stats["size"] == 0
+        assert stats["max_size"] == 100
+        assert stats["ttl"] == 3600
+
+    def test_stats_hit_rate_calculation(self):
+        """Test hit rate is calculated correctly."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        cache.set("key", {"data": "value"})
+        cache.get("key")
+        cache.get("key")
+        cache.get("missing")
+        stats = cache.get_stats()
+        assert stats["hits"] == 2
+        assert stats["misses"] == 1
+        assert stats["hit_rate"] == pytest.approx(2 / 3)
+
+    def test_stats_hit_rate_zero_total(self):
+        """Test hit rate is 0 when no operations performed."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        stats = cache.get_stats()
+        assert stats["hit_rate"] == 0.0
+
+    def test_stats_size_reflects_cache_contents(self):
+        """Test size in stats reflects actual cache contents."""
+        cache = MemoryCache(max_size=100, ttl=3600)
+        for i in range(10):
+            cache.set(f"key{i}", {"data": i})
+        stats = cache.get_stats()
+        assert stats["size"] == 10
+
+
+class TestMemoryCacheLRUEviction:
+    """Test LRU eviction logic in MemoryCache."""
+
+    def test_lru_eviction_removes_oldest(self):
+        """Test that LRU eviction removes oldest (first) entry."""
+        cache = MemoryCache(max_size=3, ttl=3600)
+        cache.set("key1", {"data": "1"})
+        cache.set("key2", {"data": "2"})
+        cache.set("key3", {"data": "3"})
+        cache.set("key4", {"data": "4"})
+        assert cache.get("key1") is None
+        assert cache.get("key2") is not None
+        assert cache.get("key3") is not None
+        assert cache.get("key4") is not None
+
+    def test_lru_get_moves_to_end(self):
+        """Test that get moves accessed item to end, protecting from eviction."""
+        cache = MemoryCache(max_size=3, ttl=3600)
+        cache.set("key1", {"data": "1"})
+        cache.set("key2", {"data": "2"})
+        cache.set("key3", {"data": "3"})
+        cache.get("key1")
+        cache.set("key4", {"data": "4"})
+        assert cache.get("key1") is not None
+        assert cache.get("key4") is not None
+
+    def test_lru_set_existing_moves_to_end(self):
+        """Test that updating existing key moves it to end."""
+        cache = MemoryCache(max_size=3, ttl=3600)
+        cache.set("key1", {"data": "1"})
+        cache.set("key2", {"data": "2"})
+        cache.set("key3", {"data": "3"})
+        cache.set("key1", {"data": "1_updated"})
+        cache.set("key4", {"data": "4"})
+        assert cache.get("key1") is not None
+        assert cache.get("key1").data == {"data": "1_updated"}
+
+    def test_lru_exact_max_size(self):
+        """Test cache does not exceed max_size."""
+        cache = MemoryCache(max_size=5, ttl=3600)
+        for i in range(10):
+            cache.set(f"key{i}", {"data": i})
+        stats = cache.get_stats()
+        assert stats["size"] == 5
+
+    def test_lru_order_after_mixed_operations(self):
+        """Test LRU order is maintained after mixed get/set operations.
+        
+        With max_size=4:
+        - Initial: [a, b, c, d]
+        - get(a): moves a to end -> [b, c, d, a]
+        - set(e): "a" exists so move_to_end (no-op), then insert e -> [b, c, d, a, e]
+                  Evict oldest (b) -> [c, d, a, e]
+        """
+        cache = MemoryCache(max_size=4, ttl=3600)
+        cache.set("a", {"data": "a"})
+        cache.set("b", {"data": "b"})
+        cache.set("c", {"data": "c"})
+        cache.set("d", {"data": "d"})
+        cache.get("a")
+        cache.set("e", {"data": "e"})
+        assert cache.get("a") is not None
+        assert cache.get("b") is None  # evicted during set(e)
+        assert cache.get("c") is not None
+        assert cache.get("d") is not None
+        assert cache.get("e") is not None
+
+
+class TestCachedResult:
+    """Test CachedResult dataclass."""
+
+    def test_cached_result_default_timestamp(self):
+        """Test CachedResult has default UTC timestamp."""
+        result = CachedResult(data={"key": "value"})
+        assert result.timestamp is not None
+        assert isinstance(result.timestamp, datetime)
+
+    def test_cached_result_default_ttl(self):
+        """Test CachedResult has default TTL of 3600."""
+        result = CachedResult(data={"key": "value"})
+        assert result.ttl == 3600
+
+    def test_cached_result_is_expired_with_seconds(self):
+        """Test is_expired with float timestamp."""
+        result = CachedResult(
+            data={"key": "value"},
+            timestamp=time.time() - 100,
+            ttl=10,
+        )
+        assert result.is_expired() is True
+
+    def test_cached_result_is_expired_with_datetime(self):
+        """Test is_expired with datetime timestamp."""
+        old_time = datetime.now(timezone.utc).timestamp() - 100
+        result = CachedResult(
+            data={"key": "value"},
+            timestamp=old_time,
+            ttl=10,
+        )
+        assert result.is_expired() is True
+
+    def test_cached_result_not_expired(self):
+        """Test is_expired returns False for fresh entry."""
+        result = CachedResult(
+            data={"key": "value"},
+            timestamp=time.time(),
+            ttl=3600,
+        )
+        assert result.is_expired() is False


### PR DESCRIPTION
## Summary

Add 197 unit tests covering 5 priority modules that had 0% coverage, directly addressing Issue #1687.

## New Test Files

| Test File | Tests | Module |
|-----------|-------|--------|
|  | 51 |  - PatternLibrary |
|  | 62 |  - PatternMappingRegistry |
|  | 34 |  - MemoryCache |
|  | 16 |  - Document dataclass |
|  | 34 |  - RubricScore, RubricResult |

## Additional Changes

- **pyproject.toml**: Updated coverage omits to exclude research/experimental code that isn't part of conversion pipeline
- **test_logic_translator_coverage.py**: Extended with error path tests

## Coverage Impact

These tests bring coverage to previously-untested modules:
-  - 0% → tested
-  - 0% → tested
-  - 0% → tested
-  - 0% → tested
-  - 0% → tested

Fixes #1687