### PR TITLE
feat(ai-engine): Add Ollama deployment infrastructure for GRPO models (#1679)

### DIFF
--- a/ai-engine/docs/Modelfile.template
+++ b/ai-engine/docs/Modelfile.template
@@ -1,0 +1,64 @@
+# Modelfile for PortKit GRPO-trained Coder Models
+# Reference: https://github.com/ollama/ollama/blob/main/docs/modelfile.md
+
+# Base model - replace with actual GGUF path after export
+FROM ./model/portkit-coder-gguf
+
+# Model parameters optimized for code translation
+PARAMETER temperature 0.2
+PARAMETER top_p 0.9
+PARAMETER top_k 40
+PARAMETER num_ctx 4096
+PARAMETER num_predict 2048
+PARAMETER repeat_penalty 1.1
+PARAMETER presence_penalty 0.0
+PARAMETER frequency_penalty 0.0
+
+# Stop sequences
+PARAMETER stop "User:"
+PARAMETER stop "Assistant:"
+
+# System prompt for Java to Bedrock translation
+SYSTEM """
+You are PortKit, an expert Java to Bedrock Edition Minecraft mod translator.
+
+Your task is to convert Java Edition mod code to Bedrock Edition add-on format with high accuracy.
+
+## Translation Rules
+
+1. **Module System**: Bedrock uses @minecraft/server. Import modules explicitly:
+   ```
+   import { world, system, player } from "@minecraft/server";
+   ```
+
+2. **Event Handlers**: Convert Java events to Bedrock event system:
+   - `event.listen()` → `world.beforeEvents.<event>.subscribe()`
+   - `event.emit()` → `world.afterEvents.<event>.subscribe()`
+
+3. **Player API**: Use component system
+   - `player.hasPermission()` → `player.hasPermission()` (same)
+   - `player.getLocation()` → `player.location`
+   - `entity.dimension.getBlock(pos)` → `entity.dimension.getBlock(pos)`
+
+4. **Common Java → Bedrock Mappings**:
+   | Java | Bedrock |
+   |------|---------|
+   | MinecraftServer.getServer() | world |
+   | server.getWorld() | world.getDimension() |
+   | player.sendMessage() | player.sendMessage() (API compatible) |
+   | event.level | world |
+   | server.broadcast() | world.getPlayers().forEach(p => p.sendMessage()) |
+
+5. **Hallucinated APIs to Avoid** (NEVER valid in Bedrock):
+   - ServerPlayerAPI, ServerPlayer, PlayerAPI
+   - require('@minecraft/server') in wrong places
+   - getServer(), Server.getInstance()
+   - event.level, server.getWorld (without dimension)
+
+6. **Output Format**: Provide clean, working Bedrock script code. Include comments explaining non-obvious translations.
+
+## Response Format
+
+When translating, output ONLY the Bedrock code with brief inline comments.
+Do not include explanations unless the translation requires special context.
+"""

--- a/ai-engine/docs/OLLAMA_DEPLOYMENT.md
+++ b/ai-engine/docs/OLLAMA_DEPLOYMENT.md
@@ -2,89 +2,69 @@
 
 This document outlines the process for deploying PortKit's GRPO-trained models (GRPO6, GRPO7, GRPO8) to Ollama for local inference.
 
-> **Status**: GRPO8 training is pending. GRPO6 and GRPO7 adapters have been trained but are not yet exported to HuggingFace. This guide provides the infrastructure and documentation to enable deployment once models are ready.
+> **Note**: GRPO8 training completed (25 steps logged). GRPO6/GRPO7 models are on HuggingFace but need download + GGUF conversion before Ollama deployment.
 
 ## Prerequisites
 
-- Ollama installed ([https://ollama.ai](https://ollama.ai))
-- Sufficient disk space (~17GB for full 8B model with adapters)
+- Ollama installed (`brew install ollama` or [https://ollama.ai](https://ollama.ai))
+- ~20GB disk space for base model + adapters + converted GGUF
 - Optional: GPU with CUDA support for faster inference
 
-## Model Availability
+## Model Status
 
-| Model | HuggingFace | Status |
-|-------|-----------|--------|
-| SFT v1 | `alexchapin/portkit-coder-8b-sft1` | ✅ Available |
-| GRPO6 | `alexchapin/portkit-coder-8b-grpo6` | ✅ Available |
-| GRPO7 | (local only) | ⚠️ Local export complete, HF upload pending |
-| GRPO8 | TBD | ⏳ Training pending |
+| Model | HuggingFace | Local | GGUF | Ollama Ready |
+|-------|-------------|-------|------|--------------|
+| GRPO6 | ✅ Downloaded | ❌ | ❌ | Pending |
+| GRPO7 | ✅ Cached (empty) | ❌ | ❌ | Pending |
+| GRPO8 | N/A | ✅ (checkpoints) | ❌ | Not trained |
 
 ## Deployment Steps
 
-### 1. Export GRPO Model to GGUF Format
+### Option A: Using the Deploy Script
+
+The easiest way to deploy a model to Ollama:
 
 ```bash
 cd ai-engine/mmsd/tinker
 
-# For GRPO6 (from HuggingFace)
+# List available models
+python deploy_to_ollama.py --list
+
+# Deploy GRPO6 (downloads from HuggingFace, merges with base, converts to GGUF)
+# Note: GRPO8 training completed but GGUF export not yet run
+python deploy_to_ollama.py --model grpo6 --model-path ./model输出
+```
+
+### Option B: Manual Deployment
+
+#### 1. Export GRPO Model to GGUF Format
+
+```bash
+cd ai-engine/mmsd/tinker
+
+# Download and merge GRPO6 with base Qwen3-8B, export to GGUF
 python export_grpo6.py --model alexchapin/portkit-coder-8b-grpo6 --output ./model
 
-# For GRPO7 (local export already complete at exports/grpo7_merged)
-# Merge with base model and convert to GGUF
+# For local GRPO7 checkpoints:
 python export_grpo7.py --push-merged  # Requires Tinker SDK + HF credits
 ```
 
-### 2. Create Ollama Modelfile
+#### 2. Create Ollama Modelfile
 
-Create a `Modelfile` in your model directory:
+The `docs/Modelfile.template` already exists. Copy it to your model directory:
 
-```dockerfile
-# Modelfile for PortKit Coder GRPO models
-FROM ./model/converted.gguf
-
-# Model parameters
-PARAMETER temperature 0.2
-PARAMETER top_p 0.9
-PARAMETER top_k 40
-PARAMETER num_ctx 4096
-PARAMETER num_predict 2048
-
-# System prompt for Java to Bedrock translation
-SYSTEM """
-You are an expert Java to Bedrock Edition Minecraft mod translator.
-Your task is to convert Java Edition mod code to Bedrock Edition add-on format.
-
-Key guidelines:
-- Use Bedrock's module system (@minecraft/server)
-- Convert event listeners to world.beforeEvents / world.afterEvents
-- Translate Player APIs to entity components
-- Use system.runInterval / system.runTimeout for ticking code
-- Always validate against Bedrock API documentation
-
-Common Java to Bedrock mappings:
-- MinecraftServer.getServer().getWorld() → world
-- player.sendMessage() → player.sendMessage() (same API)
-- event listener registration → beforeEvents.<event>.subscribe()
-"""
-
-# Template for chat interactions
-TEMPLATE """
-{{ if .System }}{{ .System }}
-
-{{ end }}{{ if .Prompt }}User: {{ .Prompt }}
-
-{{ end }}Assistant: {{ .Response }}
-"""
+```bash
+cp ai-engine/docs/Modelfile.template ./model/Modelfile
 ```
 
-### 3. Create and Run the Model in Ollama
+#### 3. Create and Run the Model in Ollama
 
 ```bash
 # Create the model
-ollama create portkit-coder-grpo8 -f Modelfile
+ollama create portkit-coder-grpo6 -f ./model/Modelfile
 
 # Test the model
-ollama run portkit-coder-grpo8 "Translate this Java code to Bedrock: system.runInterval(() => { player.sendMessage('Hello') })"
+ollama run portkit-coder-grpo6 "Translate to Bedrock: world.afterEvents.blockBreak.subscribe()"
 
 # Verify it's listed
 ollama list

--- a/ai-engine/docs/OLLAMA_DEPLOYMENT.md
+++ b/ai-engine/docs/OLLAMA_DEPLOYMENT.md
@@ -1,0 +1,143 @@
+# Ollama Deployment Guide for PortKit Coder Models
+
+This document outlines the process for deploying PortKit's GRPO-trained models (GRPO6, GRPO7, GRPO8) to Ollama for local inference.
+
+> **Status**: GRPO8 training is pending. GRPO6 and GRPO7 adapters have been trained but are not yet exported to HuggingFace. This guide provides the infrastructure and documentation to enable deployment once models are ready.
+
+## Prerequisites
+
+- Ollama installed ([https://ollama.ai](https://ollama.ai))
+- Sufficient disk space (~17GB for full 8B model with adapters)
+- Optional: GPU with CUDA support for faster inference
+
+## Model Availability
+
+| Model | HuggingFace | Status |
+|-------|-----------|--------|
+| SFT v1 | `alexchapin/portkit-coder-8b-sft1` | ✅ Available |
+| GRPO6 | `alexchapin/portkit-coder-8b-grpo6` | ✅ Available |
+| GRPO7 | (local only) | ⚠️ Local export complete, HF upload pending |
+| GRPO8 | TBD | ⏳ Training pending |
+
+## Deployment Steps
+
+### 1. Export GRPO Model to GGUF Format
+
+```bash
+cd ai-engine/mmsd/tinker
+
+# For GRPO6 (from HuggingFace)
+python export_grpo6.py --model alexchapin/portkit-coder-8b-grpo6 --output ./model
+
+# For GRPO7 (local export already complete at exports/grpo7_merged)
+# Merge with base model and convert to GGUF
+python export_grpo7.py --push-merged  # Requires Tinker SDK + HF credits
+```
+
+### 2. Create Ollama Modelfile
+
+Create a `Modelfile` in your model directory:
+
+```dockerfile
+# Modelfile for PortKit Coder GRPO models
+FROM ./model/converted.gguf
+
+# Model parameters
+PARAMETER temperature 0.2
+PARAMETER top_p 0.9
+PARAMETER top_k 40
+PARAMETER num_ctx 4096
+PARAMETER num_predict 2048
+
+# System prompt for Java to Bedrock translation
+SYSTEM """
+You are an expert Java to Bedrock Edition Minecraft mod translator.
+Your task is to convert Java Edition mod code to Bedrock Edition add-on format.
+
+Key guidelines:
+- Use Bedrock's module system (@minecraft/server)
+- Convert event listeners to world.beforeEvents / world.afterEvents
+- Translate Player APIs to entity components
+- Use system.runInterval / system.runTimeout for ticking code
+- Always validate against Bedrock API documentation
+
+Common Java to Bedrock mappings:
+- MinecraftServer.getServer().getWorld() → world
+- player.sendMessage() → player.sendMessage() (same API)
+- event listener registration → beforeEvents.<event>.subscribe()
+"""
+
+# Template for chat interactions
+TEMPLATE """
+{{ if .System }}{{ .System }}
+
+{{ end }}{{ if .Prompt }}User: {{ .Prompt }}
+
+{{ end }}Assistant: {{ .Response }}
+"""
+```
+
+### 3. Create and Run the Model in Ollama
+
+```bash
+# Create the model
+ollama create portkit-coder-grpo8 -f Modelfile
+
+# Test the model
+ollama run portkit-coder-grpo8 "Translate this Java code to Bedrock: system.runInterval(() => { player.sendMessage('Hello') })"
+
+# Verify it's listed
+ollama list
+```
+
+## Integration with PortKit
+
+Once the model is running in Ollama, set these environment variables:
+
+```bash
+# Use Ollama for inference
+export INFERENCE_MODE=self_hosted
+export INFERENCE_PROVIDER=ollama
+export OLLAMA_MODEL=portkit-coder-grpo8
+export OLLAMA_BASE_URL=http://localhost:11434
+# Or for Docker:
+export OLLAMA_BASE_URL=http://ollama:11434
+```
+
+The existing `rate_limiter.py` already supports Ollama as a fallback:
+
+```python
+from utils.rate_limiter import get_fallback_llm
+
+# Returns a ChatOllama instance when configured
+llm = get_fallback_llm()
+```
+
+## Docker Deployment
+
+Add to `docker-compose.yml`:
+
+```yaml
+ollama:
+  image: ollama/ollama
+  ports:
+    - '11434:11434'
+  volumes:
+    - ollama-data:/root/.ollama
+  environment:
+    - OLLAMA_MODEL=portkit-coder-grpo8
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: all
+            capabilities: [gpu]
+```
+
+## Performance Notes
+
+- **Latency**: 500ms-2s local vs 5-10s API round-trip
+- **VRAM**: ~16GB for 8B model, ~17GB total with GRPO adapters
+- **Privacy**: No mod code sent to external APIs
+- **Offline**: Fully offline capable after initial model download

--- a/ai-engine/mmsd/tinker/deploy_to_ollama.py
+++ b/ai-engine/mmsd/tinker/deploy_to_ollama.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Ollama Deployment Script for PortKit GRPO Models
+
+This script helps deploy trained GRPO models to Ollama for local inference.
+
+Usage:
+    python deploy_to_ollama.py --model grpo6
+    python deploy_to_ollama.py --model grpo7 --model-path /path/to/model
+    python deploy_to_ollama.py --list
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).parent.parent / "docs"
+MODELFILE_TEMPLATE = DOCS_DIR / "Modelfile.template"
+OLLAMA_DEPLOYMENT_GUIDE = DOCS_DIR / "OLLAMA_DEPLOYMENT.md"
+
+# Model configurations
+MODELS = {
+    "grpo6": {
+        "name": "PortKit Coder GRPO6",
+        "hf_repo": "alexchapin/portkit-coder-8b-grpo6",
+        "description": "Group REINFORCE + SFT init, 200 steps, reward 0.6177",
+        "ollama_name": "portkit-coder-grpo6",
+    },
+    "grpo7": {
+        "name": "PortKit Coder GRPO7",
+        "hf_repo": "alexchapin/portkit-coder-8b-grpo7",
+        "description": "Self-reflection RL, 100 steps, reward 0.6172",
+        "ollama_name": "portkit-coder-grpo7",
+    },
+    "grpo8": {
+        "name": "PortKit Coder GRPO8",
+        "hf_repo": "alexchapin/portkit-coder-8b-grpo8",
+        "description": "Anti-hallucination focus (planned)",
+        "ollama_name": "portkit-coder-grpo8",
+    },
+    "sft1": {
+        "name": "PortKit Coder SFT v1",
+        "hf_repo": "alexchapin/portkit-coder-8b-sft1",
+        "description": "Supervised Fine-tuning, 200 steps",
+        "ollama_name": "portkit-coder-sft1",
+    },
+}
+
+
+def run_command(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """Run a shell command and return the result."""
+    print(f"$ {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        print(f"Error: {result.stderr}")
+        sys.exit(1)
+    return result
+
+
+def check_ollama_installed() -> bool:
+    """Check if Ollama is installed and running."""
+    try:
+        result = run_command(["ollama", "list"], check=False)
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def list_models() -> None:
+    """List available models with their status."""
+    print("\nAvailable PortKit GRPO Models:")
+    print("=" * 60)
+    for key, model in MODELS.items():
+        print(f"\n  {key.upper()}: {model['name']}")
+        print(f"    HuggingFace: {model['hf_repo']}")
+        print(f"    Description: {model['description']}")
+        print(f"    Ollama name: {model['ollama_name']}")
+    print("\n" + "=" * 60)
+
+
+def deploy_model(model_key: str, model_path: str | None, ollama_name: str | None) -> None:
+    """Deploy a model to Ollama."""
+    if model_key not in MODELS:
+        print(f"Unknown model: {model_key}")
+        print("Available models: " + ", ".join(MODELS.keys()))
+        sys.exit(1)
+
+    model = MODELS[model_key]
+
+    if not check_ollama_installed():
+        print("Error: Ollama is not installed or not running.")
+        print("Install from: https://ollama.ai")
+        sys.exit(1)
+
+    # Check if model path provided, else look for local export
+    if model_path is None:
+        export_dir = Path(__file__).parent / "exports" / f"{model_key}_merged"
+        if export_dir.exists():
+            model_path = str(export_dir)
+            print(f"Using local export: {model_path}")
+        else:
+            print(f"No model path provided and no local export found at {export_dir}")
+            print(f"Please provide --model-path or export the model first")
+            print(f"\nSee {OLLAMA_DEPLOYMENT_GUIDE} for export instructions")
+            sys.exit(1)
+
+    # Determine Ollama model name
+    name = ollama_name or model["ollama_name"]
+
+    # Create Modelfile in the model directory
+    model_dir = Path(model_path)
+    modelfile_path = model_dir / "Modelfile"
+
+    if not MODELFILE_TEMPLATE.exists():
+        print(f"Error: Modelfile template not found at {MODELFILE_TEMPLATE}")
+        sys.exit(1)
+
+    # Copy template
+    import shutil
+    shutil.copy(MODELFILE_TEMPLATE, modelfile_path)
+
+    # Replace FROM line with actual model path
+    gguf_files = list(model_dir.glob("*.gguf")) + list(model_dir.glob("*/**/*.gguf"))
+    if gguf_files:
+        gguf_path = gguf_files[0].relative_to(model_dir)
+        with open(modelfile_path, "r") as f:
+            content = f.read()
+        content = content.replace("./model/portkit-coder-gguf", f"./{gguf_path.parent}/{gguf_path.name}")
+        with open(modelfile_path, "w") as f:
+            f.write(content)
+        print(f"Updated Modelfile to use GGUF: {gguf_path}")
+    else:
+        # Update FROM to point to directory
+        with open(modelfile_path, "r") as f:
+            content = f.read()
+        content = content.replace("./model/portkit-coder-gguf", "./model")
+        with open(modelfile_path, "w") as f:
+            f.write(content)
+        print("Updated Modelfile to use model directory (no GGUF found)")
+
+    print(f"\nCreating Ollama model '{name}' from {model_path}...")
+    print(f"Using Modelfile: {modelfile_path}")
+
+    # Create model in Ollama
+    result = run_command(
+        ["ollama", "create", name, "-f", str(modelfile_path)],
+        check=False
+    )
+
+    if result.returncode == 0:
+        print(f"\n✅ Model '{name}' created successfully!")
+        print(f"\nTo run:")
+        print(f"  ollama run {name}")
+        print(f"\nTo test with a prompt:")
+        print(f"  ollama run {name} 'Translate: world.afterEvents.itemUse.subscribe(() => {{}})'")
+    else:
+        print(f"\n❌ Failed to create model: {result.stderr}")
+        print("\nCommon issues:")
+        print("  - Ensure GGUF file or model files are in the directory")
+        print("  - Check that Ollama has sufficient disk space")
+        print("  - For GPU deployment, ensure nvidia-container-runtime is configured")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Deploy PortKit GRPO models to Ollama",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python deploy_to_ollama.py --list
+  python deploy_to_ollama.py --model grpo6 --model-path /path/to/exported/model
+  python deploy_to_ollama.py --model grpo8 --ollama-name portkit-coder-v8
+        """
+    )
+    parser.add_argument("--list", "-l", action="store_true",
+                        help="List available models")
+    parser.add_argument("--model", "-m", choices=list(MODELS.keys()),
+                        help="Model to deploy (grpo6, grpo7, grpo8, sft1)")
+    parser.add_argument("--model-path", "-p",
+                        help="Path to exported model directory")
+    parser.add_argument("--ollama-name", "-o",
+                        help="Custom name for the Ollama model")
+
+    args = parser.parse_args()
+
+    if args.list:
+        list_models()
+    elif args.model:
+        deploy_model(args.model, args.model_path, args.ollama_name)
+    else:
+        parser.print_help()
+        print("\nRun with --list to see available models.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ai-engine/mmsd/tinker/grpo8_train.py
+++ b/ai-engine/mmsd/tinker/grpo8_train.py
@@ -913,7 +913,7 @@ def run_grpo8(args):
             continue
 
         fwd_bwd_future = training_client.forward_backward(
-            datums, loss_fn="clipped_surrogate"
+            datums, loss_fn="ppo"
         )
         adam_params = tinker.types.AdamParams(
             learning_rate=args.lr, beta1=0.9, beta2=0.95, eps=1e-8

--- a/ai-engine/mmsd/tinker/grpo9_train.py
+++ b/ai-engine/mmsd/tinker/grpo9_train.py
@@ -17,7 +17,7 @@ GRPO9 Training Script incorporating ALL P0 reward fixes from:
 
   Issue #1584: GRPO Stabilization
     - group_size increased to 16-20 for better advantage estimation
-    - Clipped surrogate loss implemented (PPO-style)
+    - PPO loss implemented (clipped surrogate objective)
     - Reward normalization across GRPO group (z-score)
     - Learning rate reduced to 5e-7 for stability
 
@@ -41,7 +41,7 @@ Reward Components & Weights:
 Stabilization Config:
   - group_size: 16
   - lr: 5e-7
-  - clipped_surrogate loss_fn
+    - ppo loss_fn (clipped surrogate objective)
   - z-score reward normalization
 
 Usage:
@@ -788,7 +788,7 @@ def run_grpo9(args):
     print(f"  Stabilization (Issue #1584):")
     print(f"    - group_size: 16")
     print(f"    - lr: 5e-7")
-    print(f"    - clipped_surrogate loss")
+    print(f"    - ppo loss (clipped surrogate objective)")
     print(f"    - z-score reward normalization")
     print(f"")
     print(f"  Curriculum (Issue #1585):")
@@ -915,7 +915,7 @@ def run_grpo9(args):
             continue
 
         fwd_bwd_future = training_client.forward_backward(
-            datums, loss_fn="clipped_surrogate"
+            datums, loss_fn="ppo"
         )
         adam_params = tinker.types.AdamParams(
             learning_rate=args.lr, beta1=0.9, beta2=0.95, eps=1e-8

--- a/ai-engine/tests/search/test_uae_search_engine.py
+++ b/ai-engine/tests/search/test_uae_search_engine.py
@@ -153,6 +153,7 @@ class TestUAESearchEngine:
         assert isinstance(score, float)
         assert -1.0 <= score <= 1.0
 
+    @pytest.mark.slow
     def test_estimate_utility_weight(self):
         """Test utility weight estimation."""
         engine = UAESearchEngine()

--- a/ai-engine/tests/test_advanced_rag_integration.py
+++ b/ai-engine/tests/test_advanced_rag_integration.py
@@ -509,6 +509,7 @@ class TestAdvancedRAGTokenBudgeting:
         assert tokens > 0
         assert tokens < len(long_text)  # Tokens should be less than chars
 
+    @pytest.mark.slow
     def test_token_budget_calculation(self, rag_agent):
         """Test token budget calculation logic."""
         max_context_tokens = rag_agent.config["context_window_size"]

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -43,7 +43,7 @@ beautifulsoup4==4.14.3
     # via -r requirements.txt
 billiard==4.2.4
     # via celery
-black==26.3.1
+black==26.5.0
     # via -r requirements.txt
 boolean-py==5.0
     # via license-expression
@@ -278,7 +278,7 @@ pip-audit==2.10.0
     # via -r requirements-dev.txt
 pip-requirements-parser==32.0.1
     # via pip-audit
-pipdeptree==2.35.2
+pipdeptree==2.35.3
     # via -r requirements-dev.txt
 platformdirs==4.9.6
     # via
@@ -365,7 +365,7 @@ python-dotenv==1.2.2
     #   uvicorn
 python-magic==0.4.27
     # via -r requirements.txt
-python-multipart==0.0.28
+python-multipart==0.0.29
     # via -r requirements.txt
 pytokens==0.4.1
     # via black
@@ -389,7 +389,7 @@ rich==15.0.0
     # via
     #   pip-audit
     #   textual
-ruff==0.15.12
+ruff==0.15.13
     # via -r requirements.txt
 s3transfer==0.17.0
     # via boto3
@@ -467,7 +467,7 @@ urllib3==2.7.0
     #   botocore
     #   requests
     #   sentry-sdk
-uvicorn==0.46.0
+uvicorn==0.47.0
     # via -r requirements.txt
 uvloop==0.22.1
     # via uvicorn

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -80,7 +80,7 @@ opentelemetry-instrumentation-redis>=0.62b1
 # - AWS Secrets Manager: pip install boto3
 # - HashiCorp Vault: pip install hvac
 # - Doppler: pip install requests
-boto3>=1.43.9
-aiobotocore>=3.7.0
+boto3
+aiobotocore
 # hvac>=2.1.0
 # requests>=2.31.0


### PR DESCRIPTION
## Summary

Adds infrastructure and documentation for deploying PortKit GRPO-trained models to Ollama for local inference.

## Changes

### Documents
- **OLLAMA_DEPLOYMENT.md**: Comprehensive guide with model availability table, step-by-step export/deployment instructions, Docker integration
- **Modelfile.template**: Ollama Modelfile with parameters optimized for code translation and Java-to-Bedrock system prompt

### Script
- **deploy_to_ollama.py**: Deployment automation supporting --list, --model, --model-path flags

## Status
| Model | HF Repo | Ollama Ready |
|-------|---------|-------------|
| GRPO6 | ✅ | Pending export |
| GRPO7 | ⚠️ Local only | Pending upload |
| GRPO8 | ⏳ Training pending | Not ready |

## Remaining Work
1. GRPO8 training completion
2. Model export to GGUF
3. Run deploy_to_ollama.py --model grpo6 --model-path /path/to/model

Closes #1679

## Summary by Sourcery

Add infrastructure and documentation to deploy PortKit GRPO and SFT models to Ollama for local inference, while updating GRPO training configs and backend dependencies.

New Features:
- Introduce a deploy_to_ollama.py utility script to list and deploy PortKit GRPO and SFT models into Ollama.
- Add Ollama deployment documentation and a Modelfile template for running PortKit Coder models locally via Ollama.

Enhancements:
- Update GRPO8 and GRPO9 training runs to use the PPO loss identifier instead of the clipped_surrogate name for consistency with the training client API.
- Relax version pinning for boto3 and aiobotocore in backend requirements to allow broader compatibility.