### PR TITLE
test(backend): resolve #1785 — add authZ + resource-limiter DoS guardrail tests

### DIFF
--- a/backend/src/tests/unit/test_authz_helper.py
+++ b/backend/src/tests/unit/test_authz_helper.py
@@ -1,0 +1,232 @@
+"""
+Regression tests for ``api._authz`` — specifically the anti-enumeration
+invariant introduced in issue #1417: ``assert_owner`` returns 404 (never 403)
+when a user requests a resource they don't own, to avoid leaking resource
+existence to anonymous probers.
+
+Also covers all ``get_current_user`` rejection branches (four 401 modes).
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4, UUID
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from api._authz import assert_owner, get_current_user
+from security.auth import verify_api_key, verify_token
+
+
+# ---------------------------------------------------------------------------
+# Fake AsyncSession (mirrors test_security_auth_verify_api_key.py patterns)
+# ---------------------------------------------------------------------------
+
+
+class _ScalarResult:
+    """Mimics the slice of the SQLAlchemy ``Result`` API used by get_current_user."""
+
+    def __init__(self, rows: list[Any]):
+        self._rows = rows
+
+    def scalar_one_or_none(self) -> Any | None:
+        return self._rows[0] if self._rows else None
+
+
+class _FakeAsyncSession:
+    """Single-call fake that returns a canned User row."""
+
+    def __init__(self, user: Any | None):
+        self._user = user
+
+    async def execute(self, _stmt: Any) -> _ScalarResult:
+        return _ScalarResult([self._user] if self._user else [])
+
+
+# ---------------------------------------------------------------------------
+# Fake credentials
+# ---------------------------------------------------------------------------
+
+
+def _credentials(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_current_user — mpk_ API-key path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestGetCurrentUserApiKeyPath:
+    """Exercise get_current_user when the token starts with 'mpk_'."""
+
+    async def test_valid_api_key_returns_user(self):
+        fake_user = SimpleNamespace(id=uuid4(), email="api@example.com")
+        with patch(
+            "api._authz.verify_api_key", return_value=fake_user
+        ) as mock_verify:
+            user = await get_current_user(
+                credentials=_credentials("mpk_test-api-key-12345678"),
+                db=_FakeAsyncSession(fake_user),
+            )
+            assert user is fake_user
+            mock_verify.assert_called_once()
+
+    async def test_revoked_api_key_returns_none_raises_401(self):
+        with patch("api._authz.verify_api_key", return_value=None):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(
+                    credentials=_credentials("mpk_revoked-key-12345678"),
+                    db=_FakeAsyncSession(None),
+                )
+            assert exc_info.value.status_code == 401
+            assert "Invalid or revoked API key" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_current_user — JWT path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestGetCurrentUserJwtPath:
+    """Exercise get_current_user when the token is a plain JWT."""
+
+    async def _call(self, token: str, user: Any | None):
+        return await get_current_user(
+            credentials=_credentials(token),
+            db=_FakeAsyncSession(user),
+        )
+
+    async def test_valid_jwt_returns_user(self):
+        fake_user = SimpleNamespace(id=uuid4(), email="jwt@example.com")
+        with patch("api._authz.verify_token", return_value=str(fake_user.id)):
+            user = await self._call("jwt.unsigned.token", fake_user)
+            assert user is fake_user
+
+    async def test_invalid_token_raises_401(self):
+        with patch("api._authz.verify_token", return_value=None):
+            with pytest.raises(HTTPException) as exc_info:
+                await self._call("invalid.jwt.token", None)
+            assert exc_info.value.status_code == 401
+            assert "Invalid or expired token" in exc_info.value.detail
+
+    async def test_expired_token_raises_401(self):
+        with patch("api._authz.verify_token", return_value=None):
+            with pytest.raises(HTTPException) as exc_info:
+                await self._call("expired.jwt.token", None)
+            assert exc_info.value.status_code == 401
+
+    async def test_malformed_uuid_payload_raises_401(self):
+        with patch("api._authz.verify_token", return_value="not-a-uuid-string"):
+            with pytest.raises(HTTPException) as exc_info:
+                await self._call("jwt.with.bad.payload", None)
+            assert exc_info.value.status_code == 401
+            assert "Invalid token payload" in exc_info.value.detail
+
+    async def test_missing_user_raises_401(self):
+        with patch("api._authz.verify_token", return_value=str(uuid4())):
+            with pytest.raises(HTTPException) as exc_info:
+                await self._call("jwt.no.such.user", None)
+            assert exc_info.value.status_code == 401
+            assert "User not found" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Tests: assert_owner — the anti-enumeration invariant (issue #1417)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAssertOwnerAntiEnumeration:
+    """
+    Verify assert_owner returns 404 (NEVER 403) when:
+    - resource is None
+    - user does not own the resource
+
+    This locks the anti-enumeration invariant as an executable regression test.
+    """
+
+    def _user(self, id: str | None = None):
+        id = id or str(uuid4())
+        return SimpleNamespace(id=id)
+
+    def _resource(self, user_id: str):
+        return SimpleNamespace(user_id=user_id)
+
+    def test_none_resource_raises_404(self):
+        user = self._user()
+        with pytest.raises(HTTPException) as exc_info:
+            assert_owner(None, user)
+        assert exc_info.value.status_code == 404
+
+    def test_non_owner_raises_404_never_403(self):
+        """
+        CRITICAL: This must always be 404, never 403.
+        A 403 tells the prober "the resource exists but you don't have access".
+        A 404 tells them nothing — preserving the anti-enumeration invariant.
+        """
+        owner_id = str(uuid4())
+        other_user = self._user()
+        resource = self._resource(owner_id)
+        with pytest.raises(HTTPException) as exc_info:
+            assert_owner(resource, other_user)
+        assert exc_info.value.status_code == 404, (
+            "assert_owner must return 404 (never 403) for non-owner access"
+        )
+        assert "Resource not found" in exc_info.value.detail
+
+    def test_owner_returns_resource(self):
+        owner_id = str(uuid4())
+        owner_user = self._user(owner_id)
+        resource = self._resource(owner_id)
+        result = assert_owner(resource, owner_user)
+        assert result is resource
+
+    def test_owner_with_none_owner_field_raises_404(self):
+        """A resource with owner_field=None should be treated as non-owned."""
+        user = self._user()
+        resource = SimpleNamespace(user_id=None)
+        with pytest.raises(HTTPException) as exc_info:
+            assert_owner(resource, user)
+        assert exc_info.value.status_code == 404
+
+    def test_owner_with_custom_owner_field(self):
+        """assert_owner respects a custom owner_field name."""
+        custom_owner_id = str(uuid4())
+        owner_user = self._user(custom_owner_id)
+        resource = SimpleNamespace(creator_id=custom_owner_id)
+        result = assert_owner(resource, owner_user, owner_field="creator_id")
+        assert result is resource
+
+    def test_non_owner_with_custom_owner_field_raises_404(self):
+        """Custom owner_field also returns 404 for non-owner."""
+        owner_user = self._user()
+        resource = SimpleNamespace(creator_id=str(uuid4()))  # Different user
+        with pytest.raises(HTTPException) as exc_info:
+            assert_owner(resource, owner_user, owner_field="creator_id")
+        assert exc_info.value.status_code == 404
+
+    def test_custom_not_found_detail(self):
+        """assert_owner uses the provided not_found_detail in the 404 body."""
+        user = self._user()
+        resource = SimpleNamespace(user_id=str(uuid4()))  # Different user
+        custom_msg = "custom-not-found-message"
+        with pytest.raises(HTTPException) as exc_info:
+            assert_owner(resource, user, not_found_detail=custom_msg)
+        assert exc_info.value.status_code == 404
+        assert custom_msg in exc_info.value.detail
+
+    def test_str_owner_comparison(self):
+        """assert_owner compares owner as string, so int UUIDs work too."""
+        owner_id = uuid4()  # UUID object
+        owner_user = SimpleNamespace(id=owner_id)
+        # Resource stores owner as string
+        resource = SimpleNamespace(user_id=str(owner_id))
+        result = assert_owner(resource, owner_user)
+        assert result is resource

--- a/backend/src/tests/unit/test_resource_limits.py
+++ b/backend/src/tests/unit/test_resource_limits.py
@@ -1,0 +1,220 @@
+"""
+Regression tests for ``security.resource_limits.ResourceLimiter``.
+
+Covers the four raise-branches in ``check_limits`` (lines 180/184/188/196),
+the concurrent-cap rejection and counter-decrement-in-finally paths in
+``track_operation``, and the exception→False path in
+``check_available_disk_space``.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+
+import pytest
+
+from security.resource_limits import (
+    ResourceLimiter,
+    ResourceLimits,
+    ResourceLimitExceeded,
+)
+
+
+@pytest.mark.unit
+class TestResourceLimiterCheckLimits:
+    """Exercise ResourceLimiter.check_limits rejection branches."""
+
+    def _limiter(self, **kwargs) -> ResourceLimiter:
+        """Build a limiter with tiny limits so any usage triggers the branch."""
+        limits = ResourceLimits(
+            max_memory_mb=1,
+            max_disk_usage_mb=1,
+            max_processing_time_seconds=1,
+            max_open_files=1,
+            max_concurrent_uploads=1,
+            max_concurrent_extractions=1,
+        )
+        limiter = ResourceLimiter(limits)
+        # Start tracking so elapsed time is measured
+        limiter.start_tracking(Path("/tmp"))
+        return limiter
+
+    def test_raises_on_memory_exceeded(self):
+        limiter = self._limiter()
+        with patch.object(limiter, "_get_memory_usage_mb", return_value=9999.0):
+            with pytest.raises(ResourceLimitExceeded) as exc_info:
+                limiter.check_limits()
+            assert exc_info.value.resource_type == "memory"
+            assert exc_info.value.current == 9999.0
+            assert exc_info.value.limit == 1
+
+    def test_raises_on_disk_exceeded(self):
+        limiter = self._limiter()
+        limiter._disk_usage_path = Path("/tmp")
+        # Ensure memory/time/files don't trigger first by mocking them to 0
+        with patch.object(limiter, "_get_memory_usage_mb", return_value=0.0):
+            with patch.object(limiter, "_get_open_file_count", return_value=0):
+                with patch.object(limiter, "_get_cpu_time", return_value=0.0):
+                    with patch.object(limiter, "_get_directory_size_mb", return_value=9999.0):
+                        with pytest.raises(ResourceLimitExceeded) as exc_info:
+                            limiter.check_limits()
+                        assert exc_info.value.resource_type == "disk"
+
+    def test_raises_on_processing_time_exceeded(self):
+        limiter = self._limiter()
+        # Ensure memory/disk/files don't trigger first
+        with patch.object(limiter, "_get_memory_usage_mb", return_value=0.0):
+            with patch.object(limiter, "_get_open_file_count", return_value=0):
+                with patch.object(limiter, "_get_cpu_time", return_value=0.0):
+                    with patch.object(limiter, "_get_directory_size_mb", return_value=0.0):
+                        # Patch datetime.now to return a time far in the future
+                        from datetime import datetime, timezone
+                        import unittest.mock
+
+                        future = datetime(2099, 1, 1, tzinfo=timezone.utc)
+                        with unittest.mock.patch(
+                            "security.resource_limits.datetime"
+                        ) as mock_dt:
+                            mock_dt.now.return_value = future
+                            with pytest.raises(ResourceLimitExceeded) as exc_info:
+                                limiter.check_limits()
+                            assert exc_info.value.resource_type == "processing_time"
+
+    def test_raises_on_open_files_exceeded(self):
+        limiter = self._limiter()
+        # Also mock disk to prevent disk check from triggering first
+        with patch.object(limiter, "_get_memory_usage_mb", return_value=0.0):
+            with patch.object(limiter, "_get_directory_size_mb", return_value=0.0):
+                with patch.object(limiter, "_get_open_file_count", return_value=9999):
+                    with patch.object(limiter, "_get_cpu_time", return_value=0.0):
+                        with pytest.raises(ResourceLimitExceeded) as exc_info:
+                            limiter.check_limits()
+                        assert exc_info.value.resource_type == "open_files"
+
+
+@pytest.mark.unit
+class TestResourceLimiterTrackOperation:
+    """Exercise track_operation concurrent-cap and finally-decrement branches."""
+
+    def _limiter(self) -> ResourceLimiter:
+        limits = ResourceLimits(
+            max_concurrent_uploads=1,
+            max_concurrent_extractions=1,
+        )
+        return ResourceLimiter(limits)
+
+    def test_upload_rejects_when_at_capacity(self):
+        limiter = self._limiter()
+        # Use nested context managers so both operations are active simultaneously
+        with pytest.raises(ResourceLimitExceeded) as exc_info:
+            with limiter.track_operation("upload"):
+                # While this upload is active, try to start another
+                with limiter.track_operation("upload"):
+                    pass
+        assert exc_info.value.resource_type == "concurrent_uploads"
+
+    def test_extraction_rejects_when_at_capacity(self):
+        limiter = self._limiter()
+        with pytest.raises(ResourceLimitExceeded) as exc_info:
+            with limiter.track_operation("extraction"):
+                with limiter.track_operation("extraction"):
+                    pass
+        assert exc_info.value.resource_type == "concurrent_extractions"
+
+    def test_upload_counter_decremented_in_finally_when_body_raises(self):
+        """Counter must be decremented even when the body raises."""
+        limiter = self._limiter()
+        assert limiter._active_operations["uploads"] == 0
+        try:
+            with limiter.track_operation("upload"):
+                assert limiter._active_operations["uploads"] == 1
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        # Counter MUST be zero after the finally block
+        assert limiter._active_operations["uploads"] == 0
+
+    def test_extraction_counter_decremented_in_finally_when_body_raises(self):
+        """Counter must be decremented even when the body raises."""
+        limiter = self._limiter()
+        assert limiter._active_operations["extractions"] == 0
+        try:
+            with limiter.track_operation("extraction"):
+                assert limiter._active_operations["extractions"] == 1
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert limiter._active_operations["extractions"] == 0
+
+    def test_check_limits_called_inside_operation_context(self):
+        """check_limits is called inside the context manager body."""
+        limiter = ResourceLimiter(
+            ResourceLimits(
+                max_concurrent_uploads=10,
+                max_concurrent_extractions=10,
+                max_memory_mb=0,  # Any memory usage will exceed
+                max_disk_usage_mb=1000,
+                max_processing_time_seconds=300,
+                max_open_files=100,
+            )
+        )
+        with patch.object(limiter, "_get_memory_usage_mb", return_value=9999.0):
+            with pytest.raises(ResourceLimitExceeded) as exc_info:
+                with limiter.track_operation("upload"):
+                    pass
+            assert exc_info.value.resource_type == "memory"
+
+
+@pytest.mark.unit
+class TestResourceLimiterCheckAvailableDiskSpace:
+    """Exercise check_available_disk_space paths."""
+
+    def _limiter(self) -> ResourceLimiter:
+        return ResourceLimiter()
+
+    def test_returns_true_when_space_sufficient(self, tmp_path: Path):
+        limiter = self._limiter()
+        # Mock shutil.disk_usage to return plenty of free space
+        fake_stat = SimpleNamespace(free=100 * 1024 * 1024 * 1024)  # 100 GB
+        with patch("shutil.disk_usage", return_value=fake_stat):
+            result = limiter.check_available_disk_space(tmp_path, required_mb=1000)
+            assert result is True
+
+    def test_returns_false_when_space_insufficient(self, tmp_path: Path):
+        limiter = self._limiter()
+        fake_stat = SimpleNamespace(free=1 * 1024 * 1024)  # 1 MB
+        with patch("shutil.disk_usage", return_value=fake_stat):
+            result = limiter.check_available_disk_space(tmp_path, required_mb=1000)
+            assert result is False
+
+    def test_returns_false_when_disk_usage_raises(self, tmp_path: Path):
+        limiter = self._limiter()
+        with patch("shutil.disk_usage", side_effect=OSError("mocked error")):
+            result = limiter.check_available_disk_space(tmp_path, required_mb=1000)
+            assert result is False
+
+
+@pytest.mark.unit
+class TestResourceLimiterStartStopTracking:
+    """Basic start/stop tracking smoke tests."""
+
+    def test_start_then_stop_returns_usage(self):
+        limiter = ResourceLimiter()
+        limiter.start_tracking(Path("/tmp"))
+        usage = limiter.stop_tracking()
+        assert usage.processing_time_seconds >= 0
+        assert isinstance(usage.memory_mb, float)
+
+    def test_get_current_usage_returns_all_zeros_when_no_tracking(self):
+        limiter = ResourceLimiter()
+        # Mock all the get_* methods to ensure predictable values
+        with patch.object(limiter, "_get_memory_usage_mb", return_value=0.0):
+            with patch.object(limiter, "_get_directory_size_mb", return_value=0.0):
+                with patch.object(limiter, "_get_open_file_count", return_value=0):
+                    with patch.object(limiter, "_get_cpu_time", return_value=0.0):
+                        usage = limiter.get_current_usage()
+                        assert usage.memory_mb == 0.0
+                        assert usage.disk_mb == 0.0
+                        assert usage.open_files == 0
+                        assert usage.cpu_time_seconds == 0.0
+                        assert usage.processing_time_seconds == 0.0

