### PR TITLE
fix(ai-engine): resolve P0 test-gate breakage on main

### DIFF
--- a/ai-engine/agents/logic_translator/tools/block_tools.py
+++ b/ai-engine/agents/logic_translator/tools/block_tools.py
@@ -182,8 +182,15 @@ class MapBlockPropertiesTool(_BaseLogicTranslatorTool):
     async def _arun(  # type: ignore[override]
         self, java_properties: Dict[str, Any]
     ) -> str:
+        # Resolve the helper through the package namespace
+        # (``agents.logic_translator.tools``) so callers can substitute it via
+        # ``patch("agents.logic_translator.tools._map_java_block_properties_to_bedrock")``.
+        # A direct module-global call would bypass that patch target. Lazy import
+        # avoids the circular dependency with the package ``__init__``.
+        from agents.logic_translator import tools as _tools_pkg
+
         try:
-            result = _map_java_block_properties_to_bedrock(java_properties)
+            result = _tools_pkg._map_java_block_properties_to_bedrock(java_properties)
             return json.dumps({"success": True, "bedrock_properties": result})
         except Exception as e:
             return json.dumps({"success": False, "error": str(e)})

--- a/ai-engine/agents/qa/__init__.py
+++ b/ai-engine/agents/qa/__init__.py
@@ -890,14 +890,24 @@ def calculate_structure_score(results: Dict[str, Any]) -> int:
     return int((valid_count / len(results)) * 100)
 
 
-# Attach tool instances to QAValidatorAgent after class definition
+# Attach tool instances to QAValidatorAgent after class definition.
+# Re-export both the *Input schema models and the *Tool wrappers so tests and
+# downstream code can import them from the package root (regression fix for #1819).
+# The ``*Input`` models use a redundant alias so ruff treats them as intentional
+# re-exports (F401); the ``*Tool`` classes are consumed by the assignments below.
 from .tools import (
-    _ValidateConversionQualityTool,
-    _ValidateMcaddonTool,
-    _RunFunctionalTestsTool,
+    _AnalyzeBedrockCompatibilityInput as _AnalyzeBedrockCompatibilityInput,
     _AnalyzeBedrockCompatibilityTool,
+    _AssessPerformanceMetricsInput as _AssessPerformanceMetricsInput,
     _AssessPerformanceMetricsTool,
+    _GenerateQaReportInput as _GenerateQaReportInput,
     _GenerateQaReportTool,
+    _RunFunctionalTestsInput as _RunFunctionalTestsInput,
+    _RunFunctionalTestsTool,
+    _ValidateConversionQualityInput as _ValidateConversionQualityInput,
+    _ValidateConversionQualityTool,
+    _ValidateMcaddonInput as _ValidateMcaddonInput,
+    _ValidateMcaddonTool,
 )
 
 QAValidatorAgent.validate_conversion_quality_tool = _ValidateConversionQualityTool()

--- a/ai-engine/agents/recipe/__init__.py
+++ b/ai-engine/agents/recipe/__init__.py
@@ -828,11 +828,19 @@ class RecipeConverterAgent:
             return json.dumps({"valid": False, "issues": [str(e)]}, indent=2)
 
 
-# Attach tool instances to RecipeConverterAgent after class definition
+# Attach tool instances to RecipeConverterAgent after class definition.
+# Re-export both the *Input schema models and the *Tool wrappers so tests and
+# downstream code can import them from the package root (regression fix for #1819).
+# The ``*Input`` models use a redundant alias so ruff treats them as intentional
+# re-exports (F401); the ``*Tool`` classes are consumed by the assignments below.
 from .tools import (
+    _ConvertRecipeInput as _ConvertRecipeInput,
     _ConvertRecipeTool,
+    _ConvertRecipesBatchInput as _ConvertRecipesBatchInput,
     _ConvertRecipesBatchTool,
+    _MapItemIdInput as _MapItemIdInput,
     _MapItemIdTool,
+    _ValidateRecipeInput as _ValidateRecipeInput,
     _ValidateRecipeTool,
 )
 

--- a/ai-engine/tests/test_advanced_rag_integration.py
+++ b/ai-engine/tests/test_advanced_rag_integration.py
@@ -19,6 +19,24 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+@pytest.fixture(autouse=True)
+def _huggingface_offline(monkeypatch):
+    """Force HuggingFace into offline mode for the RAG integration tests.
+
+    The Advanced RAG agent eagerly loads ``sentence-transformers/all-MiniLM-L6-v2``
+    via ``LocalEmbeddingGenerator``. Without offline mode, a cache miss triggers a
+    HuggingFace download that CI rate-limits (HTTP 429) and that exceeds the
+    pytest-timeout budget (>120 s) during fixture setup. With offline mode set, a
+    cache miss fails fast and ``LocalEmbeddingGenerator._init_model`` falls back to
+    its deterministic fallback vectors, so the agent still constructs and the
+    integration flow remains exercisable — no network, no flakiness, coverage
+    preserved. When the model IS cached the real embeddings are used.
+    """
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setenv("HF_HUB_DISABLE_TELEMETRY", "1")
+
+
 class TestAdvancedRAGIntegration:
     """Integration tests for the Advanced RAG system."""
 


### PR DESCRIPTION
Main's AI-engine gate is broken (regression from #1819), blocking every PR's CI. Three fixes:

**1. ImportError collection errors (highest priority)**
`tests/unit/test_qa_tools_typed.py` and `tests/unit/test_recipe_typed.py` import the `*Input` schema classes (`_AnalyzeBedrockCompatibilityInput`, `_ConvertRecipeInput`, …) from the package root, but the `tools.py` split (#1819) only re-exported the `*Tool` classes from `agents/qa/__init__.py` and `agents/recipe/__init__.py`. Re-export the missing `*Input` models (redundant-alias form so ruff F401 treats them as intentional re-exports).

**2. logic_translator assertion — real bug**
`MapBlockPropertiesTool._arun` called the helper via its own `block_tools` module global, so `patch("agents.logic_translator.tools._map_java_block_properties_to_bedrock")` (the package re-export the test targets) never took effect → the real helper ran and `success` came back `True` instead of `False`. Route the call through the package namespace (lazy import to avoid the circular dependency with the package `__init__`) so the documented helper substitution works and failures propagate correctly.

**3. HuggingFace 429 timeout (flaky)**
`AdvancedRAGAgent` eagerly loads `sentence-transformers/all-MiniLM-L6-v2`; a CI cache miss triggered an HF download that got rate-limited (HTTP 429) and exceeded pytest-timeout (>120 s) at fixture setup. Added an autouse fixture setting `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1`. `LocalEmbeddingGenerator._init_model` already degrades gracefully to deterministic fallback vectors on any load failure, so with offline mode a cache miss fails fast (no network, no timeout) and the integration flow still runs — no skips, coverage preserved.

Verified locally: the 3 target failures are fixed; full ai-engine suite is green apart from pre-existing `torch`-dependent failures caused by this sandbox's broken `torch` install (reproduce on base with changes stashed; pass in CI with a proper torch). Coverage 72.09% (≥ 70% floor). Ruff: no new errors introduced.

## Summary by Sourcery

Stabilize AI-engine tests by fixing logic translator helper resolution and isolating HuggingFace-dependent integration tests from network and rate limiting issues.

Bug Fixes:
- Ensure MapBlockPropertiesTool resolves its helper through the logic_translator.tools package namespace so test patches and failure propagation behave as intended.

Tests:
- Add an autouse pytest fixture to force HuggingFace into offline mode for Advanced RAG integration tests, preventing rate-limited model downloads and timeout-related flakiness.