### PR TITLE
refactor(ai-engine): resolve #1746 — split translator.py (38K) into domain modules

### DIFF
--- a/ai-engine/agents/logic_translator/ast_analyzer.py
+++ b/ai-engine/agents/logic_translator/ast_analyzer.py
@@ -1,0 +1,179 @@
+"""Tree-sitter Java AST analysis.
+
+Split out from ``translator.py`` per Issue #1746. Provides Java source analysis
+via tree-sitter, producing structured AST dictionaries and natural-language
+summaries that feed downstream translation.
+
+The :class:`ASTAnalyzerMixin` is composed into :class:`LogicTranslatorAgent`.
+"""
+
+from typing import Any, Dict
+
+try:
+    import tree_sitter_java as ts_java
+    from tree_sitter import Language, Parser
+
+    TREE_SITTER_AVAILABLE = True
+except ImportError:
+    TREE_SITTER_AVAILABLE = False
+    ts_java = None
+    Parser = None
+
+from utils.logging_config import get_agent_logger
+
+logger = get_agent_logger("logic_translator")
+
+
+class ASTAnalyzerMixin:
+    """Tree-sitter Java AST analysis methods for the LogicTranslatorAgent."""
+
+    def _get_tree_sitter_parser(self):
+        """Get or create tree-sitter parser instance."""
+        if not TREE_SITTER_AVAILABLE:
+            return None
+        if not hasattr(self, "_ts_parser") or self._ts_parser is None:
+            try:
+                lang = Language(ts_java.language())
+                self._ts_parser = Parser(lang)
+            except Exception as e:
+                logger.warning(f"Failed to initialize tree-sitter parser: {e}")
+                self._ts_parser = None
+        return self._ts_parser
+
+    def _tree_sitter_to_dict(self, node, error_count: int = 0) -> Dict[str, Any]:
+        """Convert tree-sitter node to dictionary."""
+        result = {
+            "type": node.type,
+            "start_point": node.start_point,
+            "end_point": node.end_point,
+            "start_byte": node.start_byte,
+            "end_byte": node.end_byte,
+            "has_errors": error_count > 0 or node.type == "ERROR",
+        }
+
+        if node.child_count == 0:
+            result["text"] = node.text.decode("utf8") if node.text else ""
+
+        if node.child_count > 0:
+            result["children"] = [
+                self._tree_sitter_to_dict(child, error_count) for child in node.children
+            ]
+
+        return result
+
+    def analyze_java_code_ast(self, java_code: str):
+        """Analyze Java code and return AST using tree-sitter."""
+        if not TREE_SITTER_AVAILABLE:
+            logger.warning(
+                "Tree-sitter not available, javalang fallback not supported in migrated code"
+            )
+            return {
+                "success": False,
+                "error": "tree-sitter not available",
+                "ast_tree": None,
+            }
+
+        parser = self._get_tree_sitter_parser()
+        if parser is None:
+            return {
+                "success": False,
+                "error": "tree-sitter parser not available",
+                "ast_tree": None,
+            }
+
+        try:
+            tree = parser.parse(bytes(java_code, "utf8"))
+            ast_dict = self._tree_sitter_to_dict(tree.root_node)
+            return {
+                "success": True,
+                "ast_tree": ast_dict,
+                "root_type": tree.root_node.type,
+            }
+        except Exception as e:
+            logger.error(f"Error analyzing Java code AST: {e}")
+            return {
+                "success": False,
+                "error": str(e),
+                "ast_tree": None,
+            }
+
+    def _serialize_ast_for_llm(self, ast_dict: Dict[str, Any], max_depth: int = 10) -> str:
+        """Serialize AST dictionary for LLM consumption."""
+        if ast_dict is None:
+            return "No AST available"
+
+        lines = []
+        indent = "  "
+
+        def serialize_node(node: Dict[str, Any], depth: int = 0):
+            if depth >= max_depth:
+                lines.append(f"{indent * depth}...")
+                return
+
+            node_type = node.get("type", "unknown")
+            has_errors = node.get("has_errors", False)
+
+            prefix = "[ERROR] " if has_errors else ""
+            lines.append(f"{indent * depth}{prefix}{node_type}")
+
+            if "text" in node:
+                text = node["text"]
+                if text.strip():
+                    lines.append(f"{indent * (depth + 1)}text: {repr(text)}")
+
+            if "children" in node:
+                for child in node["children"]:
+                    serialize_node(child, depth + 1)
+
+        serialize_node(ast_dict, 0)
+        return "\n".join(lines)
+
+    def generate_nl_summary_from_ast(self, java_code: str) -> str:
+        """Generate natural language summary from Java AST using tree-sitter."""
+        try:
+            result = self.analyze_java_code_ast(java_code)
+
+            if not result.get("success"):
+                return f"Could not analyze code: {result.get('error', 'Unknown error')}"
+
+            ast_dict = result.get("ast_tree")
+            if not ast_dict:
+                return "No AST found in analysis result"
+
+            self._serialize_ast_for_llm(ast_dict)
+
+            class_decl = None
+            method_sigs = []
+
+            def find_decls(node: Dict[str, Any]):
+                nonlocal class_decl
+                if node.get("type") == "class_declaration":
+                    nonlocal class_decl
+                    class_decl = node
+                elif node.get("type") == "method_declaration":
+                    method_sigs.append(node)
+
+            def walk(node: Dict[str, Any]):
+                find_decls(node)
+                for child in node.get("children", []):
+                    walk(child)
+
+            walk(ast_dict)
+
+            summary_parts = []
+            if class_decl:
+                class_name = "UnknownClass"
+                for child in class_decl.get("children", []):
+                    if child.get("type") == "identifier":
+                        class_name = child.get("text", "UnknownClass")
+                        break
+                summary_parts.append(f"Class: {class_name}")
+
+            if method_sigs:
+                summary_parts.append(f"Contains {len(method_sigs)} method(s)")
+
+            return "; ".join(summary_parts) if summary_parts else "Empty class"
+
+        except Exception as e:
+            logger.error(f"Error generating NL summary from AST: {e}")
+            return f"Error: {str(e)}"

