### PR TITLE
test(ai-engine): resolve #1820 — fix flaky AI-engine tests (UAE search engine timeout)

### DIFF
--- a/ai-engine/tests/search/conftest.py
+++ b/ai-engine/tests/search/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures for the search test-suite.
+
+Hardens every test under ``tests/search/`` against the intermittent
+HuggingFace rate-limiting (>120 s timeout under CI parallelism) that
+flaked ``test_uae_search_engine.py::test_engine_with_custom_config`` and
+its siblings (see issue #1820).
+
+This is the directory-level equivalent of the advanced_rag fix landed in
+#1830, lifted one level up so all search-engine tests benefit.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _huggingface_offline(monkeypatch):
+    """Force HuggingFace into offline mode for the whole search test-suite.
+
+    Several search engines (e.g. ``UAESearchEngine``) eagerly construct a
+    ``LocalEmbeddingGenerator`` which loads ``sentence-transformers/all-MiniLM-L6-v2``
+    during ``__init__``. Under CI parallelism (``-n auto --dist=loadfile``) a cache
+    miss triggers a HuggingFace download that gets rate-limited (HTTP 429) and
+    exceeds the pytest-timeout budget (>120 s) during construction. With offline
+    mode set, a cache miss fails fast and ``LocalEmbeddingGenerator._init_model``
+    falls back to its deterministic fallback vectors, so the engine still
+    constructs and the search flow remains exercisable — no network, no flakiness,
+    coverage preserved. When the model IS cached the real embeddings are used.
+    """
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+    monkeypatch.setenv("HF_HUB_DISABLE_TELEMETRY", "1")


### PR DESCRIPTION
Resolves #1820

## Summary
- Fixed `test_engine_with_custom_config` (`tests/search/test_uae_search_engine.py`) intermittent >120s timeout by hardening the eager model load with HuggingFace offline mode + deterministic fallback (same pattern as the advanced_rag fix in #1830, lifted to the directory level).
- `test_error_handling` (advanced_rag) already fixed by #1830 — verified still green here.
- Both flaky tests are now deterministic and fast under CI parallelism.

## Root cause
`UAESearchEngine.__init__` (`search/uae_search_engine.py:61`) eagerly constructs `LocalEmbeddingGenerator()`, whose `__init__` calls `SentenceTransformer("all-MiniLM-L6-v2")` (`utils/embedding_generator.py:153`). Under CI parallelism (`-n auto --dist=loadfile`) a cache miss triggers a HuggingFace download that gets rate-limited (HTTP 429) and retries with backoff past the >120s pytest-timeout budget → intermittent CI failure. `LocalEmbeddingGenerator._init_model` already has a deterministic fallback (`_model = None` → hash-based vectors), but it only triggers when the load *fails fast*; without offline mode the 429-retry loop hangs instead.

## Fix
Added `ai-engine/tests/search/conftest.py` with an autouse `_huggingface_offline` fixture setting `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` / `HF_HUB_DISABLE_TELEMETRY=1`. A cache miss now fails fast → `_model = None` → deterministic fallback embeddings; engines still construct and the search flow is fully exercisable. When the model IS cached (local/CI with warm cache) real embeddings are used. No assertions weakened; no production logic changed.

Scoping the fixture at `tests/search/` (rather than per-module like #1830) hardens all sibling search-engine tests that share the same eager-load risk — a general flakiness safeguard.

## Verification
- `test_uae_search_engine.py` + `test_advanced_rag_integration.py`: **47 passed in 15.44s** under `-n 2 --dist=loadfile` (exact CI parallelism) — no hangs.
- Full `tests/search/` dir: **104 passed in 7.78s** under `-n 2 --dist=loadfile`. (One pre-existing, unrelated collection error in `test_rag_conversion_integration.py` — `ImportError: knowledge.patterns.mappings` — present on main, not touched by this PR.)
- `ruff check` + `ruff format --check` clean on the new file.