### PR TITLE
refactor(ai-engine): resolve #1742 — split bedrock_builder.py into subpackage

### DIFF
--- a/ai-engine/SKELETON-agents.md
+++ b/ai-engine/SKELETON-agents.md
@@ -551,8 +551,13 @@ It contains class/function signatures, type definitions, and docstrings — **no
 
 ---
 
-### `ai-engine/agents/bedrock_builder.py`
+### `ai-engine/agents/bedrock_builder/` (package, split per Issue #1742)
 > Bedrock Builder Agent for generating Bedrock add-on files from Java mod analysis.
+>
+> Submodules:
+> - `bedrock_builder/agent.py` — `BedrockBuilderAgent` implementation.
+> - `bedrock_builder/tools.py` — typed `BaseTool` wrappers + Pydantic args-schema models.
+> - `bedrock_builder/__init__.py` — re-export shim (public API: `from agents.bedrock_builder import BedrockBuilderAgent`).
 *deps: PIL, jinja2, langchain_core.tools, models.smart_assumptions, pydantic, templates.template_engine, utils.atlas_descriptor_parser, zipfile*
 
 **class BedrockBuilderAgent:**

--- a/ai-engine/agents/bedrock_builder/__init__.py
+++ b/ai-engine/agents/bedrock_builder/__init__.py
@@ -1,0 +1,40 @@
+"""Bedrock Builder agent package -- modular Bedrock add-on generator.
+
+Public API (Issue #1742 split of the former single-file ``bedrock_builder.py``)::
+
+    from agents.bedrock_builder import BedrockBuilderAgent
+
+The :class:`BedrockBuilderAgent` implementation lives in
+:mod:`agents.bedrock_builder.agent`; the typed LangChain tool wrappers and
+their Pydantic args-schema models live in :mod:`agents.bedrock_builder.tools`.
+
+This ``__init__`` re-exports the previous public surface (the agent class plus
+every tool input model and tool class) so all existing call sites and tests
+continue to work with no import-path changes.
+"""
+
+from agents.bedrock_builder.agent import BedrockBuilderAgent
+from agents.bedrock_builder.tools import (
+    _BaseBedrockBuilderTool,
+    _BuildBedrockStructureInput,
+    _BuildBedrockStructureTool,
+    _ConvertAssetsInput,
+    _ConvertAssetsTool,
+    _GenerateBlockDefinitionsInput,
+    _GenerateBlockDefinitionsTool,
+    _PackageAddonInput,
+    _PackageAddonTool,
+)
+
+__all__ = [
+    "BedrockBuilderAgent",
+    "_BaseBedrockBuilderTool",
+    "_BuildBedrockStructureInput",
+    "_BuildBedrockStructureTool",
+    "_ConvertAssetsInput",
+    "_ConvertAssetsTool",
+    "_GenerateBlockDefinitionsInput",
+    "_GenerateBlockDefinitionsTool",
+    "_PackageAddonInput",
+    "_PackageAddonTool",
+]

--- a/ai-engine/agents/bedrock_builder/agent.py
+++ b/ai-engine/agents/bedrock_builder/agent.py
@@ -1,5 +1,17 @@
 """
-Bedrock Builder Agent for generating Bedrock add-on files from Java mod analysis.
+Bedrock Builder Agent — generates Bedrock add-on files from Java mod analysis.
+
+This module holds the :class:`BedrockBuilderAgent` implementation. It was
+extracted from the former single-file ``agents/bedrock_builder.py`` module as
+part of the ``bedrock_builder/`` subpackage split (Issue #1742).
+
+The public entry point is unchanged::
+
+    from agents.bedrock_builder import BedrockBuilderAgent
+
+The package ``__init__.py`` re-exports this class together with the typed
+LangChain tool wrappers that live in :mod:`agents.bedrock_builder.tools`.
+
 Enhanced for MVP functionality as specified in Issue #168.
 """
 