--- a/ai-engine/agents/logic_translator/block_translator.py
+++ b/ai-engine/agents/logic_translator/block_translator.py
@@ -1,0 +1,243 @@
+"""Bedrock block and recipe translation.
+
+Split out from ``translator.py`` per Issue #1746. Provides generation and
+validation of Bedrock block JSON from Java block analysis, plus crafting
+recipe conversion and block property mapping.
+
+The :class:`BlockTranslatorMixin` is composed into :class:`LogicTranslatorAgent`
+and assumes the host class provides ``self.logger``.
+"""
+
+import json
+from typing import Any, Dict
+
+from agents.logic_translator.block_state_mapper import (
+    JAVA_TO_BEDROCK_BLOCK_PROPERTIES,
+)
+from agents.logic_translator.block_templates import (
+    BEDROCK_BLOCK_TEMPLATES,
+)
+from utils.logging_config import get_agent_logger
+
+logger = get_agent_logger("logic_translator")
+
+
+class BlockTranslatorMixin:
+    """Bedrock block/recipe translation methods for the LogicTranslatorAgent."""
+
+    def translate_crafting_recipe_json(self, recipe_json_data: str) -> str:
+        """Translate crafting recipe JSON to Bedrock format."""
+        try:
+            data = json.loads(recipe_json_data)
+            recipe_type = data.get("type", "unknown")
+
+            if recipe_type == "minecraft:crafting_shaped":
+                pattern = data.get("pattern", ["ABC", "DEF", "GHI"])
+                key = data.get("key", {"A": {"item": "minecraft:stick"}})
+                result = data.get("result", {"item": "minecraft:wooden_sword"})
+
+                bedrock_key = {}
+                for k, v in key.items():
+                    bedrock_key[k] = {"item": v["item"].replace("minecraft:", "")}
+
+                bedrock_result = {"item": result["item"].replace("minecraft:", "")}
+                if "count" in result:
+                    bedrock_result["count"] = result["count"]
+
+                bedrock_recipe = {
+                    "format_version": "1.17.0",
+                    "minecraft:recipe_shaped": {
+                        "description": {"identifier": "custom:shaped_recipe"},
+                        "pattern": pattern,
+                        "key": bedrock_key,
+                        "result": bedrock_result,
+                    },
+                }
+            elif recipe_type == "minecraft:crafting_shapeless":
+                ingredients = data.get("ingredients", [{"item": "minecraft:stick"}])
+                result = data.get("result", {"item": "minecraft:wooden_sword"})
+
+                bedrock_ingredients = []
+                for ingredient in ingredients:
+                    bedrock_ingredients.append(
+                        {"item": ingredient["item"].replace("minecraft:", "")}
+                    )
+
+                bedrock_result = {"item": result["item"].replace("minecraft:", "")}
+                if "count" in result:
+                    bedrock_result["count"] = result["count"]
+
+                bedrock_recipe = {
+                    "format_version": "1.17.0",
+                    "minecraft:recipe_shapeless": {
+                        "description": {"identifier": "custom:shapeless_recipe"},
+                        "ingredients": bedrock_ingredients,
+                        "result": bedrock_result,
+                    },
+                }
+            else:
+                raise ValueError(f"Unsupported recipe type: {recipe_type}")
+
+            return json.dumps({"success": True, "bedrock_recipe": bedrock_recipe, "warnings": []})
+        except Exception as e:
+            logger.error(f"Error translating recipe: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})
+
+    def generate_bedrock_block_json(
+        self,
+        java_block_analysis: Dict[str, Any],
+        namespace: str = "modporter",
+        use_rag: bool = True,
+    ) -> Dict[str, Any]:
+        """Generate Bedrock block JSON from Java block analysis."""
+        try:
+            logger.info(
+                f"Generating Bedrock block JSON for: {java_block_analysis.get('name', 'unknown')}"
+            )
+
+            block_name = java_block_analysis.get("registry_name", "unknown_block")
+            if ":" in block_name:
+                namespace, block_name = block_name.split(":", 1)
+
+            properties = java_block_analysis.get("properties", {})
+
+            template_type = self._determine_block_template(properties)
+            template = BEDROCK_BLOCK_TEMPLATES.get(template_type, BEDROCK_BLOCK_TEMPLATES["basic"])
+
+            block_json = self._build_block_json(
+                template=template, namespace=namespace, block_name=block_name, properties=properties
+            )
+
+            validation_result = self._validate_block_json(block_json)
+
+            translation_log = {
+                "original_java_block": java_block_analysis.get("name", "unknown"),
+                "template_used": template_type,
+                "properties_mapped": list(properties.keys()),
+                "validation_passed": validation_result["is_valid"],
+            }
+            logger.info(f"Block generation complete: {translation_log}")
+
+            return {
+                "success": True,
+                "block_json": block_json,
+                "block_name": f"{namespace}:{block_name}",
+                "validation": validation_result,
+                "translation_log": translation_log,
+                "warnings": validation_result.get("warnings", []),
+            }
+
+        except Exception as e:
+            logger.error(f"Error generating Bedrock block JSON: {e}")
+            return {
+                "success": False,
+                "error": str(e),
+                "block_json": None,
+                "warnings": [f"Block generation failed: {str(e)}"],
+            }
+
+    def validate_block_json(self, block_json_data: str) -> str:
+        """Validate a Bedrock block JSON against schema requirements."""
+        try:
+            data = json.loads(block_json_data)
+            block_json = data.get("block_json", {})
+
+            is_valid = "format_version" in block_json and "minecraft:block" in block_json
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "is_valid": is_valid,
+                    "errors": [] if is_valid else ["Missing required fields"],
+                    "warnings": [],
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error validating block JSON: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})
+
+    def map_block_properties(self, properties_data: str) -> str:
+        """Map Java block properties to Bedrock equivalents."""
+        try:
+            data = json.loads(properties_data)
+            java_properties = data.get("properties", {})
+
+            bedrock_properties = {}
+            for key, value in java_properties.items():
+                mapped_key = JAVA_TO_BEDROCK_BLOCK_PROPERTIES.get(key, key)
+                bedrock_properties[mapped_key] = value
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "bedrock_properties": bedrock_properties,
+                    "warnings": [],
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error mapping block properties: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})
+
+    def _determine_block_template(self, properties: Dict[str, Any]) -> str:
+        """Determine the best block template based on properties."""
+        material = properties.get("material", "stone").lower()
+
+        if properties.get("light_level", 0) > 0:
+            return "light_emitting"
+
+        material_template_map = {
+            "wood": "wooden",
+            "stone": "stone",
+            "dirt": "dirt",
+            "sand": "sand",
+            "glass": "glass",
+            "metal": "metal",
+            "water": "liquid",
+            "lava": "liquid",
+        }
+
+        for mat, template in material_template_map.items():
+            if mat in material:
+                return template
+
+        return "basic"
+
+    def _build_block_json(
+        self, template: Dict[str, Any], namespace: str, block_name: str, properties: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Build block JSON from template."""
+        block_json = {
+            "format_version": "1.17.0",
+            f"minecraft:{template.get('type', 'block')}": {
+                "description": {
+                    "identifier": f"{namespace}:{block_name}",
+                },
+                "components": {},
+            },
+        }
+
+        for key, value in properties.items():
+            mapped_key = JAVA_TO_BEDROCK_BLOCK_PROPERTIES.get(key, key)
+            block_json[f"minecraft:{template.get('type', 'block')}"]["components"][mapped_key] = (
+                value
+            )
+
+        return block_json
+
+    def _validate_block_json(self, block_json: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate block JSON structure."""
+        errors = []
+        warnings = []
+
+        if "format_version" not in block_json:
+            errors.append("Missing format_version")
+
+        has_block_component = any(k.startswith("minecraft:") for k in block_json.keys())
+        if not has_block_component:
+            errors.append("Missing block component")
+
+        return {
+            "is_valid": len(errors) == 0,
+            "errors": errors,
+            "warnings": warnings,
+        }

--- a/ai-engine/agents/logic_translator/code_translator.py
+++ b/ai-engine/agents/logic_translator/code_translator.py
@@ -1,0 +1,230 @@
+"""Java to JavaScript code translation.
+
+Split out from ``translator.py`` per Issue #1746. Provides translation of Java
+methods, classes, API calls, event handlers, and JavaScript syntax validation.
+
+The :class:`CodeTranslatorMixin` is composed into :class:`LogicTranslatorAgent`
+and assumes the host class provides:
+
+- ``self.logger``
+- ``self.type_mappings`` (dict[str, str])
+- ``self._rag_context_enabled`` (bool)
+- ``self._get_rag_context(...)`` (from :class:`RAGContextMixin`)
+"""
+
+import json
+
+from utils.logging_config import get_agent_logger
+
+logger = get_agent_logger("logic_translator")
+
+
+class CodeTranslatorMixin:
+    """Java method/class/API/event translation methods for the LogicTranslatorAgent."""
+
+    def _get_javascript_type(self, java_type):
+        """Convert Java type to JavaScript type.
+
+        Handles both javalang and tree-sitter formats.
+        """
+        if java_type is None:
+            return "any"
+
+        # Handle tree-sitter dict format
+        if isinstance(java_type, dict):
+            type_name = java_type.get("type", str(java_type))
+            if type_name == "type_identifier":
+                type_name = java_type.get("text", str(java_type))
+            if java_type.get("type") == "array_type":
+                element_type_node = (
+                    java_type.get("children", [{}])[0] if java_type.get("children") else {}
+                )
+                element_type = element_type_node.get("text", str(element_type_node))
+                if element_type in self.type_mappings:
+                    return f"{self.type_mappings[element_type]}[]"
+                return f"{element_type}[]"
+        # Handle javalang AST types (object with .name attribute)
+        elif hasattr(java_type, "name"):
+            type_name = java_type.name
+            if hasattr(java_type, "dimensions") and java_type.dimensions:
+                type_name += "[]"
+        elif hasattr(java_type, "type") and hasattr(java_type.type, "name"):
+            type_name = java_type.type.name
+            if hasattr(java_type, "dimensions") and java_type.dimensions:
+                type_name += "[]"
+        else:
+            type_name = str(java_type)
+
+        # Handle arrays
+        if "[]" in type_name:
+            base_type = type_name.replace("[]", "")
+            js_base_type = self.type_mappings.get(base_type, base_type)
+            return f"{js_base_type}[]"
+
+        return self.type_mappings.get(type_name, type_name)
+
+    def translate_java_method(self, method_data, feature_context=None) -> str:
+        """Translate Java method to JavaScript with optional RAG context augmentation."""
+        try:
+            rag_context = ""
+            feature_type = "unknown"
+
+            if isinstance(method_data, str):
+                data = json.loads(method_data)
+                method_name = data.get("method_name", "unknown")
+                method_body = data.get("method_body", "")
+                feature_type = data.get("feature_type", "unknown")
+
+                if self._rag_context_enabled and feature_type != "unknown":
+                    rag_context = self._get_rag_context(
+                        f"{method_name} {method_body}", feature_type
+                    )
+
+                translated_js = f"// Translated {method_name}\nfunction {method_name}() {{\n  // {method_body}\n}}"
+
+                result = {
+                    "success": True,
+                    "original_method": method_name,
+                    "translated_javascript": translated_js,
+                    "warnings": [],
+                }
+
+                if rag_context:
+                    result["rag_context_applied"] = True
+                    result["conversion_context"] = rag_context
+
+                return json.dumps(result)
+            else:
+                method_name = getattr(method_data, "name", "unknown")
+
+                params = []
+                if hasattr(method_data, "parameters") and method_data.parameters:
+                    for param in method_data.parameters:
+                        param_name = param.name
+                        param_type = self._get_javascript_type(param.type)
+                        params.append(f"{param_name}: {param_type}")
+
+                return_type = "void"
+                if hasattr(method_data, "return_type") and method_data.return_type:
+                    return_type = self._get_javascript_type(method_data.return_type)
+
+                param_str = ", ".join(params)
+                if return_type != "void":
+                    translated_js = (
+                        f"// Translated {method_name}\n"
+                        f"function {method_name}({param_str}): {return_type} {{\n"
+                        f"  // Method body\n}}"
+                    )
+                else:
+                    translated_js = (
+                        f"// Translated {method_name}\n"
+                        f"function {method_name}({param_str}) {{\n"
+                        f"  // Method body\n}}"
+                    )
+
+                result = {
+                    "success": True,
+                    "original_method": method_name,
+                    "javascript_method": translated_js,
+                    "warnings": [],
+                }
+
+                if rag_context:
+                    result["rag_context_applied"] = True
+                    result["conversion_context"] = rag_context
+
+                return json.dumps(result)
+        except Exception as e:
+            logger.error(f"Error translating method: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})
+
+    def convert_java_class(self, class_data: str) -> str:
+        """Convert Java class to JavaScript with optional RAG context."""
+        try:
+            data = json.loads(class_data)
+            class_name = data.get("class_name", "UnknownClass")
+            data.get("methods", [])
+            feature_type = data.get("feature_type", "unknown")
+
+            rag_context = ""
+            if self._rag_context_enabled and feature_type != "unknown":
+                rag_context = self._get_rag_context(class_name, feature_type)
+
+            js_class = f"// Converted class {class_name}\nclass {class_name} {{}}"
+
+            result = {
+                "success": True,
+                "original_class": class_name,
+                "javascript_class": js_class,
+                "warnings": [],
+            }
+
+            if rag_context:
+                result["rag_context_applied"] = True
+                result["conversion_context"] = rag_context
+
+            return json.dumps(result)
+        except Exception as e:
+            logger.error(f"Error converting class: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})
+
+    def map_java_apis(self, api_data: str) -> str:
+        """Map Java APIs to JavaScript."""
+        try:
+            data = json.loads(api_data)
+            apis = data.get("apis", [])
+
+            mapped_apis = {}
+            for api in apis:
+                mapped_apis[api] = self._get_javascript_type(api.split(".")[-1])
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "mapped_apis": mapped_apis,
+                    "warnings": [],
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error mapping APIs: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})
+
+    def generate_event_handlers(self, event_data: str) -> str:
+        """Generate event handlers for JavaScript."""
+        try:
+            data = json.loads(event_data)
+            event_type = data.get("event_type", "unknown")
+            handlers = data.get("handlers", [])
+
+            js_handlers = [f"// Event handler for {event_type}"] * len(handlers)
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "event_handlers": js_handlers,
+                    "warnings": [],
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error generating event handlers: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})
+
+    def validate_javascript_syntax(self, js_data: str) -> str:
+        """Validate JavaScript syntax."""
+        try:
+            data = json.loads(js_data)
+            javascript_code = data.get("javascript_code", "")
+
+            is_valid = "()" in javascript_code and "{" in javascript_code
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "is_valid": is_valid,
+                    "syntax_errors": [] if is_valid else ["Syntax error detected"],
+                    "warnings": [],
+                }
+            )
+        except Exception as e:
+            logger.error(f"Error validating JavaScript: {e}")
+            return json.dumps({"success": False, "error": str(e), "warnings": []})

