### PR TITLE
docs: resolve #1669 — add OAuth data collection privacy notices

### DIFF
--- a/docs/legal/PRIVACY.md
+++ b/docs/legal/PRIVACY.md
@@ -17,6 +17,32 @@ To improve our AI model, we collect and store the following types of data associ
 *   **Job Identifiers**: We use system-generated unique identifiers (Job IDs) to link your input files, output files, and any feedback you provide for a specific conversion task.
 *   **User Identifiers (Optional)**: If you provide a user identifier (e.g., username, email) when submitting feedback, this may be stored to help us understand feedback patterns or communicate with you if necessary. Providing this is optional.
 
+### OAuth Authentication Data (Discord, GitHub, Google)
+
+If you choose to sign in with a third-party provider (Discord, GitHub, or Google) instead of creating a password-based account, PortKit receives a limited set of profile data from that provider to authenticate you and create/link your PortKit account. We request only the minimum scopes required for sign-in.
+
+**Data we request and store per provider** (verified against our OAuth configuration):
+
+| Provider | OAuth scopes requested | Data we receive & store |
+|----------|------------------------|-------------------------|
+| **Discord** | `identify`, `email` | Discord account ID, username, and email address |
+| **GitHub** | `read:user`, `user:email` | GitHub account ID, username (login), and primary verified email address |
+| **Google** | `openid`, `email`, `profile` | Google account ID (`sub`), name, and email address |
+
+For each linked provider, we store: the provider name, your unique account ID at that provider, the email address and username returned by the provider, and an encrypted OAuth access/refresh token so we can keep your session signed in. These fields are defined in our user data model under `oauth_provider`, `oauth_provider_user_id`, `oauth_email`, and `oauth_username`.
+
+**What we do NOT request or collect** (the scopes above are intentionally minimal):
+
+*   **Your password** — OAuth never shares your provider password with us; we never see or store it.
+*   **Discord**: no access to your messages or DMs, your servers/guilds, or your friends/connections list (we do not request the `guilds`, `messages.read`, or `connections` scopes).
+*   **GitHub**: no access to your repositories or source code, gists, organizations, or the ability to create, edit, or post anything on your behalf (we do not request `repo`, `gist`, or any `write:*` scopes).
+*   **Google**: no access to your Gmail, contacts, calendar, Drive, or the ability to read or send anything on your behalf (we do not request Gmail, Contacts, or Drive scopes).
+*   We **never post, modify, or take actions on your behalf** on any provider account.
+
+**Purpose**: The OAuth data above is used **solely for authentication, account creation, and account linking** — so you can sign in without a separate password. It is **not** used for marketing, sold to third parties, or shared for advertising. The access/refresh tokens are used only to maintain your login session.
+
+**Retention**: OAuth profile data (provider, account ID, email, username) and the encrypted tokens are retained for the life of your PortKit account so that sign-in and account linking continue to work. They are deleted when your account is deleted. See our [Data Retention Policy](../data-retention.md) for details, including how to request erasure of your data under GDPR Article 17.
+
 ## 3. How We Use Your Data
 
 The data we collect is primarily used for the following purpose:

--- a/frontend/src/pages/LoginPage.css
+++ b/frontend/src/pages/LoginPage.css
@@ -199,6 +199,24 @@
   flex-shrink: 0;
 }
 
