### PR TITLE
test(ai-engine): add focused unit tests to clear 70% coverage floor (#1685)

### DIFF
--- a/ai-engine/tests/evaluation/__init__.py
+++ b/ai-engine/tests/evaluation/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for the evaluation package.
+"""

--- a/ai-engine/tests/evaluation/test_evaluator.py
+++ b/ai-engine/tests/evaluation/test_evaluator.py
@@ -1,0 +1,435 @@
+"""
+Unit tests for evaluation/evaluator.py
+
+Covers BedrockConstraintChecker (JSON depth, tick rate, script API version,
+event queue size), RubricEvaluator.evaluate, and the RUBRIC_DEFINITIONS
+catalog. Tests are fast and isolated — no DB, no AI calls.
+"""
+
+import json
+
+import pytest
+
+from evaluation.evaluator import (
+    RUBRIC_DEFINITIONS,
+    BedrockConstraintChecker,
+    RubricEvaluator,
+)
+from evaluation.models import (
+    BEDROCK_CONSTRAINTS,
+    BedrockConstraint,
+    BedrockConstraintType,
+    RubricCategory,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# -----------------------------------------------------------------------
+# RUBRIC_DEFINITIONS
+# -----------------------------------------------------------------------
+
+
+class TestRubricDefinitions:
+    """Cover the static RUBRIC_DEFINITIONS catalog."""
+
+    def test_defines_all_four_categories(self):
+        assert set(RUBRIC_DEFINITIONS.keys()) == {
+            RubricCategory.BEHAVIORAL_PRESERVATION,
+            RubricCategory.BEDROCK_CONSTRAINT_COMPLIANCE,
+            RubricCategory.CODE_QUALITY,
+            RubricCategory.STRUCTURAL_VALIDITY,
+        }
+
+    def test_each_definition_has_required_fields(self):
+        for category, definition in RUBRIC_DEFINITIONS.items():
+            assert "name" in definition
+            assert "description" in definition
+            assert "max_score" in definition
+            assert "criteria" in definition
+            assert "partial_credits" in definition
+            assert definition["max_score"] > 0
+
+    def test_max_scores_sum_to_thirteen(self):
+        total = sum(d["max_score"] for d in RUBRIC_DEFINITIONS.values())
+        assert total == pytest.approx(13.0)
+
+    def test_partial_credits_sorted(self):
+        # Every partial_credits mapping should be sorted from highest to lowest
+        for definition in RUBRIC_DEFINITIONS.values():
+            credits = definition["partial_credits"]
+            values = list(credits.values())
+            assert values == sorted(values, reverse=True)
+
+    def test_criteria_are_unique_strings(self):
+        for definition in RUBRIC_DEFINITIONS.values():
+            assert isinstance(definition["criteria"], list)
+            assert all(isinstance(c, str) for c in definition["criteria"])
+            assert len(definition["criteria"]) == len(set(definition["criteria"]))
+
+
+# -----------------------------------------------------------------------
+# BedrockConstraintChecker
+# -----------------------------------------------------------------------
+
+
+class TestBedrockConstraintChecker:
+    """Cover each constraint check independently."""
+
+    def test_default_uses_global_constraints(self):
+        checker = BedrockConstraintChecker()
+        assert checker.constraints is BEDROCK_CONSTRAINTS
+
+    def test_custom_constraints_override_default(self):
+        custom = {
+            BedrockConstraintType.JSON_NESTING_DEPTH: BedrockConstraint(
+                constraint_type=BedrockConstraintType.JSON_NESTING_DEPTH,
+                description="test",
+                max_value=2.0,
+            )
+        }
+        checker = BedrockConstraintChecker(constraints=custom)
+        assert checker.constraints is custom
+
+    # --- check_json_nesting_depth -------------------------------------
+
+    def test_json_depth_within_limit(self):
+        checker = BedrockConstraintChecker()
+        # 3 levels deep, limit is 6
+        json_str = '{"a": {"b": {"c": 1}}}'
+        valid, depth = checker.check_json_nesting_depth(json_str)
+        assert valid is True
+        assert depth == 3
+
+    def test_json_depth_exceeds_limit(self):
+        checker = BedrockConstraintChecker()
+        # 8 levels deep, limit is 6
+        deep = {"a": {"b": {"c": {"d": {"e": {"f": {"g": {"h": 1}}}}}}}}
+        valid, depth = checker.check_json_nesting_depth(json.dumps(deep))
+        assert valid is False
+        assert depth == 8
+
+    def test_json_depth_with_custom_lower_limit(self):
+        # Custom limit of 1 level
+        custom = {
+            BedrockConstraintType.JSON_NESTING_DEPTH: BedrockConstraint(
+                constraint_type=BedrockConstraintType.JSON_NESTING_DEPTH,
+                description="tight",
+                max_value=1.0,
+            )
+        }
+        checker = BedrockConstraintChecker(constraints=custom)
+        # 2 levels deep > limit of 1
+        valid, depth = checker.check_json_nesting_depth('{"a": {"b": 1}}')
+        assert valid is False
+        assert depth == 2
+
+    def test_json_depth_invalid_json(self):
+        checker = BedrockConstraintChecker()
+        valid, depth = checker.check_json_nesting_depth("not valid json {{{")
+        assert valid is False
+        assert depth == 0
+
+    def test_json_depth_empty_object(self):
+        checker = BedrockConstraintChecker()
+        valid, depth = checker.check_json_nesting_depth("{}")
+        assert valid is True
+        assert depth == 0
+
+    def test_json_depth_empty_list(self):
+        checker = BedrockConstraintChecker()
+        valid, depth = checker.check_json_nesting_depth("[]")
+        assert valid is True
+        assert depth == 0
+
+    def test_json_depth_uses_max_recursion_not_first(self):
+        # The structure is asymmetric — depth 5 only in one branch
+        checker = BedrockConstraintChecker()
+        deep_branch = {"x": {"y": {"z": {"w": {"q": 1}}}}}
+        shallow_branch = {"a": 1}
+        js = json.dumps([deep_branch, shallow_branch])
+        valid, depth = checker.check_json_nesting_depth(js)
+        # Top-level list = +1, dict = +1, then 4 more levels for the deep branch
+        # depth tracking: list(+1) -> dict(+1) -> dict(+1) -> dict(+1) -> dict(+1) -> dict(+1)
+        # Inner dict in deep branch is empty so it returns current_depth
+        assert depth >= 4
+        assert valid is True  # 6 is the limit, depth is well under
+
+    # --- check_script_api_version -------------------------------------
+
+    def test_script_api_version_compatible(self):
+        checker = BedrockConstraintChecker()
+        js = "import { world } from '@minecraft/server';\nworld.afterEvents.playerSpawn.subscribe()"
+        valid, issues = checker.check_script_api_version(js)
+        assert valid is True
+        assert issues == []
+
+    def test_script_api_version_v1_imports_flagged(self):
+        checker = BedrockConstraintChecker()
+        js = "import { world } from '@minecraft/server.v1.10';\nworld.afterEvents.foo.subscribe();"
+        valid, issues = checker.check_script_api_version(js)
+        assert valid is False
+        assert any("v1 API imports are deprecated" in i for i in issues)
+
+    def test_script_api_version_settype_flagged(self):
+        checker = BedrockConstraintChecker()
+        js = "import { world } from '@minecraft/server';\nworld.getBlock().setType("
+        valid, issues = checker.check_script_api_version(js)
+        assert valid is False
+        assert any("setType API changed in v2" in i for i in issues)
+
+    def test_script_api_version_missing_import_flagged(self):
+        checker = BedrockConstraintChecker()
+        # No @minecraft/server import at all
+        js = "console.log('hi');"
+        valid, issues = checker.check_script_api_version(js)
+        assert valid is False
+        assert any("No Script API import found" in i for i in issues)
+
+    def test_script_api_version_aggregates_multiple_issues(self):
+        checker = BedrockConstraintChecker()
+        js = "import { world } from '@minecraft/server.v1';\nworld.getBlock().setType("
+        valid, issues = checker.check_script_api_version(js)
+        assert valid is False
+        # Both v1 import and setType should be flagged
+        assert len(issues) >= 2
+
+    # --- check_tick_rate ----------------------------------------------
+
+    def test_tick_rate_clean(self):
+        checker = BedrockConstraintChecker()
+        js = "import { world } from '@minecraft/server';\nworld.afterEvents.foo.subscribe((e) => log(e));"
+        valid, violations = checker.check_tick_rate(js)
+        assert valid is True
+        assert violations == []
+
+    def test_tick_rate_blocks_while_loop(self):
+        checker = BedrockConstraintChecker()
+        # Note: pattern is `subscribe([^)]*` so no `)` may appear between
+        # `subscribe(` and the keyword. Place while directly in the args.
+        js = "world.afterEvents.foo.subscribe(while(x){y});"
+        valid, violations = checker.check_tick_rate(js)
+        assert valid is False
+        assert any("while" in v for v in violations)
+
+    def test_tick_rate_blocks_for_loop(self):
+        checker = BedrockConstraintChecker()
+        js = "world.afterEvents.foo.subscribe(for(let i=0;i<10;i++));"
+        valid, violations = checker.check_tick_rate(js)
+        assert valid is False
+        assert any("for" in v for v in violations)
+
+    def test_tick_rate_flags_settimeout(self):
+        checker = BedrockConstraintChecker()
+        js = "setTimeout(() => log('hi'), 100);"
+        valid, violations = checker.check_tick_rate(js)
+        assert valid is False
+        assert any("setTimeout" in v for v in violations)
+
+    # --- check_event_queue_size ---------------------------------------
+
+    def test_event_queue_size_normal(self):
+        checker = BedrockConstraintChecker()
+        js = "world.afterEvents.foo.subscribe(cb);\nworld.afterEvents.bar.subscribe(cb);"
+        valid, msg = checker.check_event_queue_size(js)
+        assert valid is True
+        assert msg == ""
+
+    def test_event_queue_size_too_many_subscriptions(self):
+        checker = BedrockConstraintChecker()
+        js = "\n".join([f"world.afterEvents.e{i}.subscribe(cb);" for i in range(105)])
+        valid, msg = checker.check_event_queue_size(js)
+        assert valid is False
+        assert "105" in msg
+
+
+# -----------------------------------------------------------------------
+# RubricEvaluator
+# -----------------------------------------------------------------------
+
+
+VALID_MANIFEST = json.dumps(
+    {
+        "format_version": 2,
+        "header": {"name": "Test", "uuid": "abc", "version": [1, 0, 0]},
+        "modules": [
+            {"type": "script", "language": "javascript", "uuid": "x", "version": [1, 0, 0]}
+        ],
+    }
+)
+VALID_SCRIPT = (
+    "import { world } from '@minecraft/server';\n"
+    "world.afterEvents.playerSpawn.subscribe(() => log('hi'));\n"
+)
+
+
+class TestRubricEvaluator:
+    """Cover RubricEvaluator end-to-end scoring."""
+
+    def test_init_default_constraint_checker(self):
+        ev = RubricEvaluator()
+        assert isinstance(ev.constraint_checker, BedrockConstraintChecker)
+
+    def test_init_custom_constraint_checker(self):
+        custom = BedrockConstraintChecker()
+        ev = RubricEvaluator(constraint_checker=custom)
+        assert ev.constraint_checker is custom
+
+    def test_evaluate_returns_rubric_result(self):
+        ev = RubricEvaluator()
+        bedrock = f"```json\n{VALID_MANIFEST}\n```\n```javascript\n{VALID_SCRIPT}\n```"
+        result = ev.evaluate(
+            java_source="",
+            bedrock_output=bedrock,
+            conversion_id="c1",
+        )
+        assert result.conversion_id == "c1"
+        assert result.java_source == ""
+        # All four rubric categories are scored
+        assert set(result.scores.keys()) == set(RubricCategory)
+        # Max score is 13
+        assert result.overall_max_score == pytest.approx(13.0)
+        # Score is within range
+        assert 0.0 <= result.overall_score <= result.overall_max_score
+
+    def test_evaluate_no_manifest_or_scripts(self):
+        ev = RubricEvaluator()
+        result = ev.evaluate(java_source="", bedrock_output="nothing here")
+        sv = result.scores[RubricCategory.STRUCTURAL_VALIDITY]
+        # evidence flags: manifest invalid, scripts vacuously parseable, no behavior
+        assert sv.evidence["manifest_valid_json"] is False
+        assert sv.evidence["scripts_parseable"] is True  # empty list -> vacuously true
+        assert sv.evidence["behavior_file_structure"] is False
+        # 1 of 3 criteria met -> 1.0 (partial_credits['1_of_3'])
+        assert sv.score == 1.0
+
+    def test_evaluate_behavioral_preservation_with_real_signals(self):
+        ev = RubricEvaluator()
+        java = (
+            "public class Foo { @SubscribeEvent public void onSpawn(EntitySpawnEvent e) {}\n"
+            "@Mod.Element public void registerBlock(BlockPos p) {}\n"
+            "public void useItem(ItemStack s) {}\n"
+            "public void handleEvent(EventHandler e) {}\n"
+            "}"
+        )
+        bedrock = (
+            f"```json\n{json.dumps({'format_version': 2, 'header': {'name': 'T', 'uuid': 'a', 'version': [1, 0, 0]}, 'modules': [{'type': 'data', 'uuid': 'b', 'version': [1, 0, 0]}]})}\n```\n"
+            f"```javascript\nimport {{ ItemStack }} from '@minecraft/server';\nworld.afterEvents.entitySpawn.subscribe((e) => log(e));\n```"
+        )
+        result = ev.evaluate(java_source=java, bedrock_output=bedrock)
+        bp = result.scores[RubricCategory.BEHAVIORAL_PRESERVATION]
+        # At least one behavioral criterion should be preserved
+        assert bp.score > 0.0
+
+    def test_evaluate_constraint_compliance_detects_violation(self):
+        ev = RubricEvaluator()
+        # Use a JS snippet that matches the constraint pattern (no `)` between
+        # `subscribe(` and the keyword).
+        bedrock = (
+            f"```json\n{VALID_MANIFEST}\n```\n"
+            "```javascript\nimport { world } from '@minecraft/server';\n"
+            "world.afterEvents.foo.subscribe(while(true){});\n"
+            "```"
+        )
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        cc = result.scores[RubricCategory.BEDROCK_CONSTRAINT_COMPLIANCE]
+        # tick_rate violation should be in evidence
+        assert cc.evidence["tick_rate_respected"] is False
+
+    def test_evaluate_code_quality_with_proper_imports(self):
+        ev = RubricEvaluator()
+        bedrock = f"```json\n{VALID_MANIFEST}\n```\n```javascript\n{VALID_SCRIPT}\n```"
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        cq = result.scores[RubricCategory.CODE_QUALITY]
+        # Valid import + world access should give full idiomatic credit
+        assert cq.evidence["idiomatic_bedrock_script"] is True
+
+    def test_evaluate_code_quality_flags_deprecated(self):
+        ev = RubricEvaluator()
+        bedrock = (
+            f"```json\n{VALID_MANIFEST}\n```\n"
+            "```javascript\nimport { world } from '@minecraft/server';\n"
+            "world.sendMessage('hi');\n"
+            "```"
+        )
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        cq = result.scores[RubricCategory.CODE_QUALITY]
+        # No deprecated APIs in this snippet
+        assert cq.evidence["no_deprecated_apis"] is True
+
+    def test_evaluate_structural_validity_balanced_braces(self):
+        ev = RubricEvaluator()
+        # Unbalanced braces should mark scripts as unparseable
+        bedrock = f"```json\n{VALID_MANIFEST}\n```\n```javascript\nimport {{ world }} from '@minecraft/server';\nworld.foo = 1;\n```"
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        sv = result.scores[RubricCategory.STRUCTURAL_VALIDITY]
+        assert sv.evidence["manifest_valid_json"] is True
+        assert sv.evidence["scripts_parseable"] is True
+
+    def test_evaluate_rewards_full_credit_yields_max(self):
+        ev = RubricEvaluator()
+        # Best-case bedrock output: valid manifest + clean script
+        bedrock = f"```json\n{VALID_MANIFEST}\n```\n```javascript\n{VALID_SCRIPT}\n```"
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        # No Java code -> behavioral preservation should get full credit (vacuously)
+        assert (
+            result.scores[RubricCategory.BEHAVIORAL_PRESERVATION].score
+            == result.scores[RubricCategory.BEHAVIORAL_PRESERVATION].max_score
+        )
+
+    def test_evaluate_adjudication_notes_present(self):
+        ev = RubricEvaluator()
+        bedrock = f"```json\n{VALID_MANIFEST}\n```\n```javascript\n{VALID_SCRIPT}\n```"
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        assert isinstance(result.adjudication_notes, str)
+        assert len(result.adjudication_notes) > 0
+
+    def test_evaluate_reward_signal_present(self):
+        ev = RubricEvaluator()
+        bedrock = f"```json\n{VALID_MANIFEST}\n```\n```javascript\n{VALID_SCRIPT}\n```"
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        rs = result.reward_signal
+        assert rs.total_reward >= 0.0
+        assert 0.0 <= rs.behavioral_preservation <= 1.0
+        assert 0.0 <= rs.constraint_compliance <= 1.0
+        assert 0.0 <= rs.code_quality <= 1.0
+        assert 0.0 <= rs.structural_validity <= 1.0
+        # Penalty reasons are a list
+        assert isinstance(rs.penalty_reasons, list)
+
+
+class TestRubricEvaluatorPartialCredits:
+    """Cover the partial-credit math per rubric category."""
+
+    def test_behavioral_partial_credit_branches(self):
+        ev = RubricEvaluator()
+        # Manually score: 2/4 preserved -> 2.0
+        # Java with entity, block, item, but no event
+        java = "class X { void f() { EntitySpawnEvent e; BlockPos p; ItemStack i; } }"
+        bedrock = f"```json\n{VALID_MANIFEST}\n```\n```javascript\n{VALID_SCRIPT}\n```"
+        result = ev.evaluate(java_source=java, bedrock_output=bedrock)
+        bp = result.scores[RubricCategory.BEHAVIORAL_PRESERVATION]
+        # Score must be one of the partial_credit values
+        valid_scores = list(
+            RUBRIC_DEFINITIONS[RubricCategory.BEHAVIORAL_PRESERVATION]["partial_credits"].values()
+        )
+        assert bp.score in valid_scores
+
+    def test_constraint_partial_credit_branches(self):
+        ev = RubricEvaluator()
+        # Force a tick violation
+        bedrock = (
+            f"```json\n{VALID_MANIFEST}\n```\n"
+            "```javascript\nimport { world } from '@minecraft/server';\n"
+            "world.afterEvents.foo.subscribe(while(true){});\n"
+            "```"
+        )
+        result = ev.evaluate(java_source="", bedrock_output=bedrock)
+        cc = result.scores[RubricCategory.BEDROCK_CONSTRAINT_COMPLIANCE]
+        valid_scores = list(
+            RUBRIC_DEFINITIONS[RubricCategory.BEDROCK_CONSTRAINT_COMPLIANCE][
+                "partial_credits"
+            ].values()
+        )
+        assert cc.score in valid_scores

--- a/ai-engine/tests/evaluation/test_rag_evaluator.py
+++ b/ai-engine/tests/evaluation/test_rag_evaluator.py
@@ -1,0 +1,491 @@
+"""
+Unit tests for evaluation/rag_evaluator.py
+
+Covers RetrievalMetrics (precision/recall/F1/MRR/NDCG/hit-rate),
+GenerationMetrics (keyword coverage/prohibition, length appropriateness,
+citation quality, coherence), DiversityMetrics, GoldenDatasetItem,
+EvaluationResult, and RAGEvaluator setup. Tests do not require a live
+RAG agent — we exercise the pure metric functions directly.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from evaluation.rag_evaluator import (
+    DiversityMetrics,
+    EvaluationResult,
+    GenerationMetrics,
+    GoldenDatasetItem,
+    MetricType,
+    RAGEvaluator,
+    RetrievalMetrics,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+# -----------------------------------------------------------------------
+# MetricType enum
+# -----------------------------------------------------------------------
+
+
+class TestMetricType:
+    def test_values(self):
+        assert MetricType.RETRIEVAL.value == "retrieval"
+        assert MetricType.GENERATION.value == "generation"
+        assert MetricType.RELEVANCE.value == "relevance"
+        assert MetricType.DIVERSITY.value == "diversity"
+        assert MetricType.EFFICIENCY.value == "efficiency"
+        assert MetricType.USER_SATISFACTION.value == "user_satisfaction"
+
+    def test_is_string_enum(self):
+        # It should behave like a string
+        assert MetricType.RETRIEVAL == "retrieval"
+
+
+# -----------------------------------------------------------------------
+# RetrievalMetrics
+# -----------------------------------------------------------------------
+
+
+class TestRetrievalMetrics:
+    """Cover the static metric calculators."""
+
+    def test_precision_at_k_perfect(self):
+        assert RetrievalMetrics.precision_at_k(["a", "b", "c"], ["a", "b", "c"], 3) == 1.0
+
+    def test_precision_at_k_partial(self):
+        # 2 of 3 retrieved are relevant
+        assert RetrievalMetrics.precision_at_k(["a", "x", "b"], ["a", "b"], 3) == pytest.approx(
+            2 / 3
+        )
+
+    def test_precision_at_k_k_truncates(self):
+        # Only consider top-k
+        assert (
+            RetrievalMetrics.precision_at_k(["a", "b", "c", "d"], ["c", "d"], 2) == 0.0
+        )  # Top-2 has 0 relevant
+
+    def test_precision_at_k_empty_retrieved(self):
+        assert RetrievalMetrics.precision_at_k([], ["a"], 5) == 0.0
+
+    def test_precision_at_k_k_zero(self):
+        assert RetrievalMetrics.precision_at_k(["a"], ["a"], 0) == 0.0
+
+    def test_recall_at_k_perfect(self):
+        assert RetrievalMetrics.recall_at_k(["a", "b", "c"], ["a", "b"], 3) == 1.0
+
+    def test_recall_at_k_partial(self):
+        # 1 of 2 relevant docs retrieved
+        assert RetrievalMetrics.recall_at_k(["a", "x"], ["a", "b"], 2) == 0.5
+
+    def test_recall_at_k_empty_relevant(self):
+        # No relevant docs, so recall is 1 if no retrieved
+        assert RetrievalMetrics.recall_at_k([], [], 5) == 1.0
+        # But 0 if anything is retrieved
+        assert RetrievalMetrics.recall_at_k(["x"], [], 5) == 0.0
+
+    def test_f1_at_k_perfect(self):
+        assert RetrievalMetrics.f1_at_k(["a", "b"], ["a", "b"], 2) == 1.0
+
+    def test_f1_at_k_no_overlap(self):
+        assert RetrievalMetrics.f1_at_k(["x"], ["y"], 1) == 0.0
+
+    def test_f1_at_k_mixed(self):
+        # precision=0.5, recall=0.5 -> F1=0.5
+        assert RetrievalMetrics.f1_at_k(["a", "x"], ["a", "y"], 2) == pytest.approx(0.5)
+
+    def test_mrr_first_relevant(self):
+        assert RetrievalMetrics.mean_reciprocal_rank(["a", "b"], ["a"]) == 1.0
+
+    def test_mrr_second_relevant(self):
+        assert RetrievalMetrics.mean_reciprocal_rank(["x", "a", "b"], ["a"]) == pytest.approx(0.5)
+
+    def test_mrr_third_relevant(self):
+        assert RetrievalMetrics.mean_reciprocal_rank(["x", "y", "a"], ["a"]) == pytest.approx(1 / 3)
+
+    def test_mrr_no_relevant(self):
+        assert RetrievalMetrics.mean_reciprocal_rank(["x", "y"], ["a"]) == 0.0
+
+    def test_mrr_empty(self):
+        assert RetrievalMetrics.mean_reciprocal_rank([], ["a"]) == 0.0
+
+    def test_ndcg_perfect_order(self):
+        # All relevant docs in order
+        ndcg = RetrievalMetrics.normalized_discounted_cumulative_gain(["a", "b"], ["a", "b"])
+        assert ndcg == pytest.approx(1.0)
+
+    def test_ndcg_reversed_order_with_graded_relevance(self):
+        # With graded relevance, a wrong order reduces NDCG
+        ndcg = RetrievalMetrics.normalized_discounted_cumulative_gain(
+            ["b", "a"],
+            ["a", "b"],
+            relevance_scores={"a": 3.0, "b": 1.0},
+        )
+        assert 0.0 < ndcg < 1.0
+
+    def test_ndcg_empty(self):
+        assert RetrievalMetrics.normalized_discounted_cumulative_gain([], ["a"]) == 0.0
+
+    def test_ndcg_with_custom_relevance(self):
+        # Custom relevance scores
+        ndcg = RetrievalMetrics.normalized_discounted_cumulative_gain(
+            ["a", "b", "c"],
+            ["a", "b", "c"],
+            relevance_scores={"a": 3.0, "b": 2.0, "c": 1.0},
+        )
+        # Perfect ordering
+        assert ndcg == pytest.approx(1.0)
+
+    def test_ndcg_zero_relevance(self):
+        # IDCG is zero -> NDCG is zero
+        ndcg = RetrievalMetrics.normalized_discounted_cumulative_gain(["a", "b"], [])
+        assert ndcg == 0.0
+
+    def test_hit_rate_positive(self):
+        assert RetrievalMetrics.hit_rate(["a", "x"], ["a"]) == 1.0
+
+    def test_hit_rate_negative(self):
+        assert RetrievalMetrics.hit_rate(["x", "y"], ["a"]) == 0.0
+
+    def test_hit_rate_empty(self):
+        assert RetrievalMetrics.hit_rate([], ["a"]) == 0.0
+
+
+# -----------------------------------------------------------------------
+# GenerationMetrics
+# -----------------------------------------------------------------------
+
+
+class TestGenerationMetrics:
+    """Cover generation-side metrics."""
+
+    def test_keyword_coverage_all_present(self):
+        assert (
+            GenerationMetrics.keyword_coverage("Blocks and items are fun", ["blocks", "items"])
+            == 1.0
+        )
+
+    def test_keyword_coverage_partial(self):
+        # 1 of 2 keywords present
+        assert GenerationMetrics.keyword_coverage("Blocks are fun", ["blocks", "items"]) == 0.5
+
+    def test_keyword_coverage_none(self):
+        assert GenerationMetrics.keyword_coverage("Hello", ["blocks", "items"]) == 0.0
+
+    def test_keyword_coverage_empty_required(self):
+        # No requirements -> trivially 1.0
+        assert GenerationMetrics.keyword_coverage("anything", []) == 1.0
+
+    def test_keyword_coverage_case_insensitive(self):
+        assert GenerationMetrics.keyword_coverage("BLOCKS and Items", ["blocks", "items"]) == 1.0
+
+    def test_keyword_prohibition_compliance_all_clean(self):
+        assert (
+            GenerationMetrics.keyword_prohibition_compliance("Hello world", ["bad", "evil"]) == 1.0
+        )
+
+    def test_keyword_prohibition_compliance_some_present(self):
+        # 1 of 2 prohibited keywords present
+        assert GenerationMetrics.keyword_prohibition_compliance("Hello bad", ["bad", "evil"]) == 0.5
+
+    def test_keyword_prohibition_compliance_all_present(self):
+        assert (
+            GenerationMetrics.keyword_prohibition_compliance("bad and evil", ["bad", "evil"]) == 0.0
+        )
+
+    def test_keyword_prohibition_compliance_empty_list(self):
+        assert GenerationMetrics.keyword_prohibition_compliance("anything", []) == 1.0
+
+    def test_answer_length_in_range(self):
+        # How-to range: 100-300 words
+        answer = " ".join(["word"] * 150)
+        score = GenerationMetrics.answer_length_appropriateness(answer, "how_to")
+        assert score == 1.0
+
+    def test_answer_length_too_short(self):
+        # 50 words for how-to (needs 100-300)
+        answer = " ".join(["word"] * 50)
+        score = GenerationMetrics.answer_length_appropriateness(answer, "how_to")
+        # Score = answer/min = 50/100 = 0.5
+        assert score == pytest.approx(0.5)
+
+    def test_answer_length_too_long(self):
+        # 500 words for how-to (needs 100-300)
+        answer = " ".join(["word"] * 500)
+        score = GenerationMetrics.answer_length_appropriateness(answer, "how_to")
+        # Penalty applied
+        assert 0.0 <= score < 1.0
+
+    def test_answer_length_unknown_type_uses_default(self):
+        # Default range is 30-200
+        answer = " ".join(["word"] * 100)
+        score = GenerationMetrics.answer_length_appropriateness(answer, "unknown")
+        assert score == 1.0
+
+    def test_source_citation_quality_no_sources(self):
+        assert GenerationMetrics.source_citation_quality("any answer", []) == 0.0
+
+    def test_source_citation_quality_with_citations(self):
+        # Sources referencing "According to" should boost score
+        source = Mock()
+        source.document.source_path = "block_guide.md"
+        answer = "According to the block_guide, you can create blocks easily."
+        score = GenerationMetrics.source_citation_quality(answer, [source])
+        assert score > 0.0
+
+    def test_source_citation_quality_no_indicators(self):
+        source = Mock()
+        source.document.source_path = "guide.md"
+        # No citation indicators, no filename match
+        answer = "Use this pattern."
+        score = GenerationMetrics.source_citation_quality(answer, [source])
+        assert score == 0.0
+
+    def test_coherence_score_empty(self):
+        assert GenerationMetrics.coherence_score("") == 0.0
+
+    def test_coherence_score_single_sentence(self):
+        # Single sentence gets medium score
+        score = GenerationMetrics.coherence_score("This is a single sentence.")
+        assert score == 0.5
+
+    def test_coherence_score_multi_sentence(self):
+        # Multi-sentence with structure gets a higher score
+        answer = (
+            "First, you create the block.\n\n"
+            "Then, you register it. Therefore, the block is available in the game. "
+            "For example, you can place it.\n\n"
+            "Finally, you test it. 1. Step one. 2. Step two."
+        )
+        score = GenerationMetrics.coherence_score(answer)
+        assert score > 0.5
+
+    def test_coherence_score_capped_at_one(self):
+        answer = "First, second, third. Therefore, however. For example. 1. 2. 3. - a. b."
+        score = GenerationMetrics.coherence_score(answer)
+        assert score <= 1.0
+
+
+# -----------------------------------------------------------------------
+# DiversityMetrics
+# -----------------------------------------------------------------------
+
+
+class TestDiversityMetrics:
+    """Cover diversity metrics — these use SearchResult-shaped objects."""
+
+    def _make_source(self, content_type: str, path: str, tags: list):
+        source = Mock()
+        source.document.content_type = content_type
+        source.document.source_path = path
+        source.document.tags = tags
+        return source
+
+    def test_content_type_diversity_empty(self):
+        assert DiversityMetrics.content_type_diversity([]) == 0.0
+
+    def test_content_type_diversity_single(self):
+        sources = [self._make_source("doc", "/a.md", [])]
+        # max_diversity = min(4, len(sources)) = 1, unique = 1 -> 1.0
+        assert DiversityMetrics.content_type_diversity(sources) == 1.0
+
+    def test_content_type_diversity_max(self):
+        sources = [
+            self._make_source("a", "/a", []),
+            self._make_source("b", "/b", []),
+            self._make_source("c", "/c", []),
+            self._make_source("d", "/d", []),
+        ]
+        # 4 unique types out of max 4 = 1.0
+        assert DiversityMetrics.content_type_diversity(sources) == 1.0
+
+    def test_content_type_diversity_half(self):
+        # 2 unique types across 4 sources
+        sources = [
+            self._make_source("a", "/a", []),
+            self._make_source("a", "/b", []),
+            self._make_source("b", "/c", []),
+            self._make_source("b", "/d", []),
+        ]
+        # 2 unique / min(4, 4) = 0.5
+        assert DiversityMetrics.content_type_diversity(sources) == 0.5
+
+    def test_source_diversity_all_unique(self):
+        sources = [
+            self._make_source("a", "/a.md", []),
+            self._make_source("b", "/b.md", []),
+        ]
+        assert DiversityMetrics.source_diversity(sources) == 1.0
+
+    def test_source_diversity_duplicates(self):
+        sources = [
+            self._make_source("a", "/a.md", []),
+            self._make_source("b", "/a.md", []),
+        ]
+        assert DiversityMetrics.source_diversity(sources) == 0.5
+
+    def test_source_diversity_empty(self):
+        assert DiversityMetrics.source_diversity([]) == 0.0
+
+    def test_topic_diversity_score(self):
+        sources = [
+            self._make_source("a", "/a", ["x", "y", "z"]),  # 3 unique
+            self._make_source("b", "/b", ["x", "y", "z"]),  # 0 new unique
+        ]
+        # 3 unique / 6 total = 0.5
+        assert DiversityMetrics.topic_diversity_score(sources) == 0.5
+
+    def test_topic_diversity_no_tags(self):
+        sources = [self._make_source("a", "/a", [])]
+        assert DiversityMetrics.topic_diversity_score(sources) == 0.0
+
+    def test_topic_diversity_empty(self):
+        assert DiversityMetrics.topic_diversity_score([]) == 0.0
+
+
+# -----------------------------------------------------------------------
+# GoldenDatasetItem
+# -----------------------------------------------------------------------
+
+
+class TestGoldenDatasetItem:
+    """Cover the dataclass that defines golden test items."""
+
+    def test_minimum_constructible(self):
+        item = GoldenDatasetItem(
+            query_id="q1",
+            query_text="What is X?",
+            query_type="explanation",
+            difficulty_level="beginner",
+            domain="blocks",
+            expected_answer="X is a thing",
+            expected_sources=["src1"],
+            required_keywords=["X"],
+            prohibited_keywords=[],
+            min_sources=1,
+            max_response_time_ms=1000.0,
+            min_confidence=0.5,
+            content_types=None,
+            metadata={},
+        )
+        assert item.query_id == "q1"
+        assert item.content_types is None
+
+
+# -----------------------------------------------------------------------
+# EvaluationResult
+# -----------------------------------------------------------------------
+
+
+class TestEvaluationResult:
+    """Cover EvaluationResult serialization."""
+
+    def test_to_dict_with_response(self):
+        # Mock a RAGResponse with to_dict
+        response = Mock()
+        response.to_dict = Mock(return_value={"answer": "hi", "sources": []})
+        result = EvaluationResult(
+            query_id="q1",
+            query_text="what?",
+            expected_answer="answer",
+            expected_sources=["s1"],
+            actual_response=response,
+            metrics={"p": 0.5},
+            passed_tests=["p"],
+            failed_tests=[],
+            evaluation_timestamp="2024-01-01T00:00:00Z",
+        )
+        d = result.to_dict()
+        assert d["query_id"] == "q1"
+        assert d["actual_response"] == {"answer": "hi", "sources": []}
+        assert d["metrics"] == {"p": 0.5}
+
+    def test_to_dict_with_none_response(self):
+        result = EvaluationResult(
+            query_id="q1",
+            query_text="what?",
+            expected_answer=None,
+            expected_sources=[],
+            actual_response=None,
+            metrics={},
+            passed_tests=[],
+            failed_tests=["err"],
+            evaluation_timestamp="2024-01-01T00:00:00Z",
+        )
+        d = result.to_dict()
+        assert d["actual_response"] is None
+
+
+# -----------------------------------------------------------------------
+# RAGEvaluator
+# -----------------------------------------------------------------------
+
+
+class TestRAGEvaluator:
+    """Cover RAGEvaluator setup and sample-dataset creation."""
+
+    def test_init_empty_state(self):
+        ev = RAGEvaluator()
+        assert ev.golden_dataset == []
+        assert ev.evaluation_history == []
+        assert MetricType.RETRIEVAL in ev.metrics_calculators
+        assert MetricType.GENERATION in ev.metrics_calculators
+        assert MetricType.DIVERSITY in ev.metrics_calculators
+
+    def test_create_sample_golden_dataset(self):
+        ev = RAGEvaluator()
+        sample = ev.create_sample_golden_dataset()
+        assert len(sample) == 3
+        assert sample[0].query_id == "blocks_001"
+        assert sample[1].domain == "recipes"
+        assert sample[2].metadata.get("platform") == "bedrock"
+        # The dataset is also stored on the instance
+        assert ev.golden_dataset == sample
+
+    def test_get_evaluation_history_empty(self):
+        ev = RAGEvaluator()
+        assert ev.get_evaluation_history() == []
+
+    def test_load_golden_dataset_missing_file(self, tmp_path):
+        ev = RAGEvaluator()
+        result = ev.load_golden_dataset(str(tmp_path / "nope.json"))
+        assert result == 0
+        assert ev.golden_dataset == []
+
+    def test_load_golden_dataset_invalid_json(self, tmp_path):
+        ev = RAGEvaluator()
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json at all {")
+        result = ev.load_golden_dataset(str(bad))
+        assert result == 0
+
+    def test_load_golden_dataset_valid_file(self, tmp_path):
+        ev = RAGEvaluator()
+        good = tmp_path / "good.json"
+        good.write_text(
+            '{"items": [{"query_id": "q1", "query_text": "t", '
+            '"query_type": "explanation", "difficulty_level": "beginner", '
+            '"domain": "blocks", "expected_answer": null, '
+            '"expected_sources": [], "required_keywords": [], '
+            '"prohibited_keywords": [], "min_sources": 1, '
+            '"max_response_time_ms": 1000, "min_confidence": 0.5, '
+            '"content_types": null, "metadata": {}}]}'
+        )
+        result = ev.load_golden_dataset(str(good))
+        assert result == 1
+        assert len(ev.golden_dataset) == 1
+        assert ev.golden_dataset[0].query_id == "q1"
+
+    def test_export_evaluation_report(self, tmp_path):
+        ev = RAGEvaluator()
+        report = {"overall_score": 0.85, "details": "x"}
+        out = tmp_path / "report.json"
+        ev.export_evaluation_report(report, str(out))
+        import json
+
+        with open(out) as f:
+            loaded = json.load(f)
+        assert loaded["overall_score"] == 0.85

--- a/ai-engine/tests/orchestration/test_monitoring.py
+++ b/ai-engine/tests/orchestration/test_monitoring.py
@@ -1,0 +1,593 @@
+"""
+Unit tests for orchestration/monitoring.py - OrchestrationMonitor.
+
+Covers PerformanceMetric/ExecutionEvent dataclasses, the monitor's
+init/start/stop lifecycle, the recording methods (execution/task/strategy),
+the alert path, retention cleanup, performance summaries, metric/event
+export, and the context manager protocol. Real-time monitoring is disabled
+in tests to avoid the background thread.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from orchestration.monitoring import (
+    ExecutionEvent,
+    OrchestrationMonitor,
+    PerformanceMetric,
+)
+from orchestration.strategy_selector import OrchestrationStrategy
+from orchestration.task_graph import TaskNode
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_monitor(**overrides) -> OrchestrationMonitor:
+    """Helper: build a monitor with the background thread disabled."""
+    defaults = {
+        "enable_real_time_monitoring": False,
+        "metrics_retention_hours": 24,
+    }
+    defaults.update(overrides)
+    return OrchestrationMonitor(**defaults)
+
+
+def _shutdown(m: OrchestrationMonitor) -> None:
+    """Stop the monitor's background thread (if any).
+
+    Note: ``m.stop_monitoring`` is a ``threading.Event`` instance set
+    in ``__init__`` and therefore shadows the same-named method. Call
+    the unbound method directly to actually stop the thread.
+    """
+    if m.monitoring_thread and m.monitoring_thread.is_alive():
+        OrchestrationMonitor.stop_monitoring(m)
+
+
+class TestDataclasses:
+    """Cover the small serializable dataclasses."""
+
+    def test_performance_metric_to_dict(self):
+        m = PerformanceMetric(metric_name="x", value=1.5, metadata={"k": "v"})
+        d = m.to_dict()
+        assert d["metric_name"] == "x"
+        assert d["value"] == 1.5
+        assert d["metadata"] == {"k": "v"}
+        assert "timestamp" in d
+
+    def test_performance_metric_defaults(self):
+        m = PerformanceMetric(metric_name="x", value=0.0)
+        assert m.metadata == {}
+        assert isinstance(m.timestamp, float)
+
+    def test_execution_event_to_dict(self):
+        e = ExecutionEvent(
+            event_type="task_started",
+            task_id="t1",
+            agent_name="a",
+            strategy="sequential",
+            details={"x": 1},
+        )
+        d = e.to_dict()
+        assert d["event_type"] == "task_started"
+        assert d["task_id"] == "t1"
+        assert d["agent_name"] == "a"
+        assert d["strategy"] == "sequential"
+        assert d["details"] == {"x": 1}
+        assert "timestamp" in d
+
+    def test_execution_event_defaults(self):
+        e = ExecutionEvent(event_type="x")
+        assert e.task_id is None
+        assert e.agent_name is None
+        assert e.strategy is None
+        assert e.details == {}
+
+
+class TestMonitorInit:
+    """Cover the OrchestrationMonitor constructor and alert thresholds."""
+
+    def test_default_thresholds(self):
+        m = _make_monitor()
+        try:
+            assert "task_failure_rate" in m.alert_thresholds
+            assert "avg_task_duration" in m.alert_thresholds
+            assert "queue_depth" in m.alert_thresholds
+            assert "worker_utilization" in m.alert_thresholds
+        finally:
+            _shutdown(m)
+
+    def test_custom_thresholds_override_defaults(self):
+        m = _make_monitor(alert_thresholds={"queue_depth": 10})
+        try:
+            assert m.alert_thresholds["queue_depth"] == 10
+        finally:
+            _shutdown(m)
+
+    def test_real_time_monitoring_default_starts_thread(self):
+        m = OrchestrationMonitor(enable_real_time_monitoring=True)
+        try:
+            assert m.monitoring_thread is not None
+            assert m.monitoring_thread.is_alive()
+        finally:
+            _shutdown(m)
+
+    def test_real_time_monitoring_disabled_does_not_start_thread(self):
+        m = _make_monitor()
+        try:
+            assert m.monitoring_thread is None
+        finally:
+            _shutdown(m)
+
+
+class TestStartStop:
+    """Cover start_monitoring/stop_monitoring edge cases."""
+
+    def test_start_when_already_running_is_noop(self):
+        m = OrchestrationMonitor(enable_real_time_monitoring=True)
+        try:
+            original = m.monitoring_thread
+            m.start_monitoring()
+            assert m.monitoring_thread is original
+        finally:
+            _shutdown(m)
+
+    def test_stop_when_no_thread_is_noop(self):
+        m = _make_monitor()
+        # Should not raise even though no thread exists
+        _shutdown(m)
+
+
+class TestRecordExecutionStartEnd:
+    """Cover the execution-level recording path."""
+
+    def test_record_execution_start_appends_event_and_active(self):
+        m = _make_monitor()
+        try:
+            m.record_execution_start(
+                execution_id="e1",
+                strategy=OrchestrationStrategy.SEQUENTIAL,
+                task_count=3,
+                metadata={"src": "test"},
+            )
+            assert "e1" in m.active_executions
+            assert m.active_executions["e1"]["task_count"] == 3
+            events = m.get_execution_events(event_type="execution_started")
+            assert len(events) == 1
+            assert events[0]["strategy"] == "sequential"
+        finally:
+            _shutdown(m)
+
+    def test_record_execution_end_missing_id_warns_and_returns(self):
+        m = _make_monitor()
+        try:
+            # Should not raise
+            m.record_execution_end("missing", success=True, final_results={})
+            assert m.metrics == []
+        finally:
+            _shutdown(m)
+
+    def test_record_execution_end_records_metrics_and_removes_active(self):
+        m = _make_monitor()
+        try:
+            m.record_execution_start(
+                execution_id="e2",
+                strategy=OrchestrationStrategy.PARALLEL_BASIC,
+                task_count=2,
+            )
+            m.record_execution_end(
+                "e2",
+                success=True,
+                final_results={
+                    "overall_success_rate": 0.9,
+                    "detailed_report": {
+                        "parallel_execution_stats": {
+                            "completed_tasks": 8,
+                            "failed_tasks": 2,
+                        }
+                    },
+                },
+            )
+            assert "e2" not in m.active_executions
+            metric_names = {met.metric_name for met in m.metrics}
+            assert "execution_duration" in metric_names
+            assert "execution_success_rate" in metric_names
+            assert "tasks_completed" in metric_names
+            assert "tasks_failed" in metric_names
+            # execution_ended event is appended
+            ended = m.get_execution_events(event_type="execution_ended")
+            assert len(ended) == 1
+            assert ended[0]["details"]["success_rate"] == 0.9
+        finally:
+            _shutdown(m)
+
+
+class TestRecordTaskEvent:
+    """Cover the task-level recording path."""
+
+    def test_record_task_started_event(self):
+        m = _make_monitor()
+        try:
+            t = TaskNode(task_id="t1", agent_name="a", agent_type="a", input_data={})
+            m.record_task_event(t, "task_started", additional_details={"k": "v"})
+            events = m.get_execution_events(event_type="task_started")
+            assert len(events) == 1
+            assert events[0]["task_id"] == "t1"
+            assert events[0]["details"]["agent_name"] == "a"
+        finally:
+            _shutdown(m)
+
+    def test_record_task_completed_records_duration_metric(self):
+        m = _make_monitor()
+        try:
+            t = TaskNode(
+                task_id="t2",
+                agent_name="a",
+                agent_type="a",
+                input_data={},
+            )
+            t.started_at = 100.0
+            t.completed_at = 100.25
+            m.record_task_event(t, "task_completed")
+            duration_metrics = m.get_detailed_metrics("task_duration")
+            assert len(duration_metrics) == 1
+            assert abs(duration_metrics[0]["value"] - 0.25) < 1e-9
+        finally:
+            _shutdown(m)
+
+    def test_record_task_failed_records_failure_metric_with_error(self):
+        m = _make_monitor()
+        try:
+            t = TaskNode(task_id="t3", agent_name="a", agent_type="a", input_data={})
+            t.mark_failed("boom")
+            m.record_task_event(t, "task_failed")
+            failure = m.get_detailed_metrics("task_failure")
+            assert len(failure) == 1
+            assert failure[0]["metadata"]["error"] == "boom"
+        finally:
+            _shutdown(m)
+
+    def test_record_task_event_without_duration_or_error(self):
+        m = _make_monitor()
+        try:
+            t = TaskNode(task_id="t4", agent_name="a", agent_type="a", input_data={})
+            m.record_task_event(t, "task_started")
+            # No task_duration metric recorded
+            assert m.get_detailed_metrics("task_duration") == []
+        finally:
+            _shutdown(m)
+
+
+class TestRecordStrategySelection:
+    """Cover the strategy-selection recording path."""
+
+    def test_record_strategy_selection_appends_event_and_metric(self):
+        m = _make_monitor()
+        try:
+            m.record_strategy_selection(
+                selected_strategy=OrchestrationStrategy.HYBRID,
+                available_strategies=[
+                    OrchestrationStrategy.SEQUENTIAL,
+                    OrchestrationStrategy.HYBRID,
+                ],
+                selection_reason="high load",
+                selection_metadata={"load": 0.9},
+            )
+            ev = m.get_execution_events(event_type="strategy_selected")
+            assert len(ev) == 1
+            assert ev[0]["strategy"] == "hybrid"
+            assert ev[0]["details"]["selection_reason"] == "high load"
+            sel = m.get_detailed_metrics("strategy_selection")
+            assert len(sel) == 1
+            assert sel[0]["value"] == 1.0
+        finally:
+            _shutdown(m)
+
+
+class TestAlertCallbacks:
+    """Cover the alert callback path."""
+
+    def test_trigger_alert_invokes_callbacks(self):
+        m = _make_monitor()
+        try:
+            captured = []
+            m.add_alert_callback(lambda t, d: captured.append((t, d)))
+            m._trigger_alert("test_alert", {"k": 1})
+            assert captured == [("test_alert", {"k": 1})]
+        finally:
+            _shutdown(m)
+
+    def test_trigger_alert_swallows_callback_errors(self):
+        m = _make_monitor()
+        try:
+            m.add_alert_callback(lambda t, d: (_ for _ in ()).throw(RuntimeError("boom")))
+            # Should not raise
+            m._trigger_alert("test_alert", {})
+        finally:
+            _shutdown(m)
+
+    def test_check_alerts_with_high_failure_rate_fires_alert(self):
+        m = _make_monitor(alert_thresholds={"task_failure_rate": 0.1})
+        try:
+            callbacks = []
+            m.add_alert_callback(lambda t, d: callbacks.append((t, d)))
+            # Add 1 failure and 1 completion -> 50% failure rate
+            m._record_metric("task_failure", 1.0)
+            m._record_metric("task_duration", 1.0)
+            m._check_alerts()
+            assert any(t == "high_task_failure_rate" for t, _ in callbacks)
+        finally:
+            _shutdown(m)
+
+    def test_check_alerts_with_high_avg_duration_fires_alert(self):
+        m = _make_monitor(alert_thresholds={"avg_task_duration": 0.5})
+        try:
+            callbacks = []
+            m.add_alert_callback(lambda t, d: callbacks.append((t, d)))
+            m._record_metric("task_duration", 5.0)
+            m._check_alerts()
+            assert any(t == "high_avg_task_duration" for t, _ in callbacks)
+        finally:
+            _shutdown(m)
+
+    def test_check_alerts_no_recent_metrics_is_noop(self):
+        m = _make_monitor()
+        try:
+            callbacks = []
+            m.add_alert_callback(lambda t, d: callbacks.append(t))
+            # No metrics added
+            m._check_alerts()
+            assert callbacks == []
+        finally:
+            _shutdown(m)
+
+
+class TestRetentionCleanup:
+    """Cover _cleanup_old_data."""
+
+    def test_cleanup_drops_metrics_outside_window(self):
+        m = _make_monitor(metrics_retention_hours=1)
+        try:
+            old = PerformanceMetric(metric_name="x", value=1.0)
+            old.timestamp = time.time() - 7200  # 2h ago, outside 1h window
+            new = PerformanceMetric(metric_name="x", value=2.0)
+            m.metrics.append(old)
+            m.metrics.append(new)
+            m._cleanup_old_data()
+            assert m.metrics == [new]
+        finally:
+            _shutdown(m)
+
+    def test_cleanup_drops_events_outside_window(self):
+        m = _make_monitor(metrics_retention_hours=1)
+        try:
+            old = ExecutionEvent(event_type="x")
+            old.timestamp = time.time() - 7200
+            new = ExecutionEvent(event_type="y")
+            m.execution_events.extend([old, new])
+            m._cleanup_old_data()
+            assert m.execution_events == [new]
+        finally:
+            _shutdown(m)
+
+
+class TestPerformanceSummary:
+    """Cover get_performance_summary aggregation."""
+
+    def test_empty_returns_empty_dict(self):
+        m = _make_monitor()
+        try:
+            assert m.get_performance_summary() == {}
+        finally:
+            _shutdown(m)
+
+    def test_summary_aggregates_executions_tasks_failures_strategies(self):
+        m = _make_monitor()
+        try:
+            m.record_execution_start(
+                execution_id="e1",
+                strategy=OrchestrationStrategy.SEQUENTIAL,
+                task_count=2,
+            )
+            m.record_execution_end(
+                "e1",
+                success=True,
+                final_results={
+                    "overall_success_rate": 0.8,
+                    "detailed_report": {
+                        "parallel_execution_stats": {
+                            "completed_tasks": 4,
+                            "failed_tasks": 1,
+                        }
+                    },
+                },
+            )
+            # Add a task_duration metric
+            m._record_metric("task_duration", 1.0)
+            m._record_metric("task_duration", 3.0)
+            m._record_metric("task_failure", 1.0)
+            m.record_strategy_selection(
+                selected_strategy=OrchestrationStrategy.SEQUENTIAL,
+                available_strategies=[OrchestrationStrategy.SEQUENTIAL],
+                selection_reason="r1",
+            )
+            summary = m.get_performance_summary()
+            assert summary["total_metrics"] >= 4
+            assert "executions" in summary
+            assert summary["executions"]["total_started"] == 1
+            assert summary["executions"]["total_completed"] == 1
+            assert summary["tasks"]["total_completed"] == 2
+            assert summary["tasks"]["min_duration"] == 1.0
+            assert summary["tasks"]["max_duration"] == 3.0
+            assert summary["failures"]["total_failures"] == 1
+            assert "strategies" in summary
+        finally:
+            _shutdown(m)
+
+    def test_summary_caches_result(self):
+        m = _make_monitor()
+        try:
+            m._record_metric("task_duration", 1.0)
+            s1 = m.get_performance_summary()
+            s2 = m.get_performance_summary()
+            assert s1 is s2  # cached
+        finally:
+            _shutdown(m)
+
+    def test_summary_invalidates_cache_when_new_metric_recorded(self):
+        m = _make_monitor()
+        try:
+            m._record_metric("task_duration", 1.0)
+            s1 = m.get_performance_summary()
+            m._record_metric("task_duration", 2.0)
+            s2 = m.get_performance_summary()
+            assert s1 is not s2
+        finally:
+            _shutdown(m)
+
+    def test_summary_with_time_window_filters(self):
+        m = _make_monitor()
+        try:
+            m._record_metric("task_duration", 1.0)
+            # 1 hour window includes everything
+            s1 = m.get_performance_summary(time_window_hours=1.0)
+            assert s1["total_metrics"] == 1
+            # Force metrics into the past to fall outside the 0.0001h window
+            m.metrics[0].timestamp = time.time() - 7200
+            m.performance_cache.clear()
+            s2 = m.get_performance_summary(time_window_hours=0.0001)
+            assert s2 == {}
+        finally:
+            _shutdown(m)
+
+
+class TestGetDetailedMetrics:
+    """Cover get_detailed_metrics filtering."""
+
+    def test_returns_all_metrics_when_no_filter(self):
+        m = _make_monitor()
+        try:
+            m._record_metric("a", 1.0)
+            m._record_metric("b", 2.0)
+            assert len(m.get_detailed_metrics()) == 2
+        finally:
+            _shutdown(m)
+
+    def test_filters_by_metric_name(self):
+        m = _make_monitor()
+        try:
+            m._record_metric("a", 1.0)
+            m._record_metric("b", 2.0)
+            only_a = m.get_detailed_metrics(metric_name="a")
+            assert len(only_a) == 1
+            assert only_a[0]["metric_name"] == "a"
+        finally:
+            _shutdown(m)
+
+    def test_time_window_filter(self):
+        m = _make_monitor()
+        try:
+            old = PerformanceMetric(metric_name="a", value=1.0)
+            old.timestamp = time.time() - 7200
+            m.metrics.append(old)
+            m._record_metric("a", 2.0)
+            recent = m.get_detailed_metrics(time_window_hours=1.0)
+            assert len(recent) == 1
+            assert recent[0]["value"] == 2.0
+        finally:
+            _shutdown(m)
+
+
+class TestGetExecutionEvents:
+    """Cover get_execution_events filtering."""
+
+    def test_filter_by_event_type(self):
+        m = _make_monitor()
+        try:
+            t = TaskNode(task_id="t1", agent_name="a", agent_type="a", input_data={})
+            m.record_task_event(t, "task_started")
+            m.record_task_event(t, "task_completed")
+            only_started = m.get_execution_events(event_type="task_started")
+            assert len(only_started) == 1
+            assert only_started[0]["event_type"] == "task_started"
+        finally:
+            _shutdown(m)
+
+    def test_returns_all_when_no_filter(self):
+        m = _make_monitor()
+        try:
+            t = TaskNode(task_id="t1", agent_name="a", agent_type="a", input_data={})
+            m.record_task_event(t, "task_started")
+            m.record_task_event(t, "task_completed")
+            assert len(m.get_execution_events()) == 2
+        finally:
+            _shutdown(m)
+
+    def test_time_window_filter(self):
+        m = _make_monitor()
+        try:
+            old = ExecutionEvent(event_type="x")
+            old.timestamp = time.time() - 7200
+            m.execution_events.append(old)
+            t = TaskNode(task_id="t1", agent_name="a", agent_type="a", input_data={})
+            m.record_task_event(t, "task_started")
+            recent = m.get_execution_events(time_window_hours=1.0)
+            assert len(recent) == 1
+            assert recent[0]["event_type"] == "task_started"
+        finally:
+            _shutdown(m)
+
+
+class TestExportMetrics:
+    """Cover export_metrics."""
+
+    def test_export_writes_json(self, tmp_path: Path):
+        m = _make_monitor()
+        try:
+            m._record_metric("x", 1.0)
+            out = tmp_path / "metrics.json"
+            assert m.export_metrics(out) is True
+            data = json.loads(out.read_text())
+            assert "export_timestamp" in data
+            assert "metrics" in data
+            assert "events" in data
+            assert "performance_summary" in data
+        finally:
+            _shutdown(m)
+
+    def test_export_unsupported_format_returns_false(self, tmp_path: Path):
+        m = _make_monitor()
+        try:
+            out = tmp_path / "metrics.csv"
+            assert m.export_metrics(out, format="csv") is False
+        finally:
+            _shutdown(m)
+
+
+class TestContextManager:
+    """Cover the context manager protocol.
+
+    The monitor's ``__exit__`` invokes ``self.stop_monitoring()`` which
+    is shadowed by a ``threading.Event`` instance attribute; the call
+    raises TypeError. This is a pre-existing bug in the production code
+    — we exercise the entry path and catch the exit-time error.
+    """
+
+    def test_context_manager_starts_monitoring(self):
+        m = _make_monitor()
+        try:
+            try:
+                with m:
+                    # Real-time was disabled in the helper; the context
+                    # manager turns it on.
+                    assert m.monitoring_thread is not None
+                    assert m.monitoring_thread.is_alive()
+            except TypeError:
+                # Known bug: __exit__ shadows the stop method with an Event
+                pass
+        finally:
+            if m.monitoring_thread and m.monitoring_thread.is_alive():
+                OrchestrationMonitor.stop_monitoring(m)

--- a/ai-engine/tests/orchestration/test_orchestrator.py
+++ b/ai-engine/tests/orchestration/test_orchestrator.py
@@ -1,0 +1,404 @@
+"""
+Unit tests for orchestration/orchestrator.py - ParallelOrchestrator
+
+Covers ParallelOrchestrator init, agent registration, workflow creation
+(sequential/parallel/adaptive/hybrid), spawn-callback factories, complexity
+analysis, system-resource detection, performance-metric recording, and the
+execution-status snapshot. Worker pools are mocked so the suite stays
+fast and isolated.
+"""
+
+import json
+import os
+from unittest.mock import Mock
+
+import pytest
+
+from orchestration.orchestrator import ParallelOrchestrator
+from orchestration.strategy_selector import (
+    OrchestrationStrategy,
+    StrategyConfig,
+    StrategySelector,
+)
+from orchestration.task_graph import TaskGraph, TaskNode
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_jar(tmp_path, size_bytes: int = 100) -> str:
+    """Create a fake JAR file of the requested size for mod_path tests."""
+    path = os.path.join(str(tmp_path), "fake.jar")
+    with open(path, "wb") as f:
+        f.write(b"PK\x03\x04")
+        f.write(b"\x00" * max(0, size_bytes - 4))
+    return path
+
+
+class TestParallelOrchestratorInit:
+    """Cover ParallelOrchestrator.__init__ defaults and custom inputs."""
+
+    def test_init_default_strategy_selector(self):
+        orch = ParallelOrchestrator()
+        assert isinstance(orch.strategy_selector, StrategySelector)
+        assert orch.enable_monitoring is True
+        assert orch.task_graph is None
+        assert orch.worker_pool is None
+        assert orch.current_strategy is None
+        assert orch.current_config is None
+        assert orch.agent_executors == {}
+        assert orch.execution_results == {}
+
+    def test_init_with_custom_selector(self):
+        custom_selector = StrategySelector(default_strategy=OrchestrationStrategy.SEQUENTIAL)
+        orch = ParallelOrchestrator(strategy_selector=custom_selector)
+        assert orch.strategy_selector is custom_selector
+
+    def test_init_with_monitoring_disabled(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        assert orch.enable_monitoring is False
+
+
+class TestRegisterAgent:
+    """Cover register_agent: stores executor under agent_name."""
+
+    def test_register_agent_with_run_method(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        agent = Mock()
+        agent.run = Mock(return_value={"result": "ok"})
+        orch.register_agent("test_agent", agent)
+        assert "test_agent" in orch.agent_executors
+        assert callable(orch.agent_executors["test_agent"])
+
+    def test_register_agent_with_execute_method(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        agent = Mock(spec=["execute"])
+        agent.execute = Mock(return_value={"r": 1})
+        orch.register_agent("exec_agent", agent)
+        assert "exec_agent" in orch.agent_executors
+
+    def test_register_agent_callable(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+
+        def my_agent(task):
+            return {"called": True}
+
+        orch.register_agent("callable_agent", my_agent)
+        assert "callable_agent" in orch.agent_executors
+
+    def test_register_agent_with_tools_mapping(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        agent = Mock()
+        agent.run = Mock(return_value={"ok": True})
+        tools = {"tool1": Mock()}
+        orch.register_agent("agent_with_tools", agent, tools_mapping=tools)
+        assert "agent_with_tools" in orch.agent_executors
+
+    def test_register_multiple_agents(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        for name in ("a", "b", "c"):
+            agent = Mock()
+            agent.run = Mock(return_value=name)
+            orch.register_agent(name, agent)
+        assert set(orch.agent_executors.keys()) == {"a", "b", "c"}
+
+
+class TestCreateConversionWorkflow:
+    """Cover create_conversion_workflow: delegates to strategy-specific builders."""
+
+    def test_create_workflow_default_returns_task_graph(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path)
+        graph = orch.create_conversion_workflow(
+            mod_path=mod_path, output_path="/tmp/out", temp_dir="/tmp/temp"
+        )
+        assert isinstance(graph, TaskGraph)
+        assert "analyze" in graph.nodes
+        assert orch.current_strategy is not None
+        assert orch.current_config is not None
+
+    def test_create_workflow_base_input_propagation(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path)
+        graph = orch.create_conversion_workflow(
+            mod_path=mod_path,
+            output_path="/tmp/o",
+            temp_dir="/tmp/t",
+            variant_id="v1",
+            smart_assumptions_enabled=False,
+            include_dependencies=False,
+        )
+        analyze_task = graph.nodes["analyze"]
+        assert analyze_task.input_data["smart_assumptions_enabled"] is False
+        assert analyze_task.input_data["include_dependencies"] is False
+        assert analyze_task.input_data["variant_id"] == "v1"
+        assert analyze_task.input_data["mod_path"] == mod_path
+
+    def test_create_workflow_sequential_strategy(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path)
+        orch.strategy_selector.select_strategy = Mock(
+            return_value=(
+                OrchestrationStrategy.SEQUENTIAL,
+                StrategyConfig(max_parallel_tasks=1),
+            )
+        )
+        graph = orch.create_conversion_workflow(
+            mod_path=mod_path, output_path="/tmp/o", temp_dir="/tmp/t"
+        )
+        for task_id in (
+            "analyze",
+            "plan",
+            "translate",
+            "convert_assets",
+            "package",
+            "validate",
+        ):
+            assert task_id in graph.nodes
+
+    def test_create_workflow_parallel_basic_strategy(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path)
+        orch.strategy_selector.select_strategy = Mock(
+            return_value=(
+                OrchestrationStrategy.PARALLEL_BASIC,
+                StrategyConfig(max_parallel_tasks=4),
+            )
+        )
+        graph = orch.create_conversion_workflow(
+            mod_path=mod_path, output_path="/tmp/o", temp_dir="/tmp/t"
+        )
+        assert len(graph.nodes) == 6
+
+    def test_create_workflow_adaptive_strategy_attaches_spawn_callbacks(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path)
+        orch.strategy_selector.select_strategy = Mock(
+            return_value=(
+                OrchestrationStrategy.PARALLEL_ADAPTIVE,
+                StrategyConfig(max_parallel_tasks=4, enable_dynamic_spawning=True),
+            )
+        )
+        graph = orch.create_conversion_workflow(
+            mod_path=mod_path, output_path="/tmp/o", temp_dir="/tmp/t"
+        )
+        # Adaptive workflow attaches spawn callbacks to analyze and plan
+        assert graph.nodes["analyze"].spawn_callback is not None
+        assert graph.nodes["plan"].spawn_callback is not None
+
+    def test_create_workflow_hybrid_strategy_delegates_to_parallel(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path)
+        orch.strategy_selector.select_strategy = Mock(
+            return_value=(
+                OrchestrationStrategy.HYBRID,
+                StrategyConfig(max_parallel_tasks=2),
+            )
+        )
+        graph = orch.create_conversion_workflow(
+            mod_path=mod_path, output_path="/tmp/o", temp_dir="/tmp/t"
+        )
+        # Hybrid delegates to parallel basic: 6 tasks, no spawn callbacks
+        assert len(graph.nodes) == 6
+        assert graph.nodes["analyze"].spawn_callback is None
+
+
+class TestSpawnCallbacks:
+    """Cover the spawn-callback factories that drive dynamic task generation."""
+
+    def test_analysis_spawn_callback_with_json_string(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        callback = orch._create_analysis_spawn_callback({"base": True})
+        analysis_result = json.dumps(
+            {
+                "features": {
+                    "entities": [
+                        {"name": "zombie", "complex": True},
+                        {"name": "skeleton", "complex": False},
+                        {"name": "creeper", "complex": True},
+                    ]
+                }
+            }
+        )
+        tasks = callback(analysis_result)
+        assert len(tasks) == 2
+        assert all(t.agent_name == "entity_converter" for t in tasks)
+        assert tasks[0].task_id == "convert_entity_0"
+        assert tasks[1].task_id == "convert_entity_2"
+
+    def test_analysis_spawn_callback_with_dict(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        callback = orch._create_analysis_spawn_callback({"base": True})
+        analysis_result = {"features": {"entities": [{"name": "wither", "complex": True}]}}
+        tasks = callback(analysis_result)
+        assert len(tasks) == 1
+        assert tasks[0].input_data["entity_data"]["name"] == "wither"
+
+    def test_analysis_spawn_callback_unexpected_type(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        callback = orch._create_analysis_spawn_callback({})
+        # Non-str, non-dict input is gracefully ignored
+        tasks = callback(12345)
+        assert tasks == []
+
+    def test_analysis_spawn_callback_handles_bad_json(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        callback = orch._create_analysis_spawn_callback({})
+        # Invalid JSON in a string input is gracefully ignored
+        tasks = callback("not { valid json")
+        assert tasks == []
+
+    def test_planning_spawn_callback_skips_when_no_features(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        callback = orch._create_planning_spawn_callback({"base": True})
+        # Plain object with no .complex_features attribute
+        tasks = callback({"foo": "bar"})
+        assert tasks == []
+
+
+class TestAnalyzeModComplexity:
+    """Cover _analyze_mod_complexity: derives metrics from file size."""
+
+    def test_analyze_small_mod(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path, size_bytes=100)
+        complexity = orch._analyze_mod_complexity(mod_path)
+        assert complexity["file_size_mb"] < 5
+        assert complexity["num_features"] == 5
+        assert complexity["estimated_entities"] == 3
+        assert complexity["has_complex_assets"] is False
+
+    def test_analyze_medium_mod(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path, size_bytes=6 * 1024 * 1024)
+        complexity = orch._analyze_mod_complexity(mod_path)
+        assert complexity["file_size_mb"] > 5
+        assert complexity["num_features"] == 10
+        assert complexity["estimated_entities"] == 5
+
+    def test_analyze_large_mod(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path, size_bytes=11 * 1024 * 1024)
+        complexity = orch._analyze_mod_complexity(mod_path)
+        assert complexity["file_size_mb"] > 10
+        assert complexity["num_features"] == 15
+        assert complexity["estimated_entities"] == 8
+        assert complexity["has_complex_assets"] is True
+
+    def test_analyze_missing_file_returns_zero(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        complexity = orch._analyze_mod_complexity(str(tmp_path / "nope.jar"))
+        assert complexity["file_size_mb"] == 0
+        # Defaults are still applied for a non-existent file
+        assert complexity["num_features"] == 5
+
+
+class TestSystemResourcesAndStatus:
+    """Cover _get_system_resources and get_execution_status."""
+
+    def test_get_system_resources_shape(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        resources = orch._get_system_resources()
+        assert "cpu_count" in resources
+        assert "memory_gb" in resources
+        assert "is_containerized" in resources
+        assert isinstance(resources["cpu_count"], int)
+        assert resources["cpu_count"] >= 1
+
+    def test_get_execution_status_initial(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        status = orch.get_execution_status()
+        assert status["strategy"] is None
+        assert status["is_running"] is False
+        assert status["start_time"] is None
+        assert status["end_time"] is None
+        assert status["duration"] is None
+
+    def test_get_execution_status_with_task_graph(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        # execute_workflow sets self.task_graph, so we simulate that here
+        graph = TaskGraph()
+        graph.add_task(TaskNode(task_id="t", agent_name="a", agent_type="x", input_data={}))
+        orch.task_graph = graph
+        status = orch.get_execution_status()
+        # The graph was attached, so its stats are merged into status
+        assert "total_tasks" in status
+        assert status["total_tasks"] == 1
+
+    def test_get_execution_status_running(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        orch.execution_start_time = 1000.0
+        orch.execution_end_time = None
+        status = orch.get_execution_status()
+        assert status["is_running"] is True
+        assert status["duration"] is not None
+
+    def test_get_execution_status_complete(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        orch.execution_start_time = 1000.0
+        orch.execution_end_time = 1005.0
+        status = orch.get_execution_status()
+        assert status["is_running"] is False
+        assert status["duration"] == pytest.approx(5.0)
+
+
+class TestRecordPerformanceMetrics:
+    """Cover _record_performance_metrics: delegates to strategy_selector."""
+
+    def test_record_performance_metrics_writes_to_selector(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        orch.strategy_selector.record_performance = Mock()
+        orch.execution_start_time = 100.0
+        orch.execution_end_time = 102.5
+        orch.current_strategy = OrchestrationStrategy.PARALLEL_BASIC
+        graph = TaskGraph()
+        graph.add_task(TaskNode(task_id="t", agent_name="a", agent_type="x", input_data={}))
+        graph.mark_task_completed("t", "ok")
+        orch._record_performance_metrics(graph, {"t": "ok"})
+        orch.strategy_selector.record_performance.assert_called_once()
+        call_kwargs = orch.strategy_selector.record_performance.call_args.kwargs
+        assert call_kwargs["success_rate"] == 1.0
+        assert call_kwargs["task_count"] == 1
+        assert call_kwargs["total_duration"] == pytest.approx(2.5)
+
+    def test_record_performance_metrics_no_timestamps(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        orch.strategy_selector.record_performance = Mock()
+        orch.execution_start_time = None
+        orch.execution_end_time = None
+        # Should early-return without calling the selector
+        orch._record_performance_metrics(TaskGraph(), {})
+        orch.strategy_selector.record_performance.assert_not_called()
+
+
+class TestAnalyzeModForSelection:
+    """Cover that create_conversion_workflow passes computed complexity through."""
+
+    def test_workflow_passes_complexity_to_selector(self, tmp_path):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        mod_path = _make_jar(tmp_path, size_bytes=12 * 1024 * 1024)
+        orch.strategy_selector.select_strategy = Mock(
+            return_value=(
+                OrchestrationStrategy.PARALLEL_BASIC,
+                StrategyConfig(max_parallel_tasks=4),
+            )
+        )
+        orch.create_conversion_workflow(mod_path=mod_path, output_path="/tmp/o", temp_dir="/tmp/t")
+        call_kwargs = orch.strategy_selector.select_strategy.call_args.kwargs
+        assert call_kwargs["task_complexity"]["has_complex_assets"] is True
+        assert "cpu_count" in call_kwargs["system_resources"]
+
+
+class TestGetExecutionStatusWithWorkerPool:
+    """Cover get_execution_status including worker_stats when a pool is active."""
+
+    def test_status_merges_worker_stats(self):
+        orch = ParallelOrchestrator(enable_monitoring=False)
+        orch.execution_start_time = 1.0
+        orch.execution_end_time = 2.0
+        # Mock a worker pool with get_worker_stats
+        fake_pool = Mock()
+        fake_pool.get_worker_stats = Mock(return_value={"total_completed": 5})
+        orch.worker_pool = fake_pool
+        status = orch.get_execution_status()
+        assert status["worker_stats"]["total_completed"] == 5

--- a/ai-engine/tests/orchestration/test_worker_pool.py
+++ b/ai-engine/tests/orchestration/test_worker_pool.py
@@ -1,0 +1,478 @@
+"""
+Unit tests for orchestration/worker_pool.py - WorkerPool lifecycle.
+
+Covers WorkerType enum, WorkerStats dataclass behaviour, WorkerPool
+construction/start/stop/submit_task/submit_task_async/wait_for_completion,
+get_worker_stats, and the create_agent_executor factory. Tests are
+synchronous-friendly: the underlying pool is thread-based so the event
+loop is not required.
+"""
+
+import asyncio
+import time
+from unittest.mock import Mock
+
+import pytest
+
+from orchestration.task_graph import TaskNode
+from orchestration.worker_pool import (
+    WorkerPool,
+    WorkerStats,
+    WorkerType,
+    create_agent_executor,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestWorkerTypeEnum:
+    """Cover WorkerType enum membership and values."""
+
+    def test_worker_type_values(self):
+        assert WorkerType.THREAD.value == "thread"
+        assert WorkerType.PROCESS.value == "process"
+        assert WorkerType.ASYNC.value == "async"
+
+    def test_worker_type_iteration(self):
+        members = list(WorkerType)
+        assert len(members) == 3
+        assert {m.name for m in members} == {"THREAD", "PROCESS", "ASYNC"}
+
+
+class TestWorkerStats:
+    """Cover WorkerStats dataclass: counts, averages, and update_* methods."""
+
+    def test_default_values(self):
+        stats = WorkerStats()
+        assert stats.tasks_completed == 0
+        assert stats.tasks_failed == 0
+        assert stats.total_execution_time == 0.0
+        assert stats.average_task_time == 0.0
+        assert stats.last_activity is None
+
+    def test_update_completion_increments_completed(self):
+        stats = WorkerStats()
+        stats.update_completion(2.0)
+        assert stats.tasks_completed == 1
+        assert stats.total_execution_time == 2.0
+        assert stats.average_task_time == 2.0
+        assert stats.last_activity is not None
+
+    def test_update_completion_averages_correctly(self):
+        stats = WorkerStats()
+        stats.update_completion(1.0)
+        stats.update_completion(3.0)
+        # Average of 1.0 and 3.0 is 2.0
+        assert stats.average_task_time == 2.0
+        assert stats.total_execution_time == 4.0
+        assert stats.tasks_completed == 2
+
+    def test_update_failure_increments_failed(self):
+        stats = WorkerStats()
+        stats.update_failure()
+        assert stats.tasks_failed == 1
+        assert stats.last_activity is not None
+        # update_failure() does NOT touch average_task_time
+        assert stats.average_task_time == 0.0
+
+    def test_update_failure_does_not_affect_completed_stats(self):
+        stats = WorkerStats()
+        stats.update_completion(5.0)
+        stats.update_failure()
+        assert stats.tasks_completed == 1
+        assert stats.tasks_failed == 1
+        # Average is still based on successful completions
+        assert stats.average_task_time == 5.0
+
+
+class TestWorkerPoolInit:
+    """Cover WorkerPool construction defaults and auto-detect behaviour."""
+
+    def test_init_defaults(self):
+        pool = WorkerPool()
+        assert pool.worker_type == WorkerType.THREAD
+        assert pool.task_timeout == 300.0
+        assert pool.enable_monitoring is True
+        assert pool.executor is None
+        assert pool.active_futures == {}
+        assert pool.task_start_times == {}
+        assert pool.worker_stats == {}
+
+    def test_init_with_max_workers(self):
+        pool = WorkerPool(max_workers=8, worker_type=WorkerType.ASYNC)
+        assert pool.max_workers == 8
+        assert pool.worker_type == WorkerType.ASYNC
+
+    def test_init_auto_detect_for_process(self):
+        pool = WorkerPool(worker_type=WorkerType.PROCESS)
+        # max_workers should be auto-detected to a positive int
+        assert pool.max_workers >= 1
+        assert pool.worker_type == WorkerType.PROCESS
+
+    def test_init_with_custom_timeout_and_monitoring(self):
+        pool = WorkerPool(
+            max_workers=2,
+            worker_type=WorkerType.THREAD,
+            task_timeout=10.0,
+            enable_monitoring=False,
+        )
+        assert pool.task_timeout == 10.0
+        assert pool.enable_monitoring is False
+
+
+class TestWorkerPoolStartStop:
+    """Cover WorkerPool.start and stop lifecycle."""
+
+    def test_start_creates_thread_executor(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        pool.start()
+        try:
+            assert pool.executor is not None
+        finally:
+            pool.stop()
+
+    def test_start_idempotent(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        pool.start()
+        first_executor = pool.executor
+        # Second start should NOT replace the existing executor
+        pool.start()
+        assert pool.executor is first_executor
+        pool.stop()
+
+    def test_stop_when_never_started_is_noop(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        # Should not raise even though the executor was never started
+        pool.stop()
+        assert pool.executor is None
+
+    def test_stop_without_wait_cancels_active_futures(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        pool.start()
+        # Add a fake future that is not done
+        fake_future = Mock()
+        fake_future.done = Mock(return_value=False)
+        fake_future.cancel = Mock()
+        pool.active_futures["fake_task"] = fake_future
+        pool.stop(wait=False)
+        fake_future.cancel.assert_called_once()
+        assert pool.executor is None
+
+
+class TestSubmitTask:
+    """Cover WorkerPool.submit_task happy-path and rejection paths."""
+
+    def test_submit_task_before_start_raises(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        task = TaskNode(task_id="t1", agent_name="a", agent_type="x", input_data={})
+        with pytest.raises(RuntimeError, match="not started"):
+            pool.submit_task(task, lambda t: None)
+
+    def test_submit_task_returns_future(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        pool.start()
+        try:
+            task = TaskNode(
+                task_id="t1",
+                agent_name="a",
+                agent_type="x",
+                input_data={"k": "v"},
+            )
+
+            def executor(t):
+                return {"ran": True, "id": t.task_id}
+
+            future = pool.submit_task(task, executor)
+            result = future.result(timeout=5.0)
+            assert result["ran"] is True
+            assert result["id"] == "t1"
+        finally:
+            pool.stop()
+
+    def test_submit_duplicate_task_returns_existing_future(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        pool.start()
+        try:
+            task = TaskNode(task_id="dup", agent_name="a", agent_type="x", input_data={})
+            f1 = pool.submit_task(task, lambda t: 1)
+            f2 = pool.submit_task(task, lambda t: 1)
+            assert f1 is f2
+            # Wait for it to finish so the threadpool can shut down cleanly
+            f1.result(timeout=5.0)
+        finally:
+            pool.stop()
+
+    def test_submit_task_records_failure_stats(self):
+        pool = WorkerPool(max_workers=1, enable_monitoring=True)
+        pool.start()
+        try:
+            task = TaskNode(
+                task_id="bad",
+                agent_name="a",
+                agent_type="x",
+                input_data={},
+            )
+
+            def executor(t):
+                raise ValueError("nope")
+
+            future = pool.submit_task(task, executor)
+            with pytest.raises(ValueError, match="nope"):
+                future.result(timeout=5.0)
+            # Failure should be recorded in the worker_stats
+            assert sum(s.tasks_failed for s in pool.worker_stats.values()) >= 1
+        finally:
+            pool.stop()
+
+
+class TestWaitForCompletion:
+    """Cover WorkerPool.wait_for_completion."""
+
+    def test_wait_for_completion_empty_list(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        result = pool.wait_for_completion([])
+        assert result == {"completed": [], "failed": [], "timeout": []}
+
+    def test_wait_for_completion_all_succeed(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        pool.start()
+        try:
+            tasks = [
+                TaskNode(task_id=f"t{i}", agent_name="a", agent_type="x", input_data={})
+                for i in range(3)
+            ]
+            for t in tasks:
+                pool.submit_task(t, lambda task: {"id": task.task_id})
+            result = pool.wait_for_completion(tasks, timeout=5.0)
+            assert len(result["completed"]) == 3
+            assert result["failed"] == []
+            assert result["timeout"] == []
+        finally:
+            pool.stop()
+
+    def test_wait_for_completion_records_failure(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        pool.start()
+        try:
+            t_ok = TaskNode(task_id="ok", agent_name="a", agent_type="x", input_data={})
+            t_bad = TaskNode(task_id="bad", agent_name="a", agent_type="x", input_data={})
+            pool.submit_task(t_ok, lambda t: "ok")
+            pool.submit_task(t_bad, lambda t: (_ for _ in ()).throw(RuntimeError("x")))
+            result = pool.wait_for_completion([t_ok, t_bad], timeout=5.0)
+            assert len(result["completed"]) == 1
+            assert len(result["failed"]) == 1
+            assert result["failed"][0]["task_id"] == "bad"
+        finally:
+            pool.stop()
+
+
+class TestWorkerPoolStatsAndActiveCount:
+    """Cover get_active_task_count and get_worker_stats."""
+
+    def test_get_active_task_count_no_active(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        assert pool.get_active_task_count() == 0
+
+    def test_get_worker_stats_shape(self):
+        pool = WorkerPool(max_workers=2, enable_monitoring=False)
+        stats = pool.get_worker_stats()
+        assert stats["worker_type"] == "thread"
+        assert stats["max_workers"] == 2
+        assert stats["active_workers"] == 0
+        assert stats["active_tasks"] == 0
+        assert stats["total_completed"] == 0
+        assert stats["total_failed"] == 0
+        assert stats["success_rate"] == 0
+        assert stats["average_task_time"] == 0.0
+        assert stats["worker_details"] == {}
+
+
+class TestAgentExecutorFactory:
+    """Cover create_agent_executor: a thin wrapper around agent_instance."""
+
+    def test_create_agent_executor_invokes_run(self):
+        agent = Mock()
+        agent.run = Mock(return_value={"ok": True})
+        executor = create_agent_executor(agent, None)
+        task = TaskNode(task_id="t", agent_name="a", agent_type="x", input_data={"x": 1})
+        result = executor(task)
+        agent.run.assert_called_once()
+        assert result == {"ok": True}
+
+    def test_create_agent_executor_invokes_set_input_data(self):
+        agent = Mock()
+        agent.run = Mock(return_value={"r": 1})
+        agent.set_input_data = Mock()
+        executor = create_agent_executor(agent)
+        task = TaskNode(task_id="t", agent_name="a", agent_type="x", input_data={"x": 1})
+        executor(task)
+        agent.set_input_data.assert_called_once_with({"x": 1})
+
+    def test_create_agent_executor_invokes_execute(self):
+        # Agent with execute but not run
+        agent = Mock(spec=["execute"])
+        agent.execute = Mock(return_value={"r": 1})
+        executor = create_agent_executor(agent)
+        task = TaskNode(task_id="t", agent_name="a", agent_type="x", input_data={})
+        result = executor(task)
+        agent.execute.assert_called_once()
+        assert result == {"r": 1}
+
+    def test_create_agent_executor_callable(self):
+        # Plain function: called with input_data (a dict), not the TaskNode
+        def my_agent(data):
+            return {"data": data}
+
+        executor = create_agent_executor(my_agent)
+        task = TaskNode(task_id="callable", agent_name="a", agent_type="x", input_data={"k": 1})
+        assert executor(task) == {"data": {"k": 1}}
+
+    def test_create_agent_executor_invalid_raises(self):
+        executor = create_agent_executor(42)
+        task = TaskNode(task_id="t", agent_name="a", agent_type="x", input_data={})
+        with pytest.raises(ValueError, match="Don't know how to execute"):
+            executor(task)
+
+
+class TestContextManager:
+    """Cover WorkerPool context manager protocol."""
+
+    def test_context_manager_starts_and_stops_pool(self):
+        with WorkerPool(max_workers=2, enable_monitoring=False) as pool:
+            assert pool.executor is not None
+        # After exiting, executor is shut down
+        assert pool.executor is None
+
+
+class TestSubmitTaskAsync:
+    """Cover the async submit path used by the orchestrator."""
+
+    @pytest.mark.asyncio
+    async def test_submit_task_async_runs_executor(self):
+        task = TaskNode(
+            task_id="async_ok",
+            agent_name="a",
+            agent_type="a",
+            input_data={"x": 1},
+        )
+        with WorkerPool(max_workers=2) as pool:
+            future = await pool.submit_task_async(task, lambda t: {"ok": t.input_data["x"]})
+            result = await asyncio.wait_for(future, timeout=5.0)
+            assert result == {"ok": 1}
+            # Future bookkeeping is shared with sync submit
+            assert "async_ok" in pool.active_futures
+
+    @pytest.mark.asyncio
+    async def test_submit_task_async_without_start_raises(self):
+        pool = WorkerPool(max_workers=2)
+        # Not started; executor is None
+        task = TaskNode(
+            task_id="async_fail",
+            agent_name="a",
+            agent_type="a",
+            input_data={},
+        )
+        with pytest.raises(RuntimeError, match="not started"):
+            await pool.submit_task_async(task, lambda t: None)
+
+    @pytest.mark.asyncio
+    async def test_submit_task_async_duplicate_returns_existing(self):
+        task = TaskNode(
+            task_id="dup",
+            agent_name="a",
+            agent_type="a",
+            input_data={},
+        )
+        with WorkerPool(max_workers=2) as pool:
+            f1 = await pool.submit_task_async(task, lambda t: "first")
+            # The async path always runs a new submit through the executor;
+            # the dedup branch lives in the inner _submit_sync call, which the
+            # async submit will exercise only if the executor call returns
+            # twice. We assert that calling twice does not raise and returns
+            # an awaitable in both cases.
+            f2 = await pool.submit_task_async(task, lambda t: "second")
+            assert asyncio.isfuture(f1)
+            assert asyncio.isfuture(f2)
+
+
+class TestWaitForCompletionEdgeCases:
+    """Cover remaining wait_for_completion branches."""
+
+    def test_wait_for_completion_timeout_marks_task_failed(self):
+        with WorkerPool(max_workers=1, task_timeout=0.05) as pool:
+            slow = TaskNode(
+                task_id="slow",
+                agent_name="a",
+                agent_type="a",
+                input_data={},
+            )
+
+            def hang(_):
+                time.sleep(1.0)
+                return "done"
+
+            pool.submit_task(slow, hang)
+            outcome = pool.wait_for_completion([slow], timeout=0.1)
+            assert outcome["completed"] == []
+            assert len(outcome["timeout"]) >= 1
+            assert outcome["failed"] == []
+
+    def test_wait_for_completion_records_failure(self):
+        with WorkerPool(max_workers=1, task_timeout=5.0) as pool:
+            bad = TaskNode(
+                task_id="bad",
+                agent_name="a",
+                agent_type="a",
+                input_data={},
+            )
+            pool.submit_task(bad, lambda _t: (_ for _ in ()).throw(RuntimeError("boom")))
+            outcome = pool.wait_for_completion([bad], timeout=5.0)
+            assert outcome["completed"] == []
+            assert len(outcome["failed"]) >= 1
+
+    def test_wait_for_completion_empty_task_list(self):
+        with WorkerPool(max_workers=1) as pool:
+            outcome = pool.wait_for_completion([], timeout=1.0)
+            # All keys are lists in the actual return shape
+            assert outcome == {"completed": [], "failed": [], "timeout": []}
+
+
+class TestExecuteWithMonitoring:
+    """Cover the monitoring-wrapped executor path inside _submit_sync."""
+
+    def test_executor_records_completion_in_stats(self):
+        with WorkerPool(max_workers=1, enable_monitoring=True) as pool:
+            task = TaskNode(
+                task_id="monitored",
+                agent_name="a",
+                agent_type="a",
+                input_data={},
+            )
+            future = pool.submit_task(task, lambda _t: 42)
+            future.result(timeout=5.0)
+            stats = pool.get_worker_stats()
+            assert stats["total_completed"] >= 1
+            # Worker-level details should also reflect the completion
+            details = stats.get("worker_details", {})
+            assert any(d.get("tasks_completed", 0) >= 1 for d in details.values()), (
+                f"expected a completed task, got {stats}"
+            )
+
+    def test_executor_records_failure_in_stats(self):
+        with WorkerPool(max_workers=1, enable_monitoring=True) as pool:
+            task = TaskNode(
+                task_id="failed_task",
+                agent_name="a",
+                agent_type="a",
+                input_data={},
+            )
+            future = pool.submit_task(task, lambda _t: (_ for _ in ()).throw(ValueError("nope")))
+            with pytest.raises(ValueError, match="nope"):
+                future.result(timeout=5.0)
+            stats = pool.get_worker_stats()
+            assert stats["total_failed"] >= 1
+            details = stats.get("worker_details", {})
+            assert any(d.get("tasks_failed", 0) >= 1 for d in details.values()), (
+                f"expected a failed task, got {stats}"
+            )

--- a/ai-engine/tests/utils/test_error_recovery.py
+++ b/ai-engine/tests/utils/test_error_recovery.py
@@ -1,0 +1,333 @@
+"""
+Unit tests for utils/error_recovery.py - retry, circuit breaker, recovery system.
+
+Covers RecoveryStrategy.delay math, CircuitBreaker state transitions
+(CLOSED -> OPEN -> HALF_OPEN -> CLOSED), the with_retry decorator,
+and the ErrorRecoverySystem.
+"""
+
+import threading
+import time
+
+import pytest
+
+from utils.error_recovery import (
+    CircuitBreaker,
+    CircuitBreakerOpenError,
+    CircuitState,
+    ErrorRecoverySystem,
+    ErrorSeverity,
+    RecoveryError,
+    RecoveryStrategy,
+    STANDARD_RETRY,
+    get_recovery_system,
+    with_circuit_breaker,
+    with_retry,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestErrorSeverity:
+    """Cover the ErrorSeverity enum members."""
+
+    def test_values(self):
+        assert ErrorSeverity.LOW.value == "low"
+        assert ErrorSeverity.MEDIUM.value == "medium"
+        assert ErrorSeverity.HIGH.value == "high"
+        assert ErrorSeverity.CRITICAL.value == "critical"
+
+
+class TestRecoveryStrategy:
+    """Cover the RecoveryStrategy dataclass and its delay calculation."""
+
+    def test_get_delay_grows_with_attempts(self):
+        strat = RecoveryStrategy(
+            name="t",
+            max_retries=5,
+            base_delay=1.0,
+            max_delay=100.0,
+            backoff_factor=2.0,
+            jitter=False,
+        )
+        d0 = strat.get_delay(0)
+        d1 = strat.get_delay(1)
+        d2 = strat.get_delay(2)
+        assert d0 < d1 < d2
+        assert d0 == 1.0
+        assert d1 == 2.0
+        assert d2 == 4.0
+
+    def test_get_delay_caps_at_max_delay(self):
+        strat = RecoveryStrategy(
+            name="t",
+            max_retries=10,
+            base_delay=10.0,
+            max_delay=50.0,
+            backoff_factor=2.0,
+            jitter=False,
+        )
+        # 10 * 2**10 = 10240, capped at 50
+        assert strat.get_delay(10) == 50.0
+
+    def test_get_delay_jitter_within_ten_percent(self):
+        strat = RecoveryStrategy(
+            name="t",
+            max_retries=1,
+            base_delay=10.0,
+            max_delay=100.0,
+            backoff_factor=1.0,
+            jitter=True,
+        )
+        for _ in range(20):
+            d = strat.get_delay(0)
+            assert 9.0 <= d <= 11.0
+
+
+class TestCircuitBreaker:
+    """Cover the CircuitBreaker state machine."""
+
+    def test_starts_closed(self):
+        cb = CircuitBreaker(name="t", fail_max=3)
+        assert cb.state == CircuitState.CLOSED
+
+    def test_successful_call_returns_result(self):
+        cb = CircuitBreaker(name="t", fail_max=2)
+        assert cb.call(lambda: 42) == 42
+        assert cb.state == CircuitState.CLOSED
+
+    def test_opens_after_fail_max_failures(self):
+        cb = CircuitBreaker(name="t", fail_max=2)
+        for _ in range(2):
+            with pytest.raises(RuntimeError, match="boom"):
+                cb.call(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert cb.state == CircuitState.OPEN
+
+    def test_open_circuit_rejects_calls(self):
+        cb = CircuitBreaker(name="t", fail_max=1, reset_timeout=60.0)
+        with pytest.raises(RuntimeError):
+            cb.call(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert cb.state == CircuitState.OPEN
+        with pytest.raises(CircuitBreakerOpenError):
+            cb.call(lambda: "never")
+
+    def test_transitions_to_half_open_after_timeout(self):
+        cb = CircuitBreaker(name="t", fail_max=1, reset_timeout=0.05)
+        with pytest.raises(RuntimeError):
+            cb.call(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert cb.state == CircuitState.OPEN
+        time.sleep(0.1)
+        assert cb.state == CircuitState.HALF_OPEN
+
+    def test_half_open_success_closes_circuit(self):
+        cb = CircuitBreaker(name="t", fail_max=1, reset_timeout=0.05)
+        with pytest.raises(RuntimeError):
+            cb.call(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        time.sleep(0.1)
+        assert cb.call(lambda: "ok") == "ok"
+        assert cb.state == CircuitState.CLOSED
+
+    def test_half_open_failure_reopens_circuit(self):
+        cb = CircuitBreaker(name="t", fail_max=1, reset_timeout=0.05)
+        with pytest.raises(RuntimeError):
+            cb.call(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        time.sleep(0.1)
+        with pytest.raises(RuntimeError):
+            cb.call(lambda: (_ for _ in ()).throw(RuntimeError("still bad")))
+        assert cb.state == CircuitState.OPEN
+
+    def test_half_open_max_calls_rejects_extras(self):
+        cb = CircuitBreaker(name="t", fail_max=1, reset_timeout=0.05, half_open_max_calls=1)
+        with pytest.raises(RuntimeError):
+            cb.call(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+        time.sleep(0.1)
+        # First call in HALF_OPEN is allowed (but slow)
+        # Use a thread to keep the call pending
+        started = threading.Event()
+
+        def slow():
+            started.set()
+            time.sleep(0.5)
+            return "ok"
+
+        # Submit the slow call on a thread; while it is running, the next
+        # call must be rejected because half_open_max_calls == 1.
+        import threading as _t
+
+        fut_holder = {}
+
+        def runner():
+            fut_holder["fut"] = cb.call(slow)
+
+        th = _t.Thread(target=runner, daemon=True)
+        th.start()
+        started.wait(1.0)
+        # Give the breaker a moment to increment _half_open_calls
+        time.sleep(0.05)
+        with pytest.raises(CircuitBreakerOpenError):
+            cb.call(lambda: "rejected")
+        # Let the original call finish
+        th.join(timeout=2.0)
+
+    def test_get_stats(self):
+        cb = CircuitBreaker(name="mycb", fail_max=5)
+        cb.call(lambda: 1)
+        stats = cb.get_stats()
+        assert stats["name"] == "mycb"
+        assert stats["state"] == "closed"
+        assert stats["failure_count"] == 0
+        assert stats["success_count"] >= 1
+
+
+class TestWithRetryDecorator:
+    """Cover the with_retry decorator."""
+
+    def test_succeeds_on_first_try(self):
+        @with_retry(STANDARD_RETRY)
+        def good():
+            return "ok"
+
+        assert good() == "ok"
+
+    def test_retries_on_retryable_exception_then_succeeds(self):
+        attempts = {"n": 0}
+
+        @with_retry(
+            RecoveryStrategy(
+                name="t",
+                max_retries=3,
+                base_delay=0.001,
+                max_delay=0.01,
+                backoff_factor=1.0,
+                jitter=False,
+                retryable_exceptions=[ValueError],
+            )
+        )
+        def flaky():
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise ValueError("not yet")
+            return "ok"
+
+        assert flaky() == "ok"
+        assert attempts["n"] == 3
+
+    def test_non_retryable_exception_reraises(self):
+        attempts = {"n": 0}
+
+        @with_retry(
+            RecoveryStrategy(
+                name="t",
+                max_retries=3,
+                base_delay=0.001,
+                max_delay=0.01,
+                backoff_factor=1.0,
+                jitter=False,
+                retryable_exceptions=[ValueError],
+            )
+        )
+        def bad():
+            attempts["n"] += 1
+            raise KeyError("nope")
+
+        with pytest.raises(KeyError, match="nope"):
+            bad()
+        assert attempts["n"] == 1
+
+    def test_exhausts_retries_raises_recovery_error(self):
+        @with_retry(
+            RecoveryStrategy(
+                name="t",
+                max_retries=2,
+                base_delay=0.001,
+                max_delay=0.01,
+                backoff_factor=1.0,
+                jitter=False,
+                retryable_exceptions=[ValueError],
+            )
+        )
+        def always_bad():
+            raise ValueError("nope")
+
+        with pytest.raises(RecoveryError, match="Failed after 2 retries"):
+            always_bad()
+
+
+class TestWithCircuitBreakerDecorator:
+    """Cover the with_circuit_breaker decorator."""
+
+    def test_creates_circuit_breaker_attribute(self):
+        @with_circuit_breaker("api_call", fail_max=2)
+        def call_api():
+            return "ok"
+
+        assert isinstance(call_api.circuit_breaker, CircuitBreaker)
+        assert call_api.circuit_breaker.name == "api_call"
+        assert call_api() == "ok"
+
+    def test_uses_function_name_when_no_name(self):
+        @with_circuit_breaker(fail_max=2)
+        def my_endpoint():
+            return "ok"
+
+        assert my_endpoint.circuit_breaker.name == "my_endpoint"
+
+
+class TestErrorRecoverySystem:
+    """Cover the centralized error recovery system."""
+
+    def test_initializes_default_strategies(self):
+        sys = ErrorRecoverySystem()
+        assert "network" in sys.recovery_strategies
+        assert "llm_api" in sys.recovery_strategies
+        assert "file_io" in sys.recovery_strategies
+
+    def test_register_and_get_circuit_breaker(self):
+        sys = ErrorRecoverySystem()
+        cb = sys.register_circuit_breaker("api1", fail_max=2)
+        assert cb is sys.get_circuit_breaker("api1")
+        assert sys.get_circuit_breaker("missing") is None
+
+    def test_execute_with_recovery_succeeds(self):
+        sys = ErrorRecoverySystem()
+        assert sys.execute_with_recovery("op", lambda: 42) == 42
+
+    def test_execute_with_recovery_eventually_raises(self):
+        sys = ErrorRecoverySystem()
+        # Patch the LLM strategy to use no retries / no backoff so the
+        # test runs fast.
+        sys.recovery_strategies["llm_api"] = RecoveryStrategy(
+            name="t",
+            max_retries=0,
+            base_delay=0.0,
+            max_delay=0.0,
+            backoff_factor=1.0,
+            jitter=False,
+        )
+        with pytest.raises(RecoveryError, match="op failed"):
+            sys.execute_with_recovery("op", lambda: (_ for _ in ()).throw(RuntimeError("bad")))
+
+    def test_get_all_stats_with_no_breakers(self):
+        sys = ErrorRecoverySystem()
+        stats = sys.get_all_stats()
+        assert "circuit_breakers" in stats
+        assert "recovery_strategies" in stats
+        assert stats["circuit_breakers"] == {}
+
+    def test_get_all_stats_with_breakers(self):
+        sys = ErrorRecoverySystem()
+        sys.register_circuit_breaker("api1", fail_max=3)
+        sys.register_circuit_breaker("api2", fail_max=5)
+        stats = sys.get_all_stats()
+        assert "api1" in stats["circuit_breakers"]
+        assert "api2" in stats["circuit_breakers"]
+
+
+class TestGetRecoverySystem:
+    """Cover the global recovery system singleton accessor."""
+
+    def test_returns_singleton(self):
+        a = get_recovery_system()
+        b = get_recovery_system()
+        assert a is b


### PR DESCRIPTION
Fixes #1685

Adds unit tests for high-ROI low-coverage modules to lift ai-engine coverage from 31.92% baseline to 70.09% (cleared the 70% CI floor).

## New test files (7)
- ai-engine/tests/evaluation/test_evaluator.py — 0% → 92.07%
- ai-engine/tests/evaluation/test_rag_evaluator.py — 0% → 92.96%
- ai-engine/tests/orchestration/test_orchestrator.py — 8.8% → 71.73%
- ai-engine/tests/orchestration/test_worker_pool.py — 14.7% → 86.32%
- ai-engine/tests/orchestration/test_monitoring.py — 96.85%
- ai-engine/tests/utils/test_error_recovery.py — 96.70%

## Pre-existing bug discovered (not fixed, documented in tests)
- `OrchestrationMonitor.__init__` shadows `self.stop_monitoring = threading.Event()` over the same-named method. Tests in test_monitoring.py document the behavior; fix can come in a separate PR.

## Notes
- All new tests are pure unit tests (@pytest.mark.unit, no DB/Redis/AI calls)
- `strategy_selector.py` skipped per the do-not-touch list (currently 21%)
- The 5 test collection errors listed in the issue (test_bedrock_patterns, test_java_patterns, test_pattern_base, test_pattern_mappings, test_web_search_tool_coverage) were already resolved in earlier commits on main; no collection fixes needed here
- Coverage gate cleared: 70.09% ≥ 70.00%

Closes #1685