### PR TITLE
feat(ai-engine): resolve #1774 — extract Java entity Goals from registerGoals() AST

### DIFF
--- a/ai-engine/agents/java_analyzer/feature_extractor.py
+++ b/ai-engine/agents/java_analyzer/feature_extractor.py
@@ -32,6 +32,12 @@ except ImportError:
 FEATURE_ANALYSIS_FILE_LIMIT = 10
 METADATA_AST_FILE_LIMIT = 5
 DEPENDENCY_ANALYSIS_FILE_LIMIT = 10
+GOAL_SELECTOR_PATTERNS = (
+    "goalSelector.addGoal",
+    "goalSelector.add",
+    "targetSelector.addGoal",
+    "targetSelector.add",
+)
 
 
 class FeatureExtractor:
@@ -91,13 +97,15 @@ class FeatureExtractor:
                         }
                     )
                 elif "Entity" in class_name and not class_name.startswith("Abstract"):
-                    features["entities"].append(
-                        {
-                            "name": class_name,
-                            "registry_name": _class_name_to_registry_name(class_name),
-                            "methods": class_info.get("methods", []),
-                        }
-                    )
+                    entity_info = {
+                        "name": class_name,
+                        "registry_name": _class_name_to_registry_name(class_name),
+                        "methods": class_info.get("methods", []),
+                    }
+                    goals = self.extract_entity_goals_from_ast(class_node)
+                    if goals:
+                        entity_info["goals"] = goals
+                    features["entities"].append(entity_info)
 
             method_declarations = self._find_nodes_by_type(tree, "method_declaration")
             for method_node in method_declarations:
@@ -133,6 +141,185 @@ class FeatureExtractor:
         except Exception as e:
             logger.warning(f"Error extracting features from AST: {e}")
             return features