--- a/ai-engine/agents/logic_translator/rag_context.py
+++ b/ai-engine/agents/logic_translator/rag_context.py
@@ -1,0 +1,55 @@
+"""RAG context augmentation for logic translation.
+
+Split out from ``translator.py`` per Issue #1746. Provides retrieval-augmented
+generation context for Java-to-Bedrock translation.
+
+The :class:`RAGContextMixin` is composed into :class:`LogicTranslatorAgent` and
+assumes the host class initializes ``self._conversion_rag_pipeline`` and
+``self._rag_context_enabled``.
+"""
+
+from utils.logging_config import get_agent_logger
+
+logger = get_agent_logger("logic_translator")
+
+
+class RAGContextMixin:
+    """RAG pipeline integration for the LogicTranslatorAgent."""
+
+    def set_rag_pipeline(self, pipeline) -> None:
+        """Set the ConversionRAGPipeline for context-augmented translation.
+
+        Args:
+            pipeline: ConversionRAGPipeline instance.
+        """
+        self._conversion_rag_pipeline = pipeline
+        self._rag_context_enabled = pipeline is not None
+        logger.info(f"RAG context {'enabled' if self._rag_context_enabled else 'disabled'}")
+
+    def enable_rag_context(self, enabled: bool = True) -> None:
+        """Enable or disable RAG context retrieval."""
+        self._rag_context_enabled = enabled and self._conversion_rag_pipeline is not None
+
+    def _get_rag_context(self, java_feature: str, feature_type: str) -> str:
+        """Get RAG context for a Java feature.
+
+        Args:
+            java_feature: Description of the Java feature.
+            feature_type: Type of feature (block, item, entity, etc.).
+
+        Returns:
+            Formatted context string for LLM, or empty string if unavailable.
+        """
+        if not self._rag_context_enabled or not self._conversion_rag_pipeline:
+            return ""
+
+        try:
+            result = self._conversion_rag_pipeline.retrieve_conversion_context_sync(
+                java_feature=java_feature,
+                feature_type=feature_type,
+                top_k=5,
+            )
+            return self._conversion_rag_pipeline.format_context_for_llm(result)
+        except Exception as e:
+            logger.warning(f"RAG context retrieval failed: {e}")
+            return ""