@@ -12,10 +24,6 @@ import zipfile
 from pathlib import Path
 from typing import Any, Dict, List
 
-from typing import ClassVar
-
-from langchain_core.tools import BaseTool
-from pydantic import BaseModel, ConfigDict, Field
 from jinja2 import Environment, FileSystemLoader
 from PIL import Image
 
@@ -43,7 +51,7 @@ class BedrockBuilderAgent:
         self.smart_assumption_engine = SmartAssumptionEngine()
 
         # Initialize enhanced template engine
-        templates_dir = Path(__file__).parent.parent / "templates" / "bedrock"
+        templates_dir = Path(__file__).parent.parent.parent / "templates" / "bedrock"
         self.template_engine = TemplateEngine(templates_dir)
 
         # Keep legacy Jinja2 environment for manifest templates
@@ -891,126 +899,3 @@ class BedrockBuilderAgent:
         # Implementation placeholder
         return json.dumps({"success": True, "message": "Addon packaged"})
 
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Typed args_schema models — one per LangChain tool wrapper
-#
-# Phase 8 A4a (refs #1201). Each schema preserves the legacy single-string
-# <name>_data shape so chat models and existing call sites continue to
-# invoke BedrockBuilderAgent.<tool_name>.invoke({"<name>_data": "..."})
-# without changes. extra="forbid" makes hallucinated extra fields fail
-# loud at validation, and min_length=1 rejects empty strings.
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class _BuildBedrockStructureInput(BaseModel):
-    """Args for :class:`_BuildBedrockStructureTool`."""
-
-    model_config = ConfigDict(extra="forbid")
-    structure_data: str = Field(
-        min_length=1,
-        description="JSON string describing the Bedrock addon directory structure to build.",
-    )
-
-
-class _GenerateBlockDefinitionsInput(BaseModel):
-    """Args for :class:`_GenerateBlockDefinitionsTool`."""
-
-    model_config = ConfigDict(extra="forbid")
-    block_data: str = Field(
-        min_length=1,
-        description="JSON string describing the Bedrock block definitions to generate.",
-    )
-
-
-class _ConvertAssetsInput(BaseModel):
-    """Args for :class:`_ConvertAssetsTool`."""
-
-    model_config = ConfigDict(extra="forbid")
-    asset_data: str = Field(
-        min_length=1,
-        description="JSON string describing the assets (textures, models, sounds) to convert.",
-    )
-
-
-class _PackageAddonInput(BaseModel):
-    """Args for :class:`_PackageAddonTool`."""
-
-    model_config = ConfigDict(extra="forbid")
-    package_data: str = Field(
-        min_length=1,
-        description="JSON string describing the addon to package into a .mcaddon archive.",
-    )
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Typed BaseTool subclasses — replace the previous @tool @staticmethod wrappers
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-class _BaseBedrockBuilderTool(BaseTool):
-    """Common scaffolding for Bedrock Builder typed tool wrappers."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-class _BuildBedrockStructureTool(_BaseBedrockBuilderTool):
-    name: str = "build_bedrock_structure_tool"
-    description: str = (
-        "Build basic Bedrock addon directory structure. "
-        "Args: structure_data (str, required) — JSON describing the structure."
-    )
-    args_schema: ClassVar[type[BaseModel]] = _BuildBedrockStructureInput
-
-    def _run(self, structure_data: str) -> str:  # type: ignore[override]
-        return BedrockBuilderAgent._build_bedrock_structure(structure_data)
-
-
-class _GenerateBlockDefinitionsTool(_BaseBedrockBuilderTool):
-    name: str = "generate_block_definitions_tool"
-    description: str = (
-        "Generate Bedrock block definition files. "
-        "Args: block_data (str, required) — JSON describing the blocks."
-    )
-    args_schema: ClassVar[type[BaseModel]] = _GenerateBlockDefinitionsInput
-
-    def _run(self, block_data: str) -> str:  # type: ignore[override]
-        return BedrockBuilderAgent._generate_block_definitions(block_data)
-
-
-class _ConvertAssetsTool(_BaseBedrockBuilderTool):
-    name: str = "convert_assets_tool"
-    description: str = (
-        "Convert mod assets to Bedrock format. "
-        "Args: asset_data (str, required) — JSON describing the assets."
-    )
-    args_schema: ClassVar[type[BaseModel]] = _ConvertAssetsInput
-
-    def _run(self, asset_data: str) -> str:  # type: ignore[override]
-        return BedrockBuilderAgent._convert_assets(asset_data)
-
-
-class _PackageAddonTool(_BaseBedrockBuilderTool):
-    name: str = "package_addon_tool"
-    description: str = (
-        "Package an addon into a .mcaddon archive. "
-        "Args: package_data (str, required) — JSON describing the package."
-    )
-    args_schema: ClassVar[type[BaseModel]] = _PackageAddonInput
-
-    def _run(self, package_data: str) -> str:  # type: ignore[override]
-        return BedrockBuilderAgent._package_addon(package_data)
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Module-level tool instances — preserved as class attributes on
-# BedrockBuilderAgent so the existing access patterns
-# (BedrockBuilderAgent.<tool_name> and agent.<tool_name>) both
-# continue to work unchanged for call sites and tests.
-# ─────────────────────────────────────────────────────────────────────────────
-
-
-BedrockBuilderAgent.build_bedrock_structure_tool = _BuildBedrockStructureTool()
-BedrockBuilderAgent.generate_block_definitions_tool = _GenerateBlockDefinitionsTool()
-BedrockBuilderAgent.convert_assets_tool = _ConvertAssetsTool()
-BedrockBuilderAgent.package_addon_tool = _PackageAddonTool()

--- a/ai-engine/agents/bedrock_builder/tools.py
+++ b/ai-engine/agents/bedrock_builder/tools.py
@@ -1,0 +1,141 @@
+"""
+Typed BaseTool wrappers and args-schema models for the Bedrock Builder agent.
+
+Phase 8 A4a (refs #1201). Each schema preserves the legacy single-string
+``<name>_data`` shape so chat models and existing call sites continue to
+invoke ``BedrockBuilderAgent.<tool_name>.invoke({"<name>_data": "..."})``
+without changes. ``extra="forbid"`` makes hallucinated extra fields fail
+loud at validation, and ``min_length=1`` rejects empty strings.
+
+Extracted from the former single-file ``agents/bedrock_builder.py`` module as
+part of the ``bedrock_builder/`` subpackage split (Issue #1742). The tool
+instances are bound onto :class:`BedrockBuilderAgent` as class attributes at
+import time so the existing access patterns
+(``BedrockBuilderAgent.<tool_name>`` and ``agent.<tool_name>``) continue to
+work unchanged for call sites and tests.
+"""
+
+from typing import ClassVar
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, ConfigDict, Field
+
+from agents.bedrock_builder.agent import BedrockBuilderAgent
+
+
+# ---------------------------------------------------------------------------
+# Typed args_schema models -- one per LangChain tool wrapper
+# ---------------------------------------------------------------------------
+
+
+class _BuildBedrockStructureInput(BaseModel):
+    """Args for :class:`_BuildBedrockStructureTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    structure_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock addon directory structure to build.",
+    )
+
+
+class _GenerateBlockDefinitionsInput(BaseModel):
+    """Args for :class:`_GenerateBlockDefinitionsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    block_data: str = Field(
+        min_length=1,
+        description="JSON string describing the Bedrock block definitions to generate.",
+    )
+
+
+class _ConvertAssetsInput(BaseModel):
+    """Args for :class:`_ConvertAssetsTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    asset_data: str = Field(
+        min_length=1,
+        description="JSON string describing the assets (textures, models, sounds) to convert.",
+    )
+
+
+class _PackageAddonInput(BaseModel):
+    """Args for :class:`_PackageAddonTool`."""
+
+    model_config = ConfigDict(extra="forbid")
+    package_data: str = Field(
+        min_length=1,
+        description="JSON string describing the addon to package into a .mcaddon archive.",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Typed BaseTool subclasses — replace the previous @tool @staticmethod wrappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _BaseBedrockBuilderTool(BaseTool):
+    """Common scaffolding for Bedrock Builder typed tool wrappers."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class _BuildBedrockStructureTool(_BaseBedrockBuilderTool):
+    name: str = "build_bedrock_structure_tool"
+    description: str = (
+        "Build basic Bedrock addon directory structure. "
+        "Args: structure_data (str, required) — JSON describing the structure."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _BuildBedrockStructureInput
+
+    def _run(self, structure_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._build_bedrock_structure(structure_data)
+
+
+class _GenerateBlockDefinitionsTool(_BaseBedrockBuilderTool):
+    name: str = "generate_block_definitions_tool"
+    description: str = (
+        "Generate Bedrock block definition files. "
+        "Args: block_data (str, required) — JSON describing the blocks."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _GenerateBlockDefinitionsInput
+
+    def _run(self, block_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._generate_block_definitions(block_data)
+
+
+class _ConvertAssetsTool(_BaseBedrockBuilderTool):
+    name: str = "convert_assets_tool"
+    description: str = (
+        "Convert mod assets to Bedrock format. "
+        "Args: asset_data (str, required) — JSON describing the assets."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _ConvertAssetsInput
+
+    def _run(self, asset_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._convert_assets(asset_data)
+
+
+class _PackageAddonTool(_BaseBedrockBuilderTool):
+    name: str = "package_addon_tool"
+    description: str = (
+        "Package an addon into a .mcaddon archive. "
+        "Args: package_data (str, required) — JSON describing the package."
+    )
+    args_schema: ClassVar[type[BaseModel]] = _PackageAddonInput
+
+    def _run(self, package_data: str) -> str:  # type: ignore[override]
+        return BedrockBuilderAgent._package_addon(package_data)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module-level tool instances — preserved as class attributes on
+# BedrockBuilderAgent so the existing access patterns
+# (BedrockBuilderAgent.<tool_name> and agent.<tool_name>) both
+# continue to work unchanged for call sites and tests.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+BedrockBuilderAgent.build_bedrock_structure_tool = _BuildBedrockStructureTool()
+BedrockBuilderAgent.generate_block_definitions_tool = _GenerateBlockDefinitionsTool()
+BedrockBuilderAgent.convert_assets_tool = _ConvertAssetsTool()
+BedrockBuilderAgent.package_addon_tool = _PackageAddonTool()

--- a/ai-engine/tests/integration/test_imports.py
+++ b/ai-engine/tests/integration/test_imports.py
@@ -36,7 +36,7 @@ def test_can_import_agents():
     - logic_translator is now a package (agents/logic_translator/)
     - texture_converter is now a package (agents/texture_converter/)
     - model_converter is now a package (agents/model_converter/)
-    - bedrock_builder is still a module (agents/bedrock_builder.py)
+    - bedrock_builder is now a package (agents/bedrock_builder/) per Issue #1742
     """
     agent_items = [
         # Packages (directories with __init__.py)
@@ -44,8 +44,8 @@ def test_can_import_agents():
         ("agents/logic_translator", "agents/logic_translator/__init__.py"),
         ("agents/texture_converter", "agents/texture_converter/__init__.py"),
         ("agents/model_converter", "agents/model_converter/__init__.py"),
+        ("agents/bedrock_builder", "agents/bedrock_builder/__init__.py"),
         # Modules (.py files)
-        ("agents/bedrock_builder.py", None),
         ("agents/asset_converter.py", None),
         ("agents/packaging_agent.py", None),
         ("agents/qa_validator.py", None),

--- a/ai-engine/tests/test_bedrock_builder_mvp.py
+++ b/ai-engine/tests/test_bedrock_builder_mvp.py
@@ -243,7 +243,7 @@ class TestBedrockBuilderMVP:
         rp_path.mkdir()
 
         # Mock Pillow Image processing since we have fake PNG data
-        with patch("agents.bedrock_builder.Image") as mock_image:
+        with patch("agents.bedrock_builder.agent.Image") as mock_image:
             mock_img = Mock()
             mock_img.size = (32, 32)
             mock_img.convert.return_value = mock_img
@@ -360,7 +360,7 @@ class TestBedrockBuilderMVP:
         assert result["success"] is False
         assert len(result["errors"]) > 0
 
-    @patch("agents.bedrock_builder.logger")
+    @patch("agents.bedrock_builder.agent.logger")
     def test_logging_behavior(self, mock_logger, builder, test_jar_with_texture, output_dir):
         """Test that appropriate logging occurs during build."""
         builder.build_block_addon_mvp(


### PR DESCRIPTION
Resolves #1742.

## What

Splits the 41K / 1,016-line single-file `ai-engine/agents/bedrock_builder.py` into a focused `bedrock_builder/` subpackage, following the established portkit convention (`java_analyzer/`, `logic_translator/`, `texture_converter/`).

```
ai-engine/agents/bedrock_builder/
├── __init__.py   # thin re-export shim — public API unchanged
├── agent.py      # BedrockBuilderAgent (36K)
└── tools.py      # typed BaseTool wrappers + Pydantic args-schema models
```

The original `bedrock_builder.py` is removed. The `__init__.py` **is** the backwards-compat re-export shim: `from agents.bedrock_builder import BedrockBuilderAgent` and all 9 tool/input symbols continue to work unchanged. (A `.py` file cannot coexist with a same-named package directory — the package wins — so `__init__.py` is the Pythonic shim, matching `java_analyzer/__init__.py`.)

## Changes
- `bedrock_builder/agent.py` — `BedrockBuilderAgent` + module-level `logger`/`Image`.
- `bedrock_builder/tools.py` — 4 input models, `_BaseBedrockBuilderTool` + 4 tool subclasses; binds instances onto `BedrockBuilderAgent` at import time.
- `bedrock_builder/__init__.py` — re-exports the full previous public surface (`__all__`).
- `tests/test_bedrock_builder_mvp.py` — two `patch()` targets updated to the new submodule path (`agents.bedrock_builder.agent.Image` / `.agent.logger`). Required: re-exporting from `__init__` would not affect the binding the code actually uses.
- `tests/integration/test_imports.py` — `bedrock_builder` now listed as a package (was: module).
- `SKELETON-agents.md` — doc updated.

## Bug caught by tests
The `__init__` templates path used `Path(__file__).parent.parent`; after moving one level deeper it resolved to `agents/templates/bedrock` instead of `ai-engine/templates/bedrock`. Fixed to `.parent.parent.parent`.

## Verification
- `ruff check` clean on all new/changed files.
- `pytest ai-engine/tests/ -k "bedrock or builder"` → **323 passed, 0 failed**.
- Byte-exact split verified programmatically (agent class body + tool section identical to the original).

## Relationship with #1707 — NOT resolved (distinct agents)
**`bedrock_builder` is a separate agent from `bedrock_architect`, not a replacement.** Evidence:
- Different classes: `BedrockBuilderAgent` (MVP block/entity addon builder + packaging) vs `BedrockArchitectAgent` (Java analysis, conversion plans, namespace mapping).
- Imported independently throughout the codebase; `tests/unit/test_bedrock_architect_builder_typed.py` exercises both as distinct agents.
- The 40K dead artifact `bedrock_architect_original.py` (the subject of #1707) contains `BedrockArchitectAgent` — an unrelated class.

Therefore #1707 (complete `bedrock_architect/` subpackage migration + delete `bedrock_architect_original.py`) remains open and should be tracked separately. This PR makes no changes to `bedrock_architect*`.