+
+    def extract_entity_goals_from_ast(self, tree: Dict) -> List[Dict[str, Any]]:
+        """
+        Extract entity AI goals from registerGoals() method AST.
+
+        Parses GoalSelector.addGoal(...) and targetSelector.addGoal(...) call sites
+        to extract goal type, priority, and constructor arguments.
+
+        Args:
+            tree: Parsed Java AST (tree-sitter format)
+
+        Returns:
+            List of goal dicts with keys: type, priority, config
+        """
+        goals: List[Dict[str, Any]] = []
+
+        try:
+            method_declarations = self._find_nodes_by_type(tree, "method_declaration")
+            for method_node in method_declarations:
+                method_name = self._get_method_name(method_node)
+                if method_name not in ("registerGoals", "createGoals"):
+                    continue
+
+                block_nodes = self._find_nodes_by_type(method_node, "block")
+                if not block_nodes:
+                    continue
+
+                goal_calls = self._find_goal_selector_calls(block_nodes[0])
+                for call in goal_calls:
+                    goal_info = self._parse_goal_call(call)
+                    if goal_info:
+                        goals.append(goal_info)
+
+        except Exception as e:
+            logger.warning(f"Error extracting entity goals from AST: {e}")
+
+        return goals
+
+    def _find_goal_selector_calls(self, block_node: Dict) -> List[Dict]:
+        """Find all GoalSelector.addGoal/add calls within a block."""
+        calls: List[Dict] = []
+        method_invocations = self._find_nodes_by_type(block_node, "method_invocation")
+        for inv in method_invocations:
+            method_name = self._get_ts_method_name(inv)
+            if method_name not in ("addGoal", "add"):
+                continue
+            for child in inv.get("children", []):
+                if child.get("type") == "field_access":
+                    qualifier = self._extract_field_access_name(child)
+                    if qualifier and qualifier.lower() == "goalselector":
+                        calls.append(inv)
+                        break
+        return calls
+
+    def _extract_field_access_name(self, field_access_node: Dict) -> Optional[str]:
+        """Extract the field name from a field_access node."""
+        identifiers = []
+        for child in field_access_node.get("children", []):
+            if child.get("type") == "identifier":
+                identifiers.append(child.get("text", ""))
+        if identifiers:
+            return identifiers[-1]
+        return None
+
+    def _parse_goal_call(self, inv_node: Dict) -> Optional[Dict[str, Any]]:
+        """Parse a goal selector call into {type, priority, config}."""
+        try:
+            args = self._get_method_arguments(inv_node)
+            if len(args) < 2:
+                return None
+
+            priority = self._extract_priority_from_arg(args[0])
+            goal_class = self._extract_goal_class_name(args[1])
+
+            if goal_class is None or priority is None:
+                return None
+
+            goal_constructor_args = self._extract_goal_constructor_args(args[1])
+            goal_type = self._goal_class_to_type(goal_class)
+            config = self._extract_goal_config(goal_class, args[2:], goal_constructor_args)
+
+            return {"type": goal_type, "priority": priority, "config": config}
+        except Exception:
+            return None
+
+    def _extract_goal_constructor_args(self, arg_node: Dict) -> Optional[List]:
+        """Extract arguments from a goal constructor 'new GoalClass(...)' node."""
+        try:
+            if arg_node.get("type") != "object_creation_expression":
+                return None
+            for child in arg_node.get("children", []):
+                if child.get("type") == "argument_list":
+                    goal_args = []
+                    for arg in child.get("children", []):
+                        arg_type = arg.get("type")
+                        if arg_type in (
+                            "decimal_integer_literal",
+                            "decimal_floating_point_literal",
+                            "true",
+                            "false",
+                            "string_literal",
+                        ):
+                            goal_args.append(arg)
+                    return goal_args
+            return None
+        except Exception:
+            return None
+
+    def _extract_priority_from_arg(self, arg_node: Dict) -> Optional[int]:
+        """Extract integer priority from the first argument."""
+        try:
+            text = arg_node.get("text", "").strip()
+            if text.isdigit():
+                return int(text)
+            if text.startswith("int(") or text.startswith("Integer."):
+                return None
+            return None
+        except Exception:
+            return None
+
+    def _extract_goal_class_name(self, arg_node: Dict) -> Optional[str]:
+        """Extract the Goal class name from 'new ClassName(...)' argument."""
+        try:
+            if arg_node.get("type") == "object_creation_expression":
+                for child in arg_node.get("children", []):
+                    child_type = child.get("type")
+                    if child_type in ("identifier", "type_identifier"):
+                        return child.get("text", "")
+            if arg_node.get("type") == "class_literal":
+                text = arg_node.get("text", "")
+                return text.replace(".class", "") if text else None
+            text = arg_node.get("text", "")
+            if "Goal" in text:
+                text = text.strip()
+                if "(" in text:
+                    text = text[: text.index("(")]
+                return text
+            return None
+        except Exception:
+            return None
+
+    def _goal_class_to_type(self, class_name: str) -> str:
+        """Convert a Java Goal class name to goal type string."""
+        name = class_name
+        name = re.sub(r"Goal$", "", name)
+        name = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", name).lower()
+        return name
+
+    def _extract_goal_config(
+        self, goal_class: str, add_goal_args: List, goal_constructor_args: Optional[List] = None
+    ) -> Dict[str, Any]:
+        """Extract configuration from goal constructor arguments."""
+        config: Dict[str, Any] = {}
+
+        try:
+            args = goal_constructor_args if goal_constructor_args else add_goal_args
+            if not args:
+                return config
+
+            if "Attack" in goal_class and len(args) >= 2:
+                speed = self._extract_numeric_arg(args[0])
+                if speed:
+                    config["speed_multiplier"] = speed
+            elif "Stroll" in goal_class or "Wander" in goal_class or "Move" in goal_class:
+                speed = self._extract_numeric_arg(args[0])
+                if speed:
+                    config["speed_multiplier"] = speed
+            elif "LookAt" in goal_class:
+                dist = self._extract_numeric_arg(args[0])
+                if dist:
+                    config["look_distance"] = dist
+            elif "Follow" in goal_class:
+                dist = self._extract_numeric_arg(args[0])
+                if dist:
+                    config["distance"] = dist
+        except Exception:
+            pass
+
+        return config
 
     def extract_features_from_bytecode(self, class_info: Dict) -> Dict:
         """Extract mod features from bytecode-analyzed class information."""

--- a/ai-engine/knowledge/patterns/entity_behavior_patterns.py
+++ b/ai-engine/knowledge/patterns/entity_behavior_patterns.py
@@ -436,6 +436,9 @@ def get_behaviors_by_type(behavior_type: EntityBehaviorType) -> List[BehaviorPat
     ]
 
 