--- a/ai-engine/agents/logic_translator/translator.py
+++ b/ai-engine/agents/logic_translator/translator.py
@@ -1,27 +1,29 @@
+"""Logic Translator Agent — core orchestrator for Java to Bedrock translation.
+
+This module is the composition root for :class:`LogicTranslatorAgent`. The
+translation logic has been split into focused domain mixins per Issue #1746:
+
+- :mod:`agents.logic_translator.rag_context` — RAG context augmentation
+- :mod:`agents.logic_translator.ast_analyzer` — tree-sitter Java AST analysis
+- :mod:`agents.logic_translator.code_translator` — Java→JS code translation
+- :mod:`agents.logic_translator.block_translator` — Bedrock block JSON generation
+
+This file keeps the class definition, singleton logic, tool wiring, and the
+shared type/enum/API mappings, and re-exports the public symbols so existing
+imports (``from agents.logic_translator.translator import LogicTranslatorAgent``)
+continue to work unchanged.
 """
-Logic Translator Agent for Java to JavaScript code conversion
-Enhanced for Issue #546: Block Generation from Java block analysis
-"""
 
-import json
-from typing import Any, Dict, List
+from typing import List
 
-try:
-    import tree_sitter_java as ts_java
-    from tree_sitter import Language, Parser
-
-    TREE_SITTER_AVAILABLE = True
-except ImportError:
-    TREE_SITTER_AVAILABLE = False
-    ts_java = None
-    Parser = None
 from agents.java_analyzer import JavaAnalyzerAgent
-from agents.logic_translator.block_state_mapper import (
-    JAVA_TO_BEDROCK_BLOCK_PROPERTIES,
+from agents.logic_translator.ast_analyzer import (
+    TREE_SITTER_AVAILABLE,
+    ASTAnalyzerMixin,
 )
-from agents.logic_translator.block_templates import (
-    BEDROCK_BLOCK_TEMPLATES,
-)
+from agents.logic_translator.block_translator import BlockTranslatorMixin
+from agents.logic_translator.code_translator import CodeTranslatorMixin
+from agents.logic_translator.rag_context import RAGContextMixin
 from models.smart_assumptions import (
     SmartAssumptionEngine,
 )
@@ -34,14 +36,22 @@ logger = get_agent_logger("logic_translator")
 LLM_CODE_TEMPERATURE = 0.2
 
 
-# Templates loaded from block_templates module# Smart assumptions loaded from assumptions module
-
-
-# Block property mappings loaded from block_state_mapper module
-class LogicTranslatorAgent:
+class LogicTranslatorAgent(
+    RAGContextMixin,
+    ASTAnalyzerMixin,
+    CodeTranslatorMixin,
+    BlockTranslatorMixin,
+):
     """
     Logic Translator Agent responsible for converting Java logic to Bedrock-compatible
     JavaScript as specified in PRD Feature 2.