+.oauth-privacy-notice {
+  margin-top: 1rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: #6b7280;
+  text-align: center;
+}
+
+.oauth-privacy-notice a {
+  color: #3b82f6;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.oauth-privacy-notice a:hover {
+  text-decoration: underline;
+}
+
 .login-footer {
   margin-top: 2rem;
   text-align: center;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -163,6 +163,14 @@ export const LoginPage: React.FC = () => {
           </button>
         </div>
 
+        <p className="oauth-privacy-notice">
+          When you sign in with Discord, GitHub, or Google, we receive your
+          email address, username, and account ID for authentication only — we
+          never see your password or access your messages, contacts, or
+          repositories. See our{' '}
+          <Link to="/privacy#third-party">Privacy Policy</Link> for details.
+        </p>
+
         <div className="login-footer">
           <p>
             Don&apos;t have an account? <Link to="/register">Sign up</Link>

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -141,11 +141,51 @@ export const PrivacyPage: React.FC = () => {
           infrastructure providers that process data under their privacy
           policies and terms.
         </p>
-        <h3 className={styles.sectionTitle}>Authentication</h3>
+        <h3 className={styles.sectionTitle}>Authentication (OAuth Sign-In)</h3>
         <p>
-          <strong>OAuth Providers (Google, GitHub, Discord)</strong> - If you
-          sign in using OAuth, these services provide certain account
-          information to us as specified in their privacy policies.
+          <strong>OAuth Providers (Discord, GitHub, Google).</strong> If you
+          choose to sign in with one of these providers instead of creating a
+          password, we receive a limited set of profile data to authenticate
+          you and create your account. We request only the minimum scopes
+          needed for sign-in:
+        </p>
+        <ul>
+          <li>
+            <strong>Discord</strong> ({' '}
+            <code>identify</code>, <code>email</code> scopes) — we receive your
+            Discord account ID, username, and email address.
+          </li>
+          <li>
+            <strong>GitHub</strong> ({' '}
+            <code>read:user</code>, <code>user:email</code> scopes) — we receive
+            your GitHub account ID, username (login), and primary verified
+            email address.
+          </li>
+          <li>
+            <strong>Google</strong> ({' '}
+            <code>openid</code>, <code>email</code>, <code>profile</code>{' '}
+            scopes) — we receive your Google account ID, name, and email
+            address.
+          </li>
+        </ul>
+        <p>
+          For each linked provider we store the provider name, your unique
+          account ID at that provider, the email and username returned by the
+          provider, and an encrypted access token used only to keep your
+          session signed in. <strong>We never receive your provider
+          password.</strong>
+        </p>
+        <p>
+          We do <strong>not</strong> request access to your messages or DMs,
+          your contacts or friends lists, your repositories or source code,
+          your Gmail, Drive, or calendar, and we{' '}
+          <strong>never post or take actions on your behalf</strong> on any
+          provider. This data is used for authentication and account creation
+          only — it is not used for marketing and is not sold. OAuth profile
+          data is retained for the life of your account and deleted when your
+          account is deleted; see the Data Retention section below and our{' '}
+          <a href="/data-retention">Data Retention Policy</a> for details,
+          including how to request deletion.
         </p>
       </section>
 


### PR DESCRIPTION
Resolves #1669

## Summary
- Added an **OAuth Authentication Data** section to `docs/legal/PRIVACY.md` disclosing, per provider (Discord/GitHub/Google), the exact OAuth scopes requested and the data received/stored (account ID, email, username, encrypted access token), what is explicitly **NOT** collected (passwords, messages/DMs, contacts, repositories, Gmail/Drive, posting on your behalf), purpose (authentication & account creation only — not marketing, not sold), and retention (life of the account, link to data-retention.md / GDPR Art. 17 erasure).
- Expanded the previously vague **Authentication** subsection of the user-facing `frontend/src/pages/PrivacyPage.tsx` with the same per-provider scope/data disclosure, the "what we do not collect" statement, and a link to the Data Retention Policy.
- Added a concise **privacy notice** directly under the OAuth buttons on `frontend/src/pages/LoginPage.tsx` linking to the policy, plus matching `oauth-privacy-notice` styling.

## Accuracy — verified against the actual code
The disclosure reflects the real OAuth implementation, not assumptions:
- **Scopes requested** (`backend/src/services/oauth_service.py:23-25`):
  - Discord: `identify`, `email`
  - GitHub: `read:user`, `user:email`
  - Google: `openid`, `email`, `profile`
- **Fields stored** (`backend/src/db/models.py`): `oauth_provider`, `oauth_provider_user_id`, `oauth_email`, `oauth_username`, and encrypted `oauth_access_token` / `oauth_refresh_token`. The notice honestly discloses that tokens are stored (encrypted) to maintain the session.
- The "not collected" list is backed by the minimal scopes (e.g. no `repo`, `messages.read`, `connections`, Gmail/Contacts/Drive scopes).

## Verification
- `pnpm exec tsc --noEmit` → pass (0 errors)
- `pnpm lint` → pass (0 errors; 4 pre-existing warnings in unrelated files: `confidence-badge.tsx`, `DataSubjectRequestPage.tsx`)
- All edited files lint-clean.