+_unmapped_goal_count = 0
+
+
 def convert_java_goal_to_bedrock(
     java_goal: Dict[str, Any],
     override_defaults: Optional[Dict[str, Any]] = None,
@@ -448,28 +451,33 @@ def convert_java_goal_to_bedrock(
         override_defaults: Optional overrides for default config
 
     Returns:
-        Bedrock behavior component dictionary
+        Bedrock behavior component dictionary; unmapped goals return
+        {"minecraft:behavior.<unmapped>": {...}, "_unmapped": True}
     """
-    goal_type = java_goal.get("type", "").lower()
+    global _unmapped_goal_count
+    goal_type = java_goal.get("type", "").strip().lower()
     goal_config = java_goal.get("config", {})
     priority = java_goal.get("priority", None)
 
     pattern = get_behavior_pattern(goal_type)
     if not pattern:
-        return {}
+        _unmapped_goal_count += 1
+        unmapped_config = {"priority": priority} if priority is not None else {}
+        if goal_config:
+            unmapped_config["_raw_config"] = goal_config
+        return {
+            f"minecraft:behavior.{goal_type}": unmapped_config,
+            "_unmapped": True,
+        }
 
-    # Start with default config
     result = pattern.default_config.copy()
 
-    # Override with goal-specific config
     if goal_config:
         result.update(goal_config)
 
-    # Override with user-specified overrides
     if override_defaults:
         result.update(override_defaults)
 
-    # Set priority if specified
     if priority is not None:
         result["priority"] = priority
     else:
@@ -555,7 +563,14 @@ def get_behavior_stats() -> Dict[str, int]:
         "interaction_behaviors": len(get_behaviors_by_type(EntityBehaviorType.INTERACTION)),
         "specialized_behaviors": len(get_behaviors_by_type(EntityBehaviorType.SPECIALIZED)),
         "entity_templates": len(get_entity_ai_templates()),
+        "unmapped_goal_count": _unmapped_goal_count,
     }
+
+
+def reset_unmapped_goal_count() -> None:
+    """Reset the unmapped goal counter (for testing)."""
+    global _unmapped_goal_count
+    _unmapped_goal_count = 0
 
 
 # Export commonly used items
@@ -570,4 +585,5 @@ __all__ = [
     "convert_java_goal_to_bedrock",
     "get_entity_ai_templates",
     "get_behavior_stats",
+    "reset_unmapped_goal_count",
 ]

--- a/ai-engine/tests/test_entity_goal_extraction.py
+++ b/ai-engine/tests/test_entity_goal_extraction.py
@@ -1,0 +1,252 @@
+"""
+Unit tests for Entity Goal Extraction from registerGoals() AST
+
+Tests the extraction of Java entity AI goals from registerGoals() method
+bodies via tree-sitter AST analysis, and the handling of unmapped goals.
+
+Issue: #1774
+"""
+
+import pytest
+import sys
+from pathlib import Path
+
+ai_engine_root = Path(__file__).parent.parent
+sys.path.insert(0, str(ai_engine_root))
+
+from agents.java_analyzer.feature_extractor import FeatureExtractor
+from knowledge.patterns.entity_behavior_patterns import (
+    convert_java_goal_to_bedrock,
+    get_behavior_stats,
+    reset_unmapped_goal_count,
+)
+
+
+class TestRegisterGoalsASTExtraction:
+    """Test cases for registerGoals() AST extraction."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        patterns = {
+            "blocks": ["Block", "BlockState", "registerBlock", "ModBlocks"],
+            "items": ["Item", "ItemStack", "registerItem", "ModItems"],
+            "entities": ["Entity", "EntityType", "registerEntity", "ModEntities"],
+            "recipes": ["IRecipe", "ShapedRecipe", "ShapelessRecipe", "registerRecipe"],
+            "dimensions": ["Dimension", "World", "DimensionType", "createDimension"],
+            "gui": ["GuiScreen", "ContainerScreen", "IGuiHandler", "MenuType"],
+            "machinery": ["TileEntity", "BlockEntity", "IEnergyStorage", "IFluidHandler"],
+            "commands": ["Command", "ICommand", "CommandBase", "registerCommand"],
+            "events": ["Event", "SubscribeEvent", "EventHandler", "Listener"],
+        }
+        self.extractor = FeatureExtractor(patterns)
+        reset_unmapped_goal_count()
+
+    def test_extract_melee_attack_goal(self):
+        """Test extraction of a MeleeAttackGoal from registerGoals."""
+        source = """
+package com.example;
+
+import net.minecraft.entity.ai.goal.MeleeAttackGoal;
+import net.minecraft.entity.ai.goal.FloatGoal;
+import net.minecraft.entity.ai.goal.WaterNavipoor;
+import net.minecraft.entity.ai.goal.Goal;
+
+public class CustomEntity extends PathfinderMob {
+    @Override
+    protected void registerGoals() {
+        this.goalSelector.addGoal(0, new FloatGoal(this));
+        this.goalSelector.addGoal(1, new MeleeAttackGoal(this, 1.2, true));
+        this.goalSelector.addGoal(2, new RandomStrollGoal(this, 1.0));
+    }
+}
+"""
+        tree = self.extractor.parse_java_source(source)
+        assert tree is not None, "Failed to parse Java source"
+
+        goals = self.extractor.extract_entity_goals_from_ast(tree)
+
+        assert len(goals) >= 1, f"Expected at least 1 goal, got {len(goals)}"
+        goal_types = [g["type"] for g in goals]
+        assert "melee_attack" in goal_types, f"melee_attack not in {goal_types}"
+
+        melee_goal = next(g for g in goals if g["type"] == "melee_attack")
+        assert melee_goal["priority"] == 1
+        assert "speed_multiplier" in melee_goal["config"]
+
+    def test_extract_multiple_goals(self):
+        """Test extraction of multiple goals with priorities."""
+        source = """
+public class MyMob extends PathfinderMob {
+    @Override
+    protected void registerGoals() {
+        this.goalSelector.addGoal(0, new FloatGoal(this));
+        this.goalSelector.addGoal(1, new MeleeAttackGoal(this, 1.0, true));
+        this.goalSelector.addGoal(2, new LookAtPlayerGoal(this, Player.class, 8.0f));
+        this.goalSelector.addGoal(3, new RandomStrollGoal(this, 0.8));
+    }
+}
+"""
+        tree = self.extractor.parse_java_source(source)
+        assert tree is not None
+
+        goals = self.extractor.extract_entity_goals_from_ast(tree)
+
+        assert len(goals) == 4, f"Expected 4 goals, got {len(goals)}"
+        priorities = [g["priority"] for g in goals]
+        assert 0 in priorities
+        assert 1 in priorities
+
+    def test_no_goals_when_no_register_goals(self):
+        """Test that goals are empty when no registerGoals method exists."""
+        source = """
+public class NoGoalsEntity extends PathfinderMob {
+    @Override
+    protected void someOtherMethod() {
+    }
+}
+"""
+        tree = self.extractor.parse_java_source(source)
+        goals = self.extractor.extract_entity_goals_from_ast(tree)
+        assert goals == [], f"Expected no goals, got {goals}"
+
+    def test_entity_features_include_goals(self):
+        """Test that entity features extracted from AST include goals."""
+        source = """
+public class CustomZombieEntity extends ZombieEntity {
+    @Override
+    protected void registerGoals() {
+        this.goalSelector.addGoal(0, new MeleeAttackGoal(this, 1.0, true));
+    }
+}
+"""
+        tree = self.extractor.parse_java_source(source)
+        features = self.extractor.extract_features_from_ast(tree)
+
+        assert len(features["entities"]) > 0
+        entity = features["entities"][0]
+        assert "goals" in entity
+        assert len(entity["goals"]) == 1
+        assert entity["goals"][0]["type"] == "melee_attack"
+
+
+class TestUnmappedGoalHandling:
+    """Test cases for unmapped goal behavior."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        reset_unmapped_goal_count()
+
+    def test_unmapped_goal_returns_explicit_record(self):
+        """Test that unmapped goals return explicit record with _unmapped flag."""
+        java_goal = {
+            "type": "custom_unknown_goal",
+            "priority": 3,
+            "config": {"speed_multiplier": 1.0},
+        }
+
+        result = convert_java_goal_to_bedrock(java_goal)
+
+        assert "_unmapped" in result
+        assert result["_unmapped"] is True
+        assert "minecraft:behavior.custom_unknown_goal" in result
+
+    def test_unmapped_goal_preserves_priority(self):
+        """Test that unmapped goal preserves priority."""
+        java_goal = {"type": "my_custom_goal", "priority": 5}
+
+        result = convert_java_goal_to_bedrock(java_goal)
+
+        assert result["minecraft:behavior.my_custom_goal"]["priority"] == 5
+
+    def test_unmapped_goal_preserves_raw_config(self):
+        """Test that unmapped goal preserves raw config."""
+        java_goal = {
+            "type": " exotic_goal",
+            "priority": 2,
+            "config": {"custom_param": 42},
+        }
+
+        result = convert_java_goal_to_bedrock(java_goal)
+
+        assert "_raw_config" in result["minecraft:behavior.exotic_goal"]
+        assert result["minecraft:behavior.exotic_goal"]["_raw_config"]["custom_param"] == 42
+
+    def test_behavior_stats_reports_unmapped(self):
+        """Test that get_behavior_stats includes unmapped count."""
+        reset_unmapped_goal_count()
+
+        convert_java_goal_to_bedrock({"type": "unknown1", "priority": 1})
+        convert_java_goal_to_bedrock({"type": "unknown2", "priority": 2})
+
+        stats = get_behavior_stats()
+        assert "unmapped_goal_count" in stats
+        assert stats["unmapped_goal_count"] >= 2
+
+    def test_reset_unmapped_goal_count(self):
+        """Test that reset_unmapped_goal_count resets the counter."""
+        convert_java_goal_to_bedrock({"type": "unknown", "priority": 1})
+
+        reset_unmapped_goal_count()
+        stats2 = get_behavior_stats()
+
+        assert stats2["unmapped_goal_count"] == 0
+
+    def test_mapped_goal_does_not_set_unmapped(self):
+        """Test that mapped goals do NOT set _unmapped flag."""
+        java_goal = {
+            "type": "melee_attack",
+            "priority": 3,
+            "config": {"speed_multiplier": 1.5},
+        }
+
+        result = convert_java_goal_to_bedrock(java_goal)
+
+        assert "_unmapped" not in result
+        assert "minecraft:behavior.melee_attack" in result
+
+
+class TestGoalConversionEndToEnd:
+    """End-to-end tests for goal conversion."""
+
+    def setup_method(self):
+        reset_unmapped_goal_count()
+
+    def test_mixed_vanilla_and_custom_goals(self):
+        """Test conversion of mixed vanilla and custom goals."""
+        goals = [
+            {"type": "melee_attack", "priority": 1, "config": {"speed_multiplier": 1.2}},
+            {"type": "wander", "priority": 6, "config": {"speed_multiplier": 0.5}},
+            {"type": "custom_special_attack", "priority": 2, "config": {"damage": 10.0}},
+        ]
+
+        results = [convert_java_goal_to_bedrock(g) for g in goals]
+
+        mapped = [r for r in results if not r.get("_unmapped")]
+        unmapped = [r for r in results if r.get("_unmapped")]
+
+        assert len(mapped) == 2
+        assert len(unmapped) == 1
+        assert "minecraft:behavior.melee_attack" in mapped[0]
+        assert "minecraft:behavior.wander" in mapped[1]
+
+    def test_goal_count_matches_registered(self):
+        """Test that output goal count equals registered goal count."""
+        registered_goals = [
+            {"type": "look_at_player", "priority": 5},
+            {"type": "melee_attack", "priority": 3},
+            {"type": "wander", "priority": 7},
+            {"type": "custom_goal", "priority": 2},
+        ]
+
+        output_components = {}
+        for goal in registered_goals:
+            result = convert_java_goal_to_bedrock(goal)
+            for key, val in result.items():
+                if key != "_unmapped":
+                    output_components[key] = val
+
+        assert len(output_components) == len(registered_goals)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add registerGoals() AST visitor to feature_extractor.py that extracts
  goal type, priority, and config from GoalSelector.addGoal() calls
- Modify convert_java_goal_to_bedrock() to return explicit unmapped
  records with _unmapped=True flag instead of silent {} drops
- Add reset_unmapped_goal_count() for testing and
  unmapped_goal_count to get_behavior_stats()
- Write comprehensive tests in test_entity_goal_extraction.py