+
+    Domain behaviour is provided by the composed mixins:
+
+    - :class:`RAGContextMixin` — retrieval-augmented context
+    - :class:`ASTAnalyzerMixin` — Java AST analysis via tree-sitter
+    - :class:`CodeTranslatorMixin` — method/class/API/event translation
+    - :class:`BlockTranslatorMixin` — Bedrock block/recipe JSON generation
     """
 
     _instance = None
@@ -290,44 +300,6 @@ class LogicTranslatorAgent:
         # Tools initialization
         self.tools = self.get_tools()
 
-    def _get_javascript_type(self, java_type):
-        """Convert Java type to JavaScript type. Handles both javalang and tree-sitter formats."""
-        if java_type is None:
-            return "any"
-
-        # Handle tree-sitter dict format
-        if isinstance(java_type, dict):
-            type_name = java_type.get("type", str(java_type))
-            if type_name == "type_identifier":
-                type_name = java_type.get("text", str(java_type))
-            if java_type.get("type") == "array_type":
-                element_type_node = (
-                    java_type.get("children", [{}])[0] if java_type.get("children") else {}
-                )
-                element_type = element_type_node.get("text", str(element_type_node))
-                if element_type in self.type_mappings:
-                    return f"{self.type_mappings[element_type]}[]"
-                return f"{element_type}[]"
-        # Handle javalang AST types (object with .name attribute)
-        elif hasattr(java_type, "name"):
-            type_name = java_type.name
-            if hasattr(java_type, "dimensions") and java_type.dimensions:
-                type_name += "[]"
-        elif hasattr(java_type, "type") and hasattr(java_type.type, "name"):
-            type_name = java_type.type.name
-            if hasattr(java_type, "dimensions") and java_type.dimensions:
-                type_name += "[]"
-        else:
-            type_name = str(java_type)
-
-        # Handle arrays
-        if "[]" in type_name:
-            base_type = type_name.replace("[]", "")
-            js_base_type = self.type_mappings.get(base_type, base_type)
-            return f"{js_base_type}[]"
-
-        return self.type_mappings.get(type_name, type_name)
-
     @classmethod
     def get_instance(cls):
         """Get singleton instance of LogicTranslatorAgent"""
@@ -416,568 +388,13 @@ class LogicTranslatorAgent:
 
         return LogicTranslatorTools.map_block_properties_tool
 
-    def set_rag_pipeline(self, pipeline) -> None:
-        """
-        Set the ConversionRAGPipeline for context-augmented translation.
 
