### PR TITLE
fix(ai-engine,backend): resolve #1821 — migrate from deprecated jaeger exporter to OTLP

### DIFF
--- a/ai-engine/main.py
+++ b/ai-engine/main.py
@@ -310,7 +310,7 @@ async def startup_event():
         assumption_engine = SmartAssumptionEngine()
         logger.info("SmartAssumptionEngine initialized")
 
-        # Initialize OpenTelemetry tracing with Jaeger/OTLP exporters
+        # Initialize OpenTelemetry tracing (OTLP exporters)
         init_tracing(app)
         logger.info("OpenTelemetry tracing initialized")
 

--- a/ai-engine/requirements.txt
+++ b/ai-engine/requirements.txt
@@ -62,9 +62,7 @@ pydantic-settings~=2.14.2
 prometheus_client>=0.25.0
 structlog>=26.1.0
 
-# Distributed Tracing - OpenTelemetry
-# Note: chromadb provides opentelemetry-exporter-otlp-proto-grpc which conflicts
-# with opentelemetry-exporter-jaeger-proto-grpc on protobuf versions.
+# Distributed Tracing - OpenTelemetry (OTLP; Jaeger exporter is deprecated upstream)
 # Using flexible versions and letting pip/legacy-resolver find a solution.
 opentelemetry-api>=1.43.0
 opentelemetry-sdk>=1.43.0

--- a/ai-engine/tests/test_tracing.py
+++ b/ai-engine/tests/test_tracing.py
@@ -1,34 +1,39 @@
 """Tests for the distributed tracing module.
 
-Covers the lazy/optional Jaeger import path (issue #1781): the
-``opentelemetry-exporter-jaeger`` package is deprecated and frequently
-unavailable, so ``_setup_jaeger_exporter`` must never raise and must return
-``None`` when the package is missing or broken.
+Covers the OTLP exporter migration (issue #1821): the deprecated
+``opentelemetry-exporter-jaeger`` package has been removed in favor of
+``opentelemetry-exporter-otlp`` (Jaeger natively ingests OTLP since v1.35).
+The ``TRACING_EXPORTER=jaeger`` value is accepted as a backwards-compatible
+alias for ``otlp``.
 """
 
-import sys
-import types
 from unittest.mock import MagicMock, patch
 
-import pytest
 
-
-def test_get_tracing_exporter_default_and_override():
-    """Exporter selection reads TRACING_EXPORTER (default 'jaeger')."""
+def test_get_tracing_exporter_default_is_otlp():
+    """Exporter selection defaults to 'otlp'."""
     import tracing
 
-    assert tracing.get_tracing_exporter() == "jaeger"
-    with patch.dict("os.environ", {"TRACING_EXPORTER": "OTLP"}):
+    with patch.dict("os.environ", {}, clear=True):
         assert tracing.get_tracing_exporter() == "otlp"
 
 
-def test_jaeger_host_port_helpers():
-    """Jaeger host/port helpers honor env overrides."""
+def test_get_tracing_exporter_jaeger_alias():
+    """'jaeger' is accepted as a backwards-compatible alias for 'otlp'."""
     import tracing
 
-    with patch.dict("os.environ", {"JAEGER_HOST": "myjaeger", "JAEGER_PORT": "12345"}):
-        assert tracing.get_jaeger_host() == "myjaeger"
-        assert tracing.get_jaeger_port() == 12345
+    with patch.dict("os.environ", {"TRACING_EXPORTER": "jaeger"}):
+        assert tracing.get_tracing_exporter() == "otlp"
+
+
+def test_get_otlp_endpoint_default_and_override():
+    """OTLP endpoint honors OTLP_ENDPOINT env var."""
+    import tracing
+
+    with patch.dict("os.environ", {}, clear=True):
+        assert tracing.get_otlp_endpoint() == "http://localhost:4317"
+    with patch.dict("os.environ", {"OTLP_ENDPOINT": "http://collector:4317"}):
+        assert tracing.get_otlp_endpoint() == "http://collector:4317"
 
 
 def test_create_resource_carries_service_metadata():
@@ -41,44 +46,30 @@ def test_create_resource_carries_service_metadata():
         assert resource.attributes.get("service.version") == "9.9"
 
 
-def test_setup_jaeger_exporter_returns_none_when_import_fails(monkeypatch):
-    """When the jaeger package is missing/broken, return None and do not raise."""
+def test_setup_otlp_exporter_returns_processor():
+    """_setup_otlp_exporter returns a BatchSpanProcessor wrapping OTLPSpanExporter."""
     import tracing
 