--- a/backend/src/tests/unit/test_resource_limits_monitor.py
+++ b/backend/src/tests/unit/test_resource_limits_monitor.py
@@ -1,0 +1,146 @@
+"""
+Regression tests for ``security.resource_limits`` module-level functions
+(DiskSpaceMonitor, get_resource_limiter, reset_resource_limiter) and the
+time_limit context manager.
+"""
+
+import signal
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+
+import pytest
+
+from security.resource_limits import (
+    DiskSpaceMonitor,
+    ResourceLimiter,
+    ResourceLimits,
+    ResourceLimitExceeded,
+    get_resource_limiter,
+    reset_resource_limiter,
+)
+
+
+@pytest.mark.unit
+class TestDiskSpaceMonitorCheckDiskSpace:
+    """Exercise DiskSpaceMonitor.check_disk_space tri-state and error paths."""
+
+    def _monitor(self) -> DiskSpaceMonitor:
+        # Tiny thresholds so any non-zero free space triggers "ok"
+        return DiskSpaceMonitor(warning_threshold_mb=500, critical_threshold_mb=100)
+
+    def test_returns_ok_status_when_plenty_of_space(self, tmp_path: Path):
+        monitor = self._monitor()
+        # 1 TB free
+        fake_stat = SimpleNamespace(
+            total=1024 * 1024 * 1024 * 1024,
+            used=100 * 1024 * 1024 * 1024,
+            free=924 * 1024 * 1024 * 1024,
+        )
+        with patch("shutil.disk_usage", return_value=fake_stat):
+            result = monitor.check_disk_space(tmp_path)
+            assert result["status"] == "ok"
+            assert "free_mb" in result
+            assert "percent_used" in result
+
+    def test_returns_warning_status_when_space_below_warning_threshold(self, tmp_path: Path):
+        monitor = self._monitor()
+        # 300 MB free (below 500 MB warning, above 100 MB critical)
+        fake_stat = SimpleNamespace(
+            total=1024 * 1024 * 1024,
+            used=724 * 1024 * 1024,
+            free=300 * 1024 * 1024,
+        )
+        with patch("shutil.disk_usage", return_value=fake_stat):
+            result = monitor.check_disk_space(tmp_path)
+            assert result["status"] == "warning"
+
+    def test_returns_critical_status_when_space_below_critical_threshold(
+        self, tmp_path: Path
+    ):
+        monitor = self._monitor()
+        # 50 MB free (below 100 MB critical)
+        fake_stat = SimpleNamespace(
+            total=1024 * 1024 * 1024,
+            used=974 * 1024 * 1024,
+            free=50 * 1024 * 1024,
+        )
+        with patch("shutil.disk_usage", return_value=fake_stat):
+            result = monitor.check_disk_space(tmp_path)
+            assert result["status"] == "critical"
+
+    def test_returns_error_status_when_disk_usage_raises(self, tmp_path: Path):
+        monitor = self._monitor()
+        with patch("shutil.disk_usage", side_effect=OSError("mocked IO error")):
+            result = monitor.check_disk_space(tmp_path)
+            assert result["status"] == "error"
+            assert "error" in result
+
+
+@pytest.mark.unit
+class TestResourceLimiterTimeLimit:
+    """Exercise time_limit context manager signal and fallback paths."""
+
+    def _limiter(self) -> ResourceLimiter:
+        return ResourceLimiter(ResourceLimits(max_processing_time_seconds=300))
+
+    def test_raises_when_operation_exceeds_time_limit(self):
+        limiter = self._limiter()
+        import time
+
+        with pytest.raises(ResourceLimitExceeded) as exc_info:
+            with limiter.time_limit(seconds=1):
+                time.sleep(2)  # Exceed the 1-second limit
+        assert exc_info.value.resource_type == "time"
+
+    def test_succeeds_when_operation_completes_within_limit(self):
+        limiter = self._limiter()
+        import time
+
+        # Should not raise
+        with limiter.time_limit(seconds=5):
+            time.sleep(0.1)
+
+    def test_time_limit_fallback_on_signal_valueerror(self):
+        """
+        When signal.SIGALRM raises ValueError (non-main-thread or Windows),
+        the fallback path should still enforce the time limit.
+        """
+        limiter = self._limiter()
+        import time
+        from unittest.mock import patch
+
+        # Force the signal path to raise ValueError, exercising the fallback
+        with patch("signal.signal", side_effect=ValueError("SIGALRM not available")):
+            with pytest.raises(ResourceLimitExceeded) as exc_info:
+                with limiter.time_limit(seconds=1):
+                    time.sleep(2)
+            assert exc_info.value.resource_type == "time"
+
+
+@pytest.mark.unit
+class TestModuleLevelResourceLimiterFunctions:
+    """Exercise get_resource_limiter singleton and reset_resource_limiter."""
+
+    def test_get_resource_limiter_returns_same_instance(self):
+        reset_resource_limiter()  # Start clean
+        first = get_resource_limiter()
+        second = get_resource_limiter()
+        assert first is second
+
+    def test_reset_resource_limiter_clears_singleton(self):
+        reset_resource_limiter()
+        first = get_resource_limiter()
+        reset_resource_limiter()
+        second = get_resource_limiter()
+        assert first is not second
+
+    def test_resource_limiter_singleton_has_default_limits(self):
+        reset_resource_limiter()
+        limiter = get_resource_limiter()
+        assert limiter.limits.max_memory_mb == 512
+        assert limiter.limits.max_disk_usage_mb == 1024
+        assert limiter.limits.max_processing_time_seconds == 300
+        assert limiter.limits.max_concurrent_uploads == 10
+        assert limiter.limits.max_concurrent_extractions == 5


### PR DESCRIPTION
## Summary by Sourcery

Add regression test coverage for authorization invariants and resource limiting safeguards to guard against enumeration and DoS scenarios.

Tests:
- Add unit tests for get_current_user API key and JWT flows covering successful authentication and all 401 rejection branches.
- Add regression tests for assert_owner to enforce 404 responses for non-owners and missing resources, including custom owner fields and messages.
- Add unit tests for ResourceLimiter.check_limits, track_operation, and disk space checks covering all limit-exceeded and error paths.
- Add regression tests for DiskSpaceMonitor, time_limit context manager, and module-level resource limiter singleton helpers including fallback behaviors and default limits.