-        Args:
-            pipeline: ConversionRAGPipeline instance
-        """
-        self._conversion_rag_pipeline = pipeline
-        self._rag_context_enabled = pipeline is not None
-        logger.info(f"RAG context {'enabled' if self._rag_context_enabled else 'disabled'}")
-
-    def enable_rag_context(self, enabled: bool = True) -> None:
-        """Enable or disable RAG context retrieval."""
-        self._rag_context_enabled = enabled and self._conversion_rag_pipeline is not None
-
-    def _get_rag_context(self, java_feature: str, feature_type: str) -> str:
-        """
-        Get RAG context for a Java feature.
-
-        Args:
-            java_feature: Description of the Java feature
-            feature_type: Type of feature (block, item, entity, etc.)
-
-        Returns:
-            Formatted context string for LLM, or empty string if unavailable
-        """
-        if not self._rag_context_enabled or not self._conversion_rag_pipeline:
-            return ""
-
-        try:
-            result = self._conversion_rag_pipeline.retrieve_conversion_context_sync(
-                java_feature=java_feature,
-                feature_type=feature_type,
-                top_k=5,
-            )
-            return self._conversion_rag_pipeline.format_context_for_llm(result)
-        except Exception as e:
-            logger.warning(f"RAG context retrieval failed: {e}")
-            return ""
-
-    def _get_tree_sitter_parser(self):
-        """Get or create tree-sitter parser instance."""
-        if not TREE_SITTER_AVAILABLE:
-            return None
-        if not hasattr(self, "_ts_parser") or self._ts_parser is None:
-            try:
-                lang = Language(ts_java.language())
-                self._ts_parser = Parser(lang)
-            except Exception as e:
-                logger.warning(f"Failed to initialize tree-sitter parser: {e}")
-                self._ts_parser = None
-        return self._ts_parser
-
-    def _tree_sitter_to_dict(self, node, error_count: int = 0) -> Dict[str, Any]:
-        """Convert tree-sitter node to dictionary."""
-        result = {
-            "type": node.type,
-            "start_point": node.start_point,
-            "end_point": node.end_point,
-            "start_byte": node.start_byte,
-            "end_byte": node.end_byte,
-            "has_errors": error_count > 0 or node.type == "ERROR",
-        }
-
-        if node.child_count == 0:
-            result["text"] = node.text.decode("utf8") if node.text else ""
-
-        if node.child_count > 0:
-            result["children"] = [
-                self._tree_sitter_to_dict(child, error_count) for child in node.children
-            ]
-
-        return result
-
-    def analyze_java_code_ast(self, java_code: str):
-        """Analyze Java code and return AST using tree-sitter."""
-        if not TREE_SITTER_AVAILABLE:
-            logger.warning(
-                "Tree-sitter not available, javalang fallback not supported in migrated code"
-            )
-            return {
-                "success": False,
-                "error": "tree-sitter not available",
-                "ast_tree": None,
-            }
-
-        parser = self._get_tree_sitter_parser()
-        if parser is None:
-            return {
-                "success": False,
-                "error": "tree-sitter parser not available",
-                "ast_tree": None,
-            }
-
-        try:
-            tree = parser.parse(bytes(java_code, "utf8"))
-            ast_dict = self._tree_sitter_to_dict(tree.root_node)
-            return {
-                "success": True,
-                "ast_tree": ast_dict,
-                "root_type": tree.root_node.type,
-            }
-        except Exception as e:
-            logger.error(f"Error analyzing Java code AST: {e}")
-            return {
-                "success": False,
-                "error": str(e),
-                "ast_tree": None,
-            }
-
-    def _serialize_ast_for_llm(self, ast_dict: Dict[str, Any], max_depth: int = 10) -> str:
-        """Serialize AST dictionary for LLM consumption."""
-        if ast_dict is None:
-            return "No AST available"
-
-        lines = []
-        indent = "  "
-
-        def serialize_node(node: Dict[str, Any], depth: int = 0):
-            if depth >= max_depth:
-                lines.append(f"{indent * depth}...")
-                return
-
-            node_type = node.get("type", "unknown")
-            has_errors = node.get("has_errors", False)
-
-            prefix = "[ERROR] " if has_errors else ""
-            lines.append(f"{indent * depth}{prefix}{node_type}")
-
-            if "text" in node:
-                text = node["text"]
-                if text.strip():
-                    lines.append(f"{indent * (depth + 1)}text: {repr(text)}")
-
-            if "children" in node:
-                for child in node["children"]:
-                    serialize_node(child, depth + 1)
-
-        serialize_node(ast_dict, 0)
-        return "\n".join(lines)
-
-    def generate_nl_summary_from_ast(self, java_code: str) -> str:
-        """Generate natural language summary from Java AST using tree-sitter."""
-        try:
-            result = self.analyze_java_code_ast(java_code)
-
-            if not result.get("success"):
-                return f"Could not analyze code: {result.get('error', 'Unknown error')}"
-
-            ast_dict = result.get("ast_tree")
-            if not ast_dict:
-                return "No AST found in analysis result"
-
-            self._serialize_ast_for_llm(ast_dict)
-
-            class_decl = None
-            method_sigs = []
-
-            def find_decls(node: Dict[str, Any]):
-                nonlocal class_decl
-                if node.get("type") == "class_declaration":
-                    nonlocal class_decl
-                    class_decl = node
-                elif node.get("type") == "method_declaration":
-                    method_sigs.append(node)
-
-            def walk(node: Dict[str, Any]):
-                find_decls(node)
-                for child in node.get("children", []):
-                    walk(child)
-
-            walk(ast_dict)
-
-            summary_parts = []
-            if class_decl:
-                class_name = "UnknownClass"
-                for child in class_decl.get("children", []):
-                    if child.get("type") == "identifier":
-                        class_name = child.get("text", "UnknownClass")
-                        break
-                summary_parts.append(f"Class: {class_name}")
-
-            if method_sigs:
-                summary_parts.append(f"Contains {len(method_sigs)} method(s)")
-
-            return "; ".join(summary_parts) if summary_parts else "Empty class"
-
-        except Exception as e:
-            logger.error(f"Error generating NL summary from AST: {e}")
-            return f"Error: {str(e)}"
-
-    def translate_java_method(self, method_data, feature_context=None) -> str:
-        """Translate Java method to JavaScript with optional RAG context augmentation."""
-        try:
-            rag_context = ""
-            feature_type = "unknown"
-
-            if isinstance(method_data, str):
-                data = json.loads(method_data)
-                method_name = data.get("method_name", "unknown")
-                method_body = data.get("method_body", "")
-                feature_type = data.get("feature_type", "unknown")
-
-                if self._rag_context_enabled and feature_type != "unknown":
-                    rag_context = self._get_rag_context(
-                        f"{method_name} {method_body}", feature_type
-                    )
-
-                translated_js = f"// Translated {method_name}\nfunction {method_name}() {{\n  // {method_body}\n}}"
-
-                result = {
-                    "success": True,
-                    "original_method": method_name,
-                    "translated_javascript": translated_js,
-                    "warnings": [],
-                }
-
-                if rag_context:
-                    result["rag_context_applied"] = True
-                    result["conversion_context"] = rag_context
-
-                return json.dumps(result)
-            else:
-                method_name = getattr(method_data, "name", "unknown")
-
-                params = []
-                if hasattr(method_data, "parameters") and method_data.parameters:
-                    for param in method_data.parameters:
-                        param_name = param.name
-                        param_type = self._get_javascript_type(param.type)
-                        params.append(f"{param_name}: {param_type}")
-
-                return_type = "void"
-                if hasattr(method_data, "return_type") and method_data.return_type:
-                    return_type = self._get_javascript_type(method_data.return_type)
-
-                param_str = ", ".join(params)
-                if return_type != "void":
-                    translated_js = f"// Translated {method_name}\nfunction {method_name}({param_str}): {return_type} {{\n  // Method body\n}}"
-                else:
-                    translated_js = f"// Translated {method_name}\nfunction {method_name}({param_str}) {{\n  // Method body\n}}"
-
-                result = {
-                    "success": True,
-                    "original_method": method_name,
-                    "javascript_method": translated_js,
-                    "warnings": [],
-                }
-
-                if rag_context:
-                    result["rag_context_applied"] = True
-                    result["conversion_context"] = rag_context
-
-                return json.dumps(result)
-        except Exception as e:
-            logger.error(f"Error translating method: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def convert_java_class(self, class_data: str) -> str:
-        """Convert Java class to JavaScript with optional RAG context."""
-        try:
-            data = json.loads(class_data)
-            class_name = data.get("class_name", "UnknownClass")
-            data.get("methods", [])
-            feature_type = data.get("feature_type", "unknown")
-
-            rag_context = ""
-            if self._rag_context_enabled and feature_type != "unknown":
-                rag_context = self._get_rag_context(class_name, feature_type)
-
-            js_class = f"// Converted class {class_name}\nclass {class_name} {{}}"
-
-            result = {
-                "success": True,
-                "original_class": class_name,
-                "javascript_class": js_class,
-                "warnings": [],
-            }
-
-            if rag_context:
-                result["rag_context_applied"] = True
-                result["conversion_context"] = rag_context
-
-            return json.dumps(result)
-        except Exception as e:
-            logger.error(f"Error converting class: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def map_java_apis(self, api_data: str) -> str:
-        """Map Java APIs to JavaScript."""
-        try:
-            data = json.loads(api_data)
-            apis = data.get("apis", [])
-
-            mapped_apis = {}
-            for api in apis:
-                mapped_apis[api] = self._get_javascript_type(api.split(".")[-1])
-
-            return json.dumps(
-                {
-                    "success": True,
-                    "mapped_apis": mapped_apis,
-                    "warnings": [],
-                }
-            )
-        except Exception as e:
-            logger.error(f"Error mapping APIs: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def generate_event_handlers(self, event_data: str) -> str:
-        """Generate event handlers for JavaScript."""
-        try:
-            data = json.loads(event_data)
-            event_type = data.get("event_type", "unknown")
-            handlers = data.get("handlers", [])
-
-            js_handlers = [f"// Event handler for {event_type}"] * len(handlers)
-
-            return json.dumps(
-                {
-                    "success": True,
-                    "event_handlers": js_handlers,
-                    "warnings": [],
-                }
-            )
-        except Exception as e:
-            logger.error(f"Error generating event handlers: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def validate_javascript_syntax(self, js_data: str) -> str:
-        """Validate JavaScript syntax."""
-        try:
-            data = json.loads(js_data)
-            javascript_code = data.get("javascript_code", "")
-
-            is_valid = "()" in javascript_code and "{" in javascript_code
-
-            return json.dumps(
-                {
-                    "success": True,
-                    "is_valid": is_valid,
-                    "syntax_errors": [] if is_valid else ["Syntax error detected"],
-                    "warnings": [],
-                }
-            )
-        except Exception as e:
-            logger.error(f"Error validating JavaScript: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def translate_crafting_recipe_json(self, recipe_json_data: str) -> str:
-        """Translate crafting recipe JSON to Bedrock format."""
-        try:
-            data = json.loads(recipe_json_data)
-            recipe_type = data.get("type", "unknown")
-
-            if recipe_type == "minecraft:crafting_shaped":
-                pattern = data.get("pattern", ["ABC", "DEF", "GHI"])
-                key = data.get("key", {"A": {"item": "minecraft:stick"}})
-                result = data.get("result", {"item": "minecraft:wooden_sword"})
-
-                bedrock_key = {}
-                for k, v in key.items():
-                    bedrock_key[k] = {"item": v["item"].replace("minecraft:", "")}
-
-                bedrock_result = {"item": result["item"].replace("minecraft:", "")}
-                if "count" in result:
-                    bedrock_result["count"] = result["count"]
-
-                bedrock_recipe = {
-                    "format_version": "1.17.0",
-                    "minecraft:recipe_shaped": {
-                        "description": {"identifier": "custom:shaped_recipe"},
-                        "pattern": pattern,
-                        "key": bedrock_key,
-                        "result": bedrock_result,
-                    },
-                }
-            elif recipe_type == "minecraft:crafting_shapeless":
-                ingredients = data.get("ingredients", [{"item": "minecraft:stick"}])
-                result = data.get("result", {"item": "minecraft:wooden_sword"})
-
-                bedrock_ingredients = []
-                for ingredient in ingredients:
-                    bedrock_ingredients.append(
-                        {"item": ingredient["item"].replace("minecraft:", "")}
-                    )
-
-                bedrock_result = {"item": result["item"].replace("minecraft:", "")}
-                if "count" in result:
-                    bedrock_result["count"] = result["count"]
-
-                bedrock_recipe = {
-                    "format_version": "1.17.0",
-                    "minecraft:recipe_shapeless": {
-                        "description": {"identifier": "custom:shapeless_recipe"},
-                        "ingredients": bedrock_ingredients,
-                        "result": bedrock_result,
-                    },
-                }
-            else:
-                raise ValueError(f"Unsupported recipe type: {recipe_type}")
-
-            return json.dumps({"success": True, "bedrock_recipe": bedrock_recipe, "warnings": []})
-        except Exception as e:
-            logger.error(f"Error translating recipe: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def generate_bedrock_block_json(
-        self,
-        java_block_analysis: Dict[str, Any],
-        namespace: str = "modporter",
-        use_rag: bool = True,
-    ) -> Dict[str, Any]:
-        """Generate Bedrock block JSON from Java block analysis."""
-        try:
-            logger.info(
-                f"Generating Bedrock block JSON for: {java_block_analysis.get('name', 'unknown')}"
-            )
-
-            block_name = java_block_analysis.get("registry_name", "unknown_block")
-            if ":" in block_name:
-                namespace, block_name = block_name.split(":", 1)
-
-            properties = java_block_analysis.get("properties", {})
-
-            template_type = self._determine_block_template(properties)
-            template = BEDROCK_BLOCK_TEMPLATES.get(template_type, BEDROCK_BLOCK_TEMPLATES["basic"])
-
-            block_json = self._build_block_json(
-                template=template, namespace=namespace, block_name=block_name, properties=properties
-            )
-
-            validation_result = self._validate_block_json(block_json)
-
-            translation_log = {
-                "original_java_block": java_block_analysis.get("name", "unknown"),
-                "template_used": template_type,
-                "properties_mapped": list(properties.keys()),
-                "validation_passed": validation_result["is_valid"],
-            }
-            logger.info(f"Block generation complete: {translation_log}")
-
-            return {
-                "success": True,
-                "block_json": block_json,
-                "block_name": f"{namespace}:{block_name}",
-                "validation": validation_result,
-                "translation_log": translation_log,
-                "warnings": validation_result.get("warnings", []),
-            }
-
-        except Exception as e:
-            logger.error(f"Error generating Bedrock block JSON: {e}")
-            return {
-                "success": False,
-                "error": str(e),
-                "block_json": None,
-                "warnings": [f"Block generation failed: {str(e)}"],
-            }
-
-    def validate_block_json(self, block_json_data: str) -> str:
-        """Validate a Bedrock block JSON against schema requirements."""
-        try:
-            data = json.loads(block_json_data)
-            block_json = data.get("block_json", {})
-
-            is_valid = "format_version" in block_json and "minecraft:block" in block_json
-
-            return json.dumps(
-                {
-                    "success": True,
-                    "is_valid": is_valid,
-                    "errors": [] if is_valid else ["Missing required fields"],
-                    "warnings": [],
-                }
-            )
-        except Exception as e:
-            logger.error(f"Error validating block JSON: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def map_block_properties(self, properties_data: str) -> str:
-        """Map Java block properties to Bedrock equivalents."""
-        try:
-            data = json.loads(properties_data)
-            java_properties = data.get("properties", {})
-
-            bedrock_properties = {}
-            for key, value in java_properties.items():
-                mapped_key = JAVA_TO_BEDROCK_BLOCK_PROPERTIES.get(key, key)
-                bedrock_properties[mapped_key] = value
-
-            return json.dumps(
-                {
-                    "success": True,
-                    "bedrock_properties": bedrock_properties,
-                    "warnings": [],
-                }
-            )
-        except Exception as e:
-            logger.error(f"Error mapping block properties: {e}")
-            return json.dumps({"success": False, "error": str(e), "warnings": []})
-
-    def _determine_block_template(self, properties: Dict[str, Any]) -> str:
-        """Determine the best block template based on properties."""
-        material = properties.get("material", "stone").lower()
-
-        if properties.get("light_level", 0) > 0:
-            return "light_emitting"
-
-        material_template_map = {
-            "wood": "wooden",
-            "stone": "stone",
-            "dirt": "dirt",
-            "sand": "sand",
-            "glass": "glass",
-            "metal": "metal",
-            "water": "liquid",
-            "lava": "liquid",
-        }
-
-        for mat, template in material_template_map.items():
-            if mat in material:
-                return template
-
-        return "basic"
-
-    def _build_block_json(
-        self, template: Dict[str, Any], namespace: str, block_name: str, properties: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Build block JSON from template."""
-        block_json = {
-            "format_version": "1.17.0",
-            f"minecraft:{template.get('type', 'block')}": {
-                "description": {
-                    "identifier": f"{namespace}:{block_name}",
-                },
-                "components": {},
-            },
-        }
-
-        for key, value in properties.items():
-            mapped_key = JAVA_TO_BEDROCK_BLOCK_PROPERTIES.get(key, key)
-            block_json[f"minecraft:{template.get('type', 'block')}"]["components"][mapped_key] = (
-                value
-            )
-
-        return block_json
-
-    def _validate_block_json(self, block_json: Dict[str, Any]) -> Dict[str, Any]:
-        """Validate block JSON structure."""
-        errors = []
-        warnings = []
-
-        if "format_version" not in block_json:
-            errors.append("Missing format_version")
-
-        has_block_component = any(k.startswith("minecraft:") for k in block_json.keys())
-        if not has_block_component:
-            errors.append("Missing block component")
-
-        return {
-            "is_valid": len(errors) == 0,
-            "errors": errors,
-            "warnings": warnings,
-        }
+__all__ = [
+    "LogicTranslatorAgent",
+    "LLM_CODE_TEMPERATURE",
+    "TREE_SITTER_AVAILABLE",
+    "ASTAnalyzerMixin",
+    "CodeTranslatorMixin",
+    "BlockTranslatorMixin",
+    "RAGContextMixin",
+]


### PR DESCRIPTION
Split the 983-line translator.py into focused domain mixins per Issue #1746:

- rag_context.py (RAGContextMixin): RAG pipeline integration, 55 lines
- ast_analyzer.py (ASTAnalyzerMixin): tree-sitter Java AST analysis, 179 lines
- code_translator.py (CodeTranslatorMixin): Java->JS method/class/API/event translation, 230 lines
- block_translator.py (BlockTranslatorMixin): Bedrock block/recipe JSON generation, 243 lines
- translator.py: reduced to 400-line core orchestrator that composes the mixins,
  holds shared type/enum/API mappings, singleton logic, and tool wiring

LogicTranslatorAgent now inherits all four mixins, preserving its full public
API (every method remains a bound instance method). translator.py re-exports
LogicTranslatorAgent, LLM_CODE_TEMPERATURE, TREE_SITTER_AVAILABLE, and the
mixins, so all existing imports (from agents.logic_translator.translator and
from agents.logic_translator) continue to work unchanged.

Follow-on to #1739 (tools.py split); tools.py is intentionally left untouched
as a separate wave.

Verified: 200 passed, 37 skipped on -k 'translator or logic' (identical to
baseline). No new ruff issues.