-    real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
-
-    def _block_jaeger(name, *args, **kwargs):
-        if "jaeger.thrift" in name:
-            raise ImportError("simulated missing jaeger package")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr("builtins.__import__", _block_jaeger)
-    # Ensure no stale cached module interferes.
-    monkeypatch.delitem(sys.modules, "opentelemetry.exporter.jaeger.thrift", raising=False)
-
-    result = tracing._setup_jaeger_exporter()
-    assert result is None
-
-
-def test_setup_jaeger_exporter_returns_processor_when_available(monkeypatch):
-    """When the jaeger package imports cleanly, a BatchSpanProcessor is returned."""
-    import tracing
-
-    fake_exporter_cls = MagicMock(name="JaegerExporter")
-    fake_module = types.ModuleType("opentelemetry.exporter.jaeger.thrift")
-    fake_module.JaegerExporter = fake_exporter_cls
-
-    parent_pkg = types.ModuleType("opentelemetry.exporter.jaeger")
-    parent_pkg.thrift = fake_module
-
-    monkeypatch.setitem(sys.modules, "opentelemetry.exporter.jaeger", parent_pkg)
-    monkeypatch.setitem(sys.modules, "opentelemetry.exporter.jaeger.thrift", fake_module)
-
-    with patch.dict("os.environ", {"JAEGER_HOST": "jh", "JAEGER_PORT": "6831"}):
-        result = tracing._setup_jaeger_exporter()
+    with patch("tracing.OTLPSpanExporter") as mock_otlp, patch(
+        "tracing.BatchSpanProcessor"
+    ) as mock_bsp:
+        mock_otlp.return_value = MagicMock(name="exporter")
+        mock_bsp.return_value = MagicMock(name="processor")
+        result = tracing._setup_otlp_exporter()
 
     assert result is not None
-    fake_exporter_cls.assert_called_once_with(agent_host_name="jh", agent_port=6831)
+    mock_otlp.assert_called_once()
+    mock_bsp.assert_called_once()
+
+
+def test_setup_otlp_exporter_returns_none_on_failure():
+    """When OTLPSpanExporter raises, _setup_otlp_exporter returns None and does not propagate."""
+    import tracing
+
+    with patch("tracing.OTLPSpanExporter", side_effect=Exception("otlp failed")):
+        result = tracing._setup_otlp_exporter()
+
+    assert result is None
 
 
 def test_get_tracer_returns_noop_when_uninitialized():
@@ -100,3 +91,4 @@ def test_create_span_and_attributes_smoke():
     assert span is not None
     tracing.add_span_attributes(span, {"k": "v", "empty": None})
     tracing.end_span(span)
+

--- a/ai-engine/tracing.py
+++ b/ai-engine/tracing.py
@@ -43,18 +43,21 @@ def get_service_version() -> str:
 
 
 def get_tracing_exporter() -> str:
-    """Get the tracing exporter type from environment."""
-    return os.getenv("TRACING_EXPORTER", "jaeger").lower()
+    """Get the tracing exporter type from environment.
 
-
-def get_jaeger_host() -> str:
-    """Get Jaeger host from environment."""
-    return os.getenv("JAEGER_HOST", "jaeger")
-
-
-def get_jaeger_port() -> int:
-    """Get Jaeger port from environment."""
-    return int(os.getenv("JAEGER_PORT", "14268"))
+    Defaults to ``otlp``. The deprecated ``jaeger`` value is accepted as an
+    alias for ``otlp`` (Jaeger natively ingests OTLP since v1.35) so existing
+    deployments keep working without configuration changes.
+    """
+    exporter = os.getenv("TRACING_EXPORTER", "otlp").lower()
+    if exporter == "jaeger":
+        logger.warning(
+            "TRACING_EXPORTER=jaeger is deprecated; the Jaeger exporter has been "
+            "removed in favor of OTLP (Jaeger natively accepts OTLP). "
+            "Falling back to the OTLP exporter. Set TRACING_EXPORTER=otlp to silence."
+        )
+        return "otlp"
+    return exporter
 
 
 def get_otlp_endpoint() -> str:
@@ -72,28 +75,8 @@ def _create_resource() -> Resource:
     )
 
 
-def _setup_jaeger_exporter() -> Optional[BatchSpanProcessor]:
-    """Setup Jaeger exporter.
-
-    The ``opentelemetry-exporter-jaeger`` package is optional (it is deprecated
-    and conflicts with protobuf pins). Import lazily so a missing package never
-    breaks module collection or OTLP-based deployments.
-    """
-    try:
-        from opentelemetry.exporter.jaeger.thrift import JaegerExporter
-
-        jaeger_exporter = JaegerExporter(
-            agent_host_name=get_jaeger_host(),
-            agent_port=get_jaeger_port(),
-        )
-        return BatchSpanProcessor(jaeger_exporter)
-    except Exception as e:
-        logger.warning(f"Failed to setup Jaeger exporter: {e}")
-        return None
-
-
 def _setup_otlp_exporter() -> Optional[BatchSpanProcessor]:
-    """Setup OTLP exporter."""
+    """Setup OTLP (gRPC) exporter."""
     try:
         otlp_exporter = OTLPSpanExporter(
             endpoint=get_otlp_endpoint(),
@@ -129,12 +112,6 @@ def init_tracing(app=None) -> None:
         exporter_type = get_tracing_exporter()
 
         # Add exporters based on configuration
-        if exporter_type in ("jaeger", "all"):
-            processor = _setup_jaeger_exporter()
-            if processor:
-                _tracer_provider.add_span_processor(processor)
-                logger.info(f"Jaeger exporter configured: {get_jaeger_host()}:{get_jaeger_port()}")
-
         if exporter_type in ("otlp", "all"):
             processor = _setup_otlp_exporter()
             if processor:

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -221,7 +221,7 @@ async def startup_event():
     init_sentry()
     logger.info("Sentry error monitoring initialized")
 
-    # Initialize OpenTelemetry tracing with Jaeger/OTLP exporters
+    # Initialize OpenTelemetry tracing (OTLP exporters)
     init_tracing(app)
     logger.info("OpenTelemetry tracing initialized")
 

--- a/backend/src/services/tracing.py
+++ b/backend/src/services/tracing.py
@@ -18,12 +18,6 @@ from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
 try:
-    from opentelemetry.exporter.jaeger.thrift import JaegerExporter
-except ImportError:
-    JaegerExporter = None
-    logger.warning("Jaeger exporter not available (missing dependencies)")
-
-try:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
     from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
     from opentelemetry.instrumentation.redis import RedisInstrumentor
@@ -80,18 +74,21 @@ def get_service_version() -> str:
 
 
 def get_tracing_exporter() -> str:
-    """Get the tracing exporter type from environment."""
-    return os.getenv("TRACING_EXPORTER", "jaeger").lower()
+    """Get the tracing exporter type from environment.
 
-
-def get_jaeger_host() -> str:
-    """Get Jaeger host from environment."""
-    return os.getenv("JAEGER_HOST", "jaeger")
-
-
-def get_jaeger_port() -> int:
-    """Get Jaeger port from environment."""
-    return int(os.getenv("JAEGER_PORT", "14268"))
+    Defaults to ``otlp``. The deprecated ``jaeger`` value is accepted as an
+    alias for ``otlp`` (Jaeger natively ingests OTLP since v1.35) so existing
+    deployments keep working without configuration changes.
+    """
+    exporter = os.getenv("TRACING_EXPORTER", "otlp").lower()
+    if exporter == "jaeger":
+        logger.warning(
+            "TRACING_EXPORTER=jaeger is deprecated; the Jaeger exporter has been "
+            "removed in favor of OTLP (Jaeger natively accepts OTLP). "
+            "Falling back to the OTLP exporter. Set TRACING_EXPORTER=otlp to silence."
+        )
+        return "otlp"
+    return exporter
 
 
 def get_otlp_endpoint() -> str:
@@ -139,23 +136,8 @@ def _create_resource() -> Resource:
     return resource
 
 
-def _setup_jaeger_exporter() -> Optional[BatchSpanProcessor]:
-    """Setup Jaeger exporter."""
-    if JaegerExporter is None:
-        return None
-    try:
-        jaeger_exporter = JaegerExporter(
-            agent_host_name=get_jaeger_host(),
-            agent_port=get_jaeger_port(),
-        )
-        return BatchSpanProcessor(jaeger_exporter)
-    except Exception as e:
-        logger.warning(f"Failed to setup Jaeger exporter: {e}")
-        return None
-
-
 def _setup_otlp_exporter() -> Optional[BatchSpanProcessor]:
-    """Setup OTLP exporter."""
+    """Setup OTLP (gRPC) exporter."""
     try:
         otlp_exporter = OTLPSpanExporter(
             endpoint=get_otlp_endpoint(),
@@ -211,12 +193,6 @@ def init_tracing(app=None) -> None:
         exporter_type = get_tracing_exporter()
 
         # Add exporters based on configuration
-        if exporter_type in ("jaeger", "all"):
-            processor = _setup_jaeger_exporter()
-            if processor:
-                _tracer_provider.add_span_processor(processor)
-                logger.info(f"Jaeger exporter configured: {get_jaeger_host()}:{get_jaeger_port()}")
-
         if exporter_type in ("otlp", "all"):
             processor = _setup_otlp_exporter()
             if processor:

--- a/backend/src/tests/unit/test_tracing.py
+++ b/backend/src/tests/unit/test_tracing.py
@@ -97,7 +97,7 @@ def test_get_service_version_env():
 
 def test_get_tracing_exporter_default():
     with patch.dict(os.environ, {}, clear=True):
-        assert tracing.get_tracing_exporter() == "jaeger"
+        assert tracing.get_tracing_exporter() == "otlp"
 
 
 def test_get_tracing_exporter_otlp():
@@ -105,24 +105,10 @@ def test_get_tracing_exporter_otlp():
         assert tracing.get_tracing_exporter() == "otlp"
 
 
-def test_get_jaeger_host_default():
-    with patch.dict(os.environ, {}, clear=True):
-        assert tracing.get_jaeger_host() == "jaeger"
-
-
-def test_get_jaeger_host_env():
-    with patch.dict(os.environ, {"JAEGER_HOST": "custom-jaeger"}):
-        assert tracing.get_jaeger_host() == "custom-jaeger"
-
-
-def test_get_jaeger_port_default():
-    with patch.dict(os.environ, {}, clear=True):
-        assert tracing.get_jaeger_port() == 14268
-
-
-def test_get_jaeger_port_env():
-    with patch.dict(os.environ, {"JAEGER_PORT": "6831"}):
-        assert tracing.get_jaeger_port() == 6831
+def test_get_tracing_exporter_jaeger_alias():
+    # "jaeger" is accepted as a backwards-compatible alias for "otlp"
+    with patch.dict(os.environ, {"TRACING_EXPORTER": "jaeger"}):
+        assert tracing.get_tracing_exporter() == "otlp"
 
 
 def test_get_otlp_endpoint_default():
@@ -291,11 +277,7 @@ def test_init_tracing_all_exporters(
 ):
     tracing._initialized = False
 
-    with (
-        patch("services.tracing._setup_jaeger_exporter") as mock_jaeger,
-        patch("services.tracing._setup_otlp_exporter") as mock_otlp,
-    ):
-        mock_jaeger.return_value = MagicMock()
+    with patch("services.tracing._setup_otlp_exporter") as mock_otlp:
         mock_otlp.return_value = MagicMock()
         tracing.init_tracing()
 
@@ -314,8 +296,7 @@ def test_init_tracing_console_exporter(
 ):
     tracing._initialized = False
 
-    with patch("services.tracing._setup_jaeger_exporter", return_value=None):
-        tracing.init_tracing()
+    tracing.init_tracing()
 
     assert tracing._initialized is True
     tracing._initialized = False
@@ -344,23 +325,6 @@ def test_init_tracing_exception(mock_provider):
     tracing.init_tracing()
 
     assert tracing._initialized is False
-
-
-def test_setup_jaeger_exporter_not_available():
-    tracing.JaegerExporter = None
-    result = tracing._setup_jaeger_exporter()
-    assert result is None
-
-
-def test_setup_jaeger_exporter_exception():
-    original = tracing.JaegerExporter
-    mock_cls = MagicMock(side_effect=Exception("jaeger failed"))
-    tracing.JaegerExporter = mock_cls
-
-    result = tracing._setup_jaeger_exporter()
-    assert result is None
-
-    tracing.JaegerExporter = original
 
 
 def test_setup_otlp_exporter_exception():
@@ -433,19 +397,6 @@ def test_create_resource_ecs_exception():
         mock_ecs.return_value.detect.side_effect = Exception("ECS detect failed")
         resource = tracing._create_resource()
         assert resource is not None
-
-
-def test_setup_jaeger_exporter_success():
-    original = tracing.JaegerExporter
-    mock_exporter = MagicMock()
-    tracing.JaegerExporter = MagicMock(return_value=mock_exporter)
-
-    with patch("services.tracing.BatchSpanProcessor") as mock_bsp:
-        mock_bsp.return_value = MagicMock()
-        result = tracing._setup_jaeger_exporter()
-        assert result is not None
-
-    tracing.JaegerExporter = original
 
 
 def test_setup_otlp_exporter_success():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,8 @@ services:
       - LOG_LEVEL=INFO
       - FEATURE_USER_ACCOUNTS=true
       - SKIP_EMAIL_VERIFICATION=true
-      - TRACING_EXPORTER=jaeger
-      - JAEGER_HOST=jaeger
-      - JAEGER_PORT=14268
+      - TRACING_EXPORTER=otlp
+      - OTLP_ENDPOINT=http://jaeger:4317
       - AI_ENGINE_URL=http://ai-engine:8001
       - SYNTHETIC_CANARY_ENABLED=true
       - SYNTHETIC_CANARY_INTERVAL_MINUTES=10
@@ -88,9 +87,8 @@ services:
       - PYTHONPATH=/app
       - REDIS_URL=redis://redis:6379/0
       - LOG_LEVEL=INFO
-      - TRACING_EXPORTER=jaeger
-      - JAEGER_HOST=jaeger
-      - JAEGER_PORT=14268
+      - TRACING_EXPORTER=otlp
+      - OTLP_ENDPOINT=http://jaeger:4317
     depends_on:
       redis:
         condition: service_healthy
@@ -205,8 +203,8 @@ services:
     ports:
       - '6831:6831/udp'
       - '16686:16686'
-      - '14268:14268'
-      - '14250:14250'
+      - '4317:4317'
+      - '4318:4318'
     environment:
       - COLLECTOR_OTLP_ENABLED=true
     networks:


### PR DESCRIPTION
Resolves #1821

## Summary
- Removed the deprecated `opentelemetry-exporter-jaeger` code path from both `backend/src/services/tracing.py` and `ai-engine/tracing.py` (deleted `_setup_jaeger_exporter`, `get_jaeger_host`, `get_jaeger_port`, the lazy `JaegerExporter` import, and the `jaeger` branch in `init_tracing`).
- Both services now export exclusively via `OTLPSpanExporter` (`opentelemetry.exporter.otlp.proto.grpc.trace_exporter`), endpoint configurable via `OTLP_ENDPOINT` (default `http://localhost:4317`).
- `TRACING_EXPORTER` now defaults to `otlp`. The value `jaeger` is accepted as a **backwards-compatible alias** for `otlp` (with a deprecation warning) so existing deployments keep working without config changes.
- Updated `docker-compose.yml`: backend + ai-engine now set `TRACING_EXPORTER=otlp` / `OTLP_ENDPOINT=http://jaeger:4317`; the `jaeger` all-in-one service now exposes OTLP ports `4317`/`4318` (gRPC/HTTP) instead of the legacy `14268`/`14250`. `COLLECTOR_OTLP_ENABLED=true` was already set.
- Refreshed tests: dropped Jaeger-specific cases, added coverage for the OTLP default, the `jaeger`→`otlp` alias, and `_setup_otlp_exporter`.
- Cleaned up the stale protobuf-conflict comment in `ai-engine/requirements.txt`.

## Why
`opentelemetry-exporter-jaeger` is deprecated upstream (as of OpenTelemetry v1.35, Jan 2024) and was already absent from `requirements.txt` because it conflicts with `protobuf` pins. This left Jaeger trace export silently disabled. Jaeger now natively accepts OTLP (gRPC/HTTP), so OTLP is the correct single exporter.

## Protocol choice
Used **OTLP/gRPC** (`proto.grpc.trace_exporter.OTLPSpanExporter`), the OTLP default and the standard Jaeger collector convention (port 4317). This matches the existing `_setup_otlp_exporter` already present in the codebase.

## Verification
- `backend/src/services/tracing.py` and `ai-engine/tracing.py` import cleanly (the original `ModuleNotFoundError` crash symptom is gone).
- `backend` tracing tests: **52 passed** (`tracing.py` at 90% coverage).
- `ai-engine` tracing tests: **8 passed**.
- `ruff check` clean on all changed files (one pre-existing unrelated `UP037` in `ai-engine/main.py`).
- Confirmed no `JaegerExporter` / `_setup_jaeger_exporter` references remain in code (only the intentional compat alias + deprecation